### PR TITLE
Core functor

### DIFF
--- a/Categories/Adjoint/Instance/Core.agda
+++ b/Categories/Adjoint/Instance/Core.agda
@@ -1,0 +1,110 @@
+{-# OPTIONS --without-K --safe #-}
+
+module Categories.Adjoint.Instance.Core where
+
+-- The adjunction between the forgetful functor from Cats to Groupoids
+-- and the Core functor.
+
+open import Level using (_⊔_)
+import Function
+
+open import Categories.Adjoint using (_⊣_)
+open import Categories.Category using (Category)
+import Categories.Category.Construction.Core as C
+open import Categories.Category.Groupoid using (Groupoid)
+open import Categories.Category.Instance.Cats using (Cats)
+open import Categories.Category.Instance.Groupoids using (Groupoids)
+open import Categories.Functor using (Functor; _∘F_; id)
+open import Categories.Functor.Instance.Core using (Core)
+import Categories.Morphism as Morphism
+open import Categories.NaturalTransformation.NaturalIsomorphism using (refl; _≃_)
+
+-- The forgetful functor from Groupoids to Cats
+
+Forgetful : ∀ {o ℓ e} → Functor (Groupoids o ℓ e) (Cats o ℓ e)
+Forgetful = record
+  { F₀ = category
+  ; F₁ = Function.id
+  ; identity     = refl
+  ; homomorphism = refl
+  ; F-resp-≈     = Function.id
+  }
+  where open Groupoid
+
+-- Core is right-adjoint to the forgetful functor from Groupoids to
+-- Cats
+
+CoreAdj : ∀ {o ℓ e} → Forgetful {o} {ℓ ⊔ e} {e} ⊣ Core
+CoreAdj = record
+  { unit   = record { η = unit   ; commute = λ {G} {H} F → unit-commute {G} {H} F }
+  ; counit = record { η = counit ; commute = counit-commute }
+  ; zig    = λ {G} → zig {G}
+  ; zag    = zag
+  }
+  where
+    open Groupoid using (category)
+    module Core = Functor Core
+
+    unit : ∀ G → Functor (category G) (C.Core′ (category G))
+    unit G = record
+      { F₀ = Function.id
+      ; F₁ = λ f → record { from = f ; to = f ⁻¹ ; iso = iso }
+      ; identity     = Equiv.refl
+      ; homomorphism = Equiv.refl
+      ; F-resp-≈     = Function.id
+      }
+      where open Groupoid G
+
+    unit-commute : ∀ {G H} (F : Functor (category G) (category H)) →
+                   unit H ∘F F ≃ Core.F₁ F ∘F unit G
+    unit-commute {G} {H} F = record
+      { F⇒G = record { η = λ _ → ≅-refl  ; commute = λ _ → Equiv.sym id-comm }
+      ; F⇐G = record { η = λ _ → ≅-refl  ; commute = λ _ → Equiv.sym id-comm }
+      ; iso = λ _ → record { isoˡ = identityˡ ; isoʳ = identityˡ }
+      }
+      where
+        open Groupoid H
+        open Morphism (category H)
+
+    counit : ∀ C → Functor (C.Core′ C) C
+    counit C = record
+      { F₀ = Function.id
+      ; F₁ = _≅_.from
+      ; identity     = Equiv.refl
+      ; homomorphism = Equiv.refl
+      ; F-resp-≈     = Function.id
+      }
+      where
+        open Category C
+        open Morphism C
+
+    counit-commute : ∀ {C D} (F : Functor C D) →
+                     counit D ∘F Core.F₁ F ≃ F ∘F counit C
+    counit-commute {C} {D} F = record
+      { F⇒G = record { η = λ _ → D.id  ; commute = λ _ → D.Equiv.sym D.id-comm }
+      ; F⇐G = record { η = λ _ → D.id  ; commute = λ _ → D.Equiv.sym D.id-comm }
+      ; iso = λ _ → _≅_.iso ≅-refl
+      }
+      where
+        module D = Category D
+        open Morphism D
+
+    zig : ∀ {G} → counit (category G) ∘F unit G ≃ id
+    zig {G} = record
+      { F⇒G = record { η = λ _ → G.id ; commute = λ _ → G.Equiv.sym G.id-comm }
+      ; F⇐G = record { η = λ _ → G.id ; commute = λ _ → G.Equiv.sym G.id-comm }
+      ; iso = λ _ → _≅_.iso ≅-refl
+      }
+      where
+        module G = Groupoid G
+        open Morphism G.category
+
+    zag : ∀ {B} → Core.F₁ (counit B) ∘F unit (Core.F₀ B) ≃ id
+    zag {B} = record
+      { F⇒G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
+      ; F⇐G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
+      ; iso = λ _ → record { isoˡ = identityˡ ; isoʳ = identityˡ }
+      }
+      where
+        open Category B
+        open Morphism B

--- a/Categories/Bicategory/Bigroupoid.agda
+++ b/Categories/Bicategory/Bigroupoid.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --without-K --safe #-}
 
-module Categories.Bicategory.IsBigroupoid where
+module Categories.Bicategory.Bigroupoid where
 
 open import Level
 open import Function using (_$_)
@@ -9,7 +9,7 @@ open import Data.Product using (Σ; _,_)
 open import Categories.Category
 open import Categories.Category.Equivalence using (WeakInverse)
 open import Categories.Category.Product
-open import Categories.Category.IsGroupoid
+open import Categories.Category.Groupoid using (IsGroupoid)
 open import Categories.Bicategory
 open import Categories.Functor renaming (id to idF)
 open import Categories.Functor.Properties
@@ -23,7 +23,7 @@ import Categories.Morphism.Properties as MP
 import Categories.Morphism.Reasoning as MR
 
 -- https://link.springer.com/article/10.1023/A:1011270417127
-record Bigroupoid {o ℓ e t} (C : Bicategory o ℓ e t) : Set (o ⊔ ℓ ⊔ e ⊔ t) where
+record IsBigroupoid {o ℓ e t} (C : Bicategory o ℓ e t) : Set (o ⊔ ℓ ⊔ e ⊔ t) where
   open Bicategory C public
 
   field
@@ -155,3 +155,12 @@ record Bigroupoid {o ℓ e t} (C : Bicategory o ℓ e t) : Set (o ⊔ ℓ ⊔ e 
   module hom⁻¹-weakInverse {A B} = WeakInverse (hom⁻¹-weakInverse {A} {B})
 
   open hom⁻¹-weakInverse using () renaming (F⊣G to hom⁻¹-⊣Equivalence) public
+
+-- A bigroupoid is a bicategory that has a bigroupoid structure
+
+record Bigroupoid (o ℓ e t : Level) : Set (suc (o ⊔ ℓ ⊔ e ⊔ t)) where
+  field
+    bicategory   : Bicategory o ℓ e t
+    isBigroupoid : IsBigroupoid bicategory
+
+  open IsBigroupoid isBigroupoid public

--- a/Categories/Bicategory/Construction/1-Category.agda
+++ b/Categories/Bicategory/Construction/1-Category.agda
@@ -16,7 +16,7 @@ open import Categories.Bicategory
 open import Categories.Category.Instance.Cats using (Cats)
 open import Categories.Category.Monoidal using (Monoidal)
 open import Categories.Category.Monoidal.Instance.Cats using (module Product)
-open import Categories.Category.IsGroupoid using (IsGroupoid)
+open import Categories.Category.Groupoid using (IsGroupoid)
 open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
 open import Categories.Functor.Construction.Constant using (const)
 open import Categories.Functor.Bifunctor using (Bifunctor)

--- a/Categories/Category/Construction/Coproduct.agda
+++ b/Categories/Category/Construction/Coproduct.agda
@@ -11,7 +11,7 @@ open import Relation.Binary using (Rel)
 open import Function using (_$_)
 
 open import Categories.Category
-open import Categories.Category.IsGroupoid
+open import Categories.Category.Groupoid using (IsGroupoid)
 import Categories.Morphism as Morphism
 
 private

--- a/Categories/Category/Construction/Core.agda
+++ b/Categories/Category/Construction/Core.agda
@@ -10,7 +10,7 @@ module Categories.Category.Construction.Core {o ℓ e} (𝒞 : Category o ℓ e)
 open import Level using (_⊔_)
 open import Function using (flip)
 
-open import Categories.Category.IsGroupoid
+open import Categories.Category.Groupoid using (IsGroupoid)
 open import Categories.Morphism 𝒞
 open import Categories.Morphism.IsoEquiv 𝒞
 

--- a/Categories/Category/Construction/Core.agda
+++ b/Categories/Category/Construction/Core.agda
@@ -58,3 +58,28 @@ Core-isGroupoid = record
       ; to-≈   = isoʳ
       }
       where open _≅_ f
+
+-- An alternative (but equivalent) version of the core that uses _≃′_
+-- as the equality.  It's often easier to prove things about this
+-- version because the equality is simpler.
+
+Core′ : Category o (ℓ ⊔ e) e
+Core′ = record
+  { Obj       = Obj
+  ; _⇒_       = _≅_
+  ; _≈_       = _≃′_
+  ; id        = ≅.refl
+  ; _∘_       = flip ≅.trans
+  ; assoc     = assoc
+  ; identityˡ = identityˡ
+  ; identityʳ = identityʳ
+  ; equiv     = ≃′-isEquivalence
+  ; ∘-resp-≈  = ∘-resp-≈
+  }
+
+Core′-isGroupoid : IsGroupoid Core′
+Core′-isGroupoid = record
+  { _⁻¹ = ≅.sym
+  ; iso = λ {_ _ f} → record { isoˡ = isoˡ f ; isoʳ = isoʳ f }
+  }
+  where open _≅_

--- a/Categories/Category/Groupoid.agda
+++ b/Categories/Category/Groupoid.agda
@@ -1,9 +1,9 @@
 {-# OPTIONS --without-K --safe #-}
-module Categories.Category.IsGroupoid where
+module Categories.Category.Groupoid where
 
-open import Level
+open import Level using (Level; suc; _⊔_)
 
-open import Categories.Category
+open import Categories.Category using (Category)
 import Categories.Morphism
 
 record IsGroupoid {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
@@ -29,3 +29,12 @@ record IsGroupoid {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
   -- this definition doesn't seem to 'carry its weight'
   equiv-obj-sym : ∀ {A B} → A ⇒ B → B ≅ A
   equiv-obj-sym f = ≅.sym (equiv-obj f)
+
+-- A groupoid is a category that has a groupoid structure
+
+record Groupoid (o ℓ e : Level) : Set (suc (o ⊔ ℓ ⊔ e)) where
+  field
+    category   : Category o ℓ e
+    isGroupoid : IsGroupoid category
+
+  open IsGroupoid isGroupoid public

--- a/Categories/Category/Instance/Groupoids.agda
+++ b/Categories/Category/Instance/Groupoids.agda
@@ -1,0 +1,58 @@
+{-# OPTIONS --without-K --safe #-}
+module Categories.Category.Instance.Groupoids where
+
+-- The category of groupoids.
+--
+-- This category should maybe be called "Ho(Groupoids)" or "Ho(Gpd)"
+-- instead.  The "homsets" are not the "usual" ones consisting of
+-- functors, but consist instead of equivalence classes of functors up
+-- to natural isomorphism.  This is because homsets here are really
+-- hom-setoids and we pick natural isomorphism as the equivalence
+-- relation for these setoids.
+--
+-- See https://ncatlab.org/nlab/show/Ho%28Cat%29
+
+open import Level
+open import Categories.Category
+open import Categories.Category.Groupoid
+open import Categories.Functor as Fctr using (Functor; _∘F_)
+open import Categories.Functor.Properties using ([_]-resp-Iso)
+import Categories.Morphism.IsoEquiv as IsoEquiv
+open import Categories.NaturalTransformation.NaturalIsomorphism
+  using (NaturalIsomorphism; associator; unitorˡ; unitorʳ; isEquivalence; _ⓘₕ_)
+private
+  variable
+    o ℓ e : Level
+
+open Groupoid using (category)
+
+-- The category of groupoids.
+
+Groupoids : ∀ o ℓ e → Category (suc (o ⊔ ℓ ⊔  e)) (o ⊔ ℓ ⊔ e) (o ⊔ ℓ ⊔ e)
+Groupoids o ℓ e = record
+  { Obj       = Groupoid o ℓ e
+  ; _⇒_       = λ G H → Functor (category G) (category H)
+  ; _≈_       = NaturalIsomorphism
+  ; id        = Fctr.id
+  ; _∘_       = _∘F_
+  ; assoc     = λ {_ _ _ _ F G H} → associator F G H
+  ; identityˡ = unitorˡ
+  ; identityʳ = unitorʳ
+  ; equiv     = isEquivalence
+  ; ∘-resp-≈  = _ⓘₕ_
+  }
+
+module _ {o ℓ e o′ ℓ′ e′} {G : Groupoid o ℓ e} {H : Groupoid o′ ℓ′ e′}
+         (F : Functor (category G) (category H))
+         where
+
+  private
+    module G = Groupoid G
+    module H = Groupoid H
+  open Functor F
+  open IsoEquiv (category H) using (to-unique)
+
+  -- Functors preserve inverses
+
+  F-resp-⁻¹ : ∀ {A B} (f : A G.⇒ B) → F₁ (f G.⁻¹) H.≈ (F₁ f) H.⁻¹
+  F-resp-⁻¹ f = to-unique ([ F ]-resp-Iso G.iso) H.iso H.Equiv.refl

--- a/Categories/Category/Monoidal/Properties.agda
+++ b/Categories/Category/Monoidal/Properties.agda
@@ -16,7 +16,7 @@ open import Categories.Category.Product using (Product)
 open import Categories.Functor using (Functor)
 open import Categories.Functor.Bifunctor
 open import Categories.Functor.Properties
-open import Categories.Category.IsGroupoid
+open import Categories.Category.Groupoid using (IsGroupoid)
 open import Categories.Morphism C
 open import Categories.Morphism.IsoEquiv C using (_≃_)
 open import Categories.Morphism.Isomorphism C

--- a/Categories/Category/Product.agda
+++ b/Categories/Category/Product.agda
@@ -7,7 +7,7 @@ open import Data.Product using (_×_; Σ; _,_; proj₁; proj₂; zip; map; <_,_>
 
 open import Categories.Utils.Product
 open import Categories.Category using (Category)
-open import Categories.Category.IsGroupoid using (IsGroupoid)
+open import Categories.Category.Groupoid using (IsGroupoid)
 open import Categories.Functor renaming (id to idF)
 open import Categories.NaturalTransformation.Core
 open import Categories.NaturalTransformation.NaturalIsomorphism hiding (refl)

--- a/Categories/Functor/Groupoid.agda
+++ b/Categories/Functor/Groupoid.agda
@@ -5,7 +5,7 @@ module Categories.Functor.Groupoid where
 open import Level
 
 open import Categories.Category
-open import Categories.Category.IsGroupoid
+open import Categories.Category.Groupoid using (IsGroupoid)
 open import Categories.Functor
 import Categories.Morphism.Reasoning as MR
 

--- a/Categories/Functor/Instance/Core.agda
+++ b/Categories/Functor/Instance/Core.agda
@@ -1,0 +1,81 @@
+{-# OPTIONS --without-K --safe #-}
+
+module Categories.Functor.Instance.Core where
+
+-- Core Functor (from Cats to Groupoids).
+-- This is the right-adjoint of the forgetful functor from Groupoids to
+-- Cats (see Categories.Functor.Adjoint.Instance.Core)
+
+open import Level using (_⊔_)
+
+open import Categories.Category using (Category)
+import Categories.Category.Construction.Core as C
+open import Categories.Category.Groupoid using (Groupoid)
+open import Categories.Category.Instance.Cats using (Cats)
+open import Categories.Category.Instance.Groupoids using (Groupoids)
+open import Categories.Functor using (Functor; _∘F_; id)
+open import Categories.Functor.Properties using ([_]-resp-≅)
+open import Categories.NaturalTransformation.NaturalIsomorphism
+  using (NaturalIsomorphism)
+import Categories.Morphism as Morphism
+
+Core : ∀ {o ℓ e} → Functor (Cats o ℓ e) (Groupoids o (ℓ ⊔ e) e)
+Core {o} {ℓ} {e} = record
+   { F₀ = CoreGrpd
+   ; F₁ = CoreFunctor
+   ; identity     = CoreId
+   ; homomorphism = λ {A B C F G} → CoreHom {A} {B} {C} {F} {G}
+   ; F-resp-≈     = CoreRespNI
+   }
+   where
+     CoreGrpd : Category o ℓ e → Groupoid o (ℓ ⊔ e) e
+     CoreGrpd C = record
+       { category   = C.Core′ C
+       ; isGroupoid = C.Core′-isGroupoid C
+       }
+
+     CoreFunctor : {A B : Category o ℓ e} →
+                   Functor A B → Functor (C.Core′ A) (C.Core′ B)
+     CoreFunctor {A} {B} F = record
+       { F₀ = F₀
+       ; F₁ = [ F ]-resp-≅
+       ; identity     = identity
+       ; homomorphism = homomorphism
+       ; F-resp-≈     = F-resp-≈
+       }
+       where open Functor F
+
+     CoreId : {A : Category o ℓ e} → NaturalIsomorphism (CoreFunctor {A} id) id
+     CoreId {A} = record
+       { F⇒G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
+       ; F⇐G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
+       ; iso = λ _ → record { isoˡ = identityˡ ; isoʳ = identityˡ }
+       }
+       where
+         open Category A
+         open Morphism A
+
+     CoreHom : {A B C : Category o ℓ e}
+               {F : Functor A B} {G : Functor B C} →
+               NaturalIsomorphism (CoreFunctor (G ∘F F))
+                                  (CoreFunctor G ∘F CoreFunctor F)
+     CoreHom {A} {B} {C} {F} {G} = record
+       { F⇒G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
+       ; F⇐G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
+       ; iso = λ _ → record { isoˡ = identityˡ ; isoʳ = identityˡ }
+       }
+       where
+         open Category C
+         open Morphism C
+
+     CoreRespNI : {A B : Category o ℓ e} {F G : Functor A B} →
+                  NaturalIsomorphism F G →
+                  NaturalIsomorphism (CoreFunctor F) (CoreFunctor G)
+     CoreRespNI {A} {B} {F} {G} μ = record
+       { F⇒G = record { η = λ _ →       FX≅GX ; commute = λ _ → ⇒.commute _ }
+       ; F⇐G = record { η = λ _ → ≅-sym FX≅GX ; commute = λ _ → ⇐.commute _ }
+       ; iso = λ X → record { isoˡ = iso.isoˡ X ; isoʳ = iso.isoʳ X }
+       }
+       where
+         open NaturalIsomorphism μ
+         open Morphism B

--- a/Categories/Morphism/Isomorphism.agda
+++ b/Categories/Morphism/Isomorphism.agda
@@ -17,7 +17,7 @@ open import Relation.Binary.Construct.Closure.Transitive
 open import Relation.Binary.PropositionalEquality as ≡ using (_≡_)
 
 import Categories.Category.Construction.Core as Core
-open import Categories.Category.IsGroupoid
+open import Categories.Category.Groupoid using (IsGroupoid)
 import Categories.Morphism as Morphism
 import Categories.Morphism.Properties as Morphismₚ
 import Categories.Morphism.IsoEquiv as IsoEquiv

--- a/Categories/Morphism/Reasoning/Iso.agda
+++ b/Categories/Morphism/Reasoning/Iso.agda
@@ -12,7 +12,7 @@ module Categories.Morphism.Reasoning.Iso {o ℓ e} (C : Category o ℓ e) where
 open import Level
 open import Function renaming (id to idᶠ; _∘_ to _∙_)
 
-open import Categories.Category.IsGroupoid
+open import Categories.Category.Groupoid using (IsGroupoid)
 open import Categories.Morphism C
 open import Categories.Morphism.Reasoning.Core C
 

--- a/Everything.agda
+++ b/Everything.agda
@@ -1,6 +1,7 @@
 import Categories.2-Category
 import Categories.Adjoint
 import Categories.Adjoint.Equivalence
+import Categories.Adjoint.Instance.Core
 import Categories.Adjoint.Mate
 import Categories.Adjoint.Properties
 import Categories.Bicategory
@@ -22,6 +23,7 @@ import Categories.Category.Complete.Finitely
 import Categories.Category.Construction.Arrow
 import Categories.Category.Construction.Comma
 import Categories.Category.Construction.Coproduct
+import Categories.Category.Construction.Core
 import Categories.Category.Construction.Elements
 import Categories.Category.Construction.F-Algebras
 import Categories.Category.Construction.Functors
@@ -100,6 +102,7 @@ import Categories.Functor.Equivalence
 import Categories.Functor.Fibration
 import Categories.Functor.Groupoid
 import Categories.Functor.Hom
+import Categories.Functor.Instance.Core
 import Categories.Functor.Instance.Discrete
 import Categories.Functor.Monoidal
 import Categories.Functor.Power

--- a/Everything.agda
+++ b/Everything.agda
@@ -4,9 +4,9 @@ import Categories.Adjoint.Equivalence
 import Categories.Adjoint.Mate
 import Categories.Adjoint.Properties
 import Categories.Bicategory
+import Categories.Bicategory.Bigroupoid
 import Categories.Bicategory.Construction.1-Category
 import Categories.Bicategory.Instance.Cats
-import Categories.Bicategory.IsBigroupoid
 import Categories.Category
 import Categories.Category.BicartesianClosed
 import Categories.Category.Cartesian
@@ -34,10 +34,12 @@ import Categories.Category.Core
 import Categories.Category.Discrete
 import Categories.Category.Equivalence
 import Categories.Category.Finite
+import Categories.Category.Groupoid
 import Categories.Category.Instance.Cats
 import Categories.Category.Instance.EmptySet
 import Categories.Category.Instance.FamilyOfSets
 import Categories.Category.Instance.Globe
+import Categories.Category.Instance.Groupoids
 import Categories.Category.Instance.One
 import Categories.Category.Instance.PointedSets
 import Categories.Category.Instance.Properties.Setoids
@@ -46,7 +48,6 @@ import Categories.Category.Instance.Sets
 import Categories.Category.Instance.SingletonSet
 import Categories.Category.Instance.StrictCats
 import Categories.Category.Instance.Zero
-import Categories.Category.IsGroupoid
 import Categories.Category.Monoidal
 import Categories.Category.Monoidal.Braided
 import Categories.Category.Monoidal.Closed


### PR DESCRIPTION
Yet another slice of #40: the core functor from categories to groupoids.

Contains:
 - the core construction (the groupoid `Core C` for a given category `C`) in `Categories.Category.Construction.Core`;
 - the construction extended to a functor in `Categories.Functor.Instance.Core`;
 - a proof that the functor is right-adjoint to the forgetful functor from `Groupoids` to `Cats` in `Categories.Adjoint.Instance.Core`.

Caveats:
 - this PR depends on #46 for the definition of the category of groupoids;
 - the `Core` construction is essentially the same as the `Isos` category from `Categories.Morphism.IsoEquiv`, but I think the name and placement of the new module is better –  "core" is the generally accepted name of this construction, AFAIK.
