### PR TITLE
Fix #44: the full Grothendieck construction for (contravariant) pseudofunctors

### DIFF
--- a/Categories/Bicategory/Construction/1-Category.agda
+++ b/Categories/Bicategory/Construction/1-Category.agda
@@ -1,0 +1,126 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category
+
+-- Lifts a 1-Category into a bicategory
+
+module Categories.Bicategory.Construction.1-Category
+  {o ℓ e} b (C : Category o ℓ e) where
+
+open import Level using (Lift; lift)
+open import Data.Unit using (⊤; tt)
+open import Data.Product using (uncurry)
+open import Relation.Binary using (Setoid)
+
+open import Categories.Bicategory
+open import Categories.Category.Instance.Cats using (Cats)
+open import Categories.Category.Monoidal using (Monoidal)
+open import Categories.Category.Monoidal.Instance.Cats using (module Product)
+open import Categories.Category.Groupoid using (Groupoid)
+open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
+open import Categories.Functor.Construction.Constant using (const)
+open import Categories.Functor.Bifunctor using (Bifunctor)
+
+private module C = Category C
+open C hiding (id)
+
+1-Category : Bicategory ℓ e b o
+1-Category = record
+  { enriched = record
+    { Obj     = Obj
+    ; hom     = hom
+    ; id      = id
+    ; ⊚       = ⊚
+    ; ⊚-assoc = ⊚-assoc
+    ; unitˡ   = unitˡ
+    ; unitʳ   = unitʳ
+    }
+  ; triangle = lift tt
+  ; pentagon = lift tt
+  }
+  where
+    open Monoidal (Product.Cats-Monoidal {ℓ} {e} {b})
+    open Category.Commutation (Cats ℓ e b)
+
+    -- Since we are doing Setoid-enriched category theory, we don't
+    -- lift homsets to discrete hom-categories, but hom-setoids to
+    -- thin hom-groupoids.
+
+    hom : C.Obj → C.Obj → Category ℓ e b
+    hom A B = record
+      { Obj = HomSetoid.Carrier
+      ; _⇒_ = HomSetoid._≈_
+      ; _≈_ = λ _ _ → Lift b ⊤
+      ; id  = HomSetoid.refl
+      ; _∘_ = λ f g → HomSetoid.trans g f
+      ; assoc     = lift tt
+      ; identityˡ = lift tt
+      ; identityʳ = lift tt
+      ; equiv     = record
+        { refl    = lift tt
+        ; sym     = λ _ → lift tt
+        ; trans   = λ _ _ → lift tt
+        }
+      ; ∘-resp-≈  = λ _ _ → lift tt
+      }
+      where module HomSetoid = Setoid (hom-setoid {A} {B})
+
+    id : ∀ A → Functor unit (hom A A)
+    id A = const (C.id {A})
+
+    ⊚ : ∀ {A B C} → Bifunctor (hom B C) (hom A B) (hom A C)
+    ⊚ {A} {B} {C} = record
+      { F₀ = uncurry _∘_
+      ; F₁ = uncurry ∘-resp-≈
+      ; identity     = lift tt
+      ; homomorphism = lift tt
+      ; F-resp-≈     = λ _ → lift tt
+      }
+
+    ⊚-assoc : ∀ {A B C D} →
+      [ (hom C D ⊗₀ hom B C) ⊗₀ hom A B ⇒ hom A D ]⟨
+        ⊚ ⊗₁ idF          ⇒⟨ hom B D ⊗₀ hom A B ⟩
+        ⊚
+      ≈ associator.from   ⇒⟨ hom C D ⊗₀ (hom B C ⊗₀ hom A B) ⟩
+        idF ⊗₁ ⊚          ⇒⟨ hom C D ⊗₀ hom A C ⟩
+        ⊚
+      ⟩
+    ⊚-assoc = record
+      { F⇒G = record { η = λ _ →           assoc ; commute = λ _ → lift tt }
+      ; F⇐G = record { η = λ _ → Equiv.sym assoc ; commute = λ _ → lift tt }
+      ; iso = λ _ → record { isoˡ = lift tt ; isoʳ = lift tt }
+      }
+
+    unitˡ : ∀ {A B} →
+      [ unit ⊗₀ hom A B ⇒ hom A B ]⟨
+        id B ⊗₁ idF   ⇒⟨ hom B B ⊗₀ hom A B ⟩
+        ⊚
+      ≈ unitorˡ.from
+      ⟩
+    unitˡ = record
+      { F⇒G = record { η = λ _ →           identityˡ ; commute = λ _ → lift tt }
+      ; F⇐G = record { η = λ _ → Equiv.sym identityˡ ; commute = λ _ → lift tt }
+      ; iso = λ _ → record { isoˡ = lift tt ; isoʳ = lift tt }
+      }
+
+    unitʳ : ∀ {A B} →
+      [ hom A B ⊗₀ unit ⇒ hom A B ]⟨
+        idF ⊗₁ id A    ⇒⟨ hom A B ⊗₀ hom A A ⟩
+        ⊚
+      ≈ unitorʳ.from
+      ⟩
+    unitʳ = record
+      { F⇒G = record { η = λ _ →           identityʳ ; commute = λ _ → lift tt }
+      ; F⇐G = record { η = λ _ → Equiv.sym identityʳ ; commute = λ _ → lift tt }
+      ; iso = λ _ → record { isoˡ = lift tt ; isoʳ = lift tt }
+      }
+
+open Bicategory 1-Category
+
+-- The hom-categories are hom-groupids
+
+hom-groupoid : ∀ {A B} → Groupoid (hom A B)
+hom-groupoid = record
+  { _⁻¹ = C.Equiv.sym
+  ; iso = record { isoˡ = lift tt ; isoʳ = lift tt }
+  }

--- a/Categories/Category/Construction/Grothendieck.agda
+++ b/Categories/Category/Construction/Grothendieck.agda
@@ -1,39 +1,362 @@
 {-# OPTIONS --without-K --safe #-}
 module Categories.Category.Construction.Grothendieck where
 
--- The simpler construction of a Category from a Functor into Cats, as a (weak) 1-Category
+-- The construction of a 1-Category from a (contravariant)
+-- pseudofunctor into Cats (as a bicategory)
+
 open import Level
-open import Data.Product using (Σ; _,_; Σ-syntax; proj₁; proj₂; map; _×_)
-open import Function using (_$_) renaming (_∘_ to _●_)
+open import Data.Product using (Σ; _,_)
+open import Function using (_$_)
+open import Relation.Binary using (IsEquivalence)
 
 open import Categories.Category
-open import Categories.Category.Instance.Cats
+open import Categories.Bicategory using (Bicategory)
+open import Categories.Bicategory.Instance.Cats
+open import Categories.Bicategory.Construction.1-Category
 open import Categories.Functor renaming (id to idF)
+open import Categories.Morphism using (Iso)
+open import Categories.Pseudofunctor
 open import Categories.NaturalTransformation hiding (id)
-open import Categories.NaturalTransformation.NaturalIsomorphism
 
 private
   variable
     o ℓ e o′ ℓ′ e′ : Level
 
-Grothendieck : {C : Category o ℓ e} → Functor C (Cats o′ ℓ′ e′) → Category (o ⊔ o′) (ℓ ⊔ ℓ′) e
-Grothendieck {C = C} F = record
-  { Obj = Σ Obj (λ c → Category.Obj $ F₀ c)
-  ; _⇒_ = λ { (c , a) (c′ , a′) →
-          Σ (c ⇒ c′) (λ f →  let module D = Category (F₀ c′) in
-                              Functor.F₀ (F₁ f) a D.⇒ a′)  }
-  ; _≈_ = λ x y → proj₁ x ≈ proj₁ y -- because the other half is always provably ≈
-  ; id = λ { {c , a} → id , (η $ F⇒G $ identity {c}) a}
-  ; _∘_ = λ { {_ , a₁} {_ , a₂} {c₃ , a₃} (u , f) (v , g) → u ∘ v ,
-          let module E = Category (F₀ c₃) in f E.∘ Functor.F₁ (F₁ u) g E.∘ (η $ F⇒G homomorphism) a₁ }
-  ; assoc = assoc
-  ; identityˡ = identityˡ
-  ; identityʳ = identityʳ
-  ; equiv = record { refl = Equiv.refl ; sym = Equiv.sym ; trans = Equiv.trans }
-  ; ∘-resp-≈ = ∘-resp-≈
-  }
-  where
-  open Category C
-  open Functor F
-  open NaturalIsomorphism
+module _ {C : Category o ℓ e} {b}
+         (P : Pseudofunctor (1-Category b (Category.op C)) (Cats o′ ℓ′ e′)) where
+
+  open Pseudofunctor P renaming (P₁ to PF; assoc to P-assoc)
+  open Functor using () renaming (F₀ to _$₀_; F₁ to _$₁_)
   open NaturalTransformation
+
+  private
+    infix  4 _≈_ _⇒_
+    infixr 9 _∘_
+
+    module B = Bicategory (1-Category b (Category.op C))
+    module C = Category C
+    module _ {x y} where
+      open Functor (PF {x} {y}) public
+        renaming (F₀ to P₁; F₁ to P₂; F-resp-≈ to P-resp-≈)
+
+    open Functor
+
+    module _ {x y : C.Obj} where
+      open Category (P₀ x)
+      open HomReasoning
+
+      -- A helper lemma.
+
+      P-resp-Iso : ∀ {f g : C [ x , y ]} (eq : C [ f ≈ g ]) {a} →
+                   Iso (P₀ x) (η (P₂ eq) a) (η (P₂ $ C.Equiv.sym eq) a)
+      P-resp-Iso eq {a} = record
+        { isoˡ = begin
+            η (P₂ $ C.Equiv.sym eq) a ∘ η (P₂ eq) a       ≈˘⟨ homomorphism PF ⟩
+            η (P₂ $ C.Equiv.trans eq (C.Equiv.sym eq)) a  ≈⟨ P-resp-≈ _ ⟩
+            η (P₂ C.Equiv.refl) a                         ≈⟨ identity PF ⟩
+            id                                            ∎
+        ; isoʳ = begin
+            η (P₂ eq) a ∘ η (P₂ $ C.Equiv.sym eq) a       ≈˘⟨ homomorphism PF ⟩
+            η (P₂ $ C.Equiv.trans (C.Equiv.sym eq) eq) a  ≈⟨ P-resp-≈ _ ⟩
+            η (P₂ C.Equiv.refl) a                         ≈⟨ identity PF ⟩
+            id                                            ∎
+        }
+
+    -- Objects and morphism
+
+    Obj : Set (o ⊔ o′)
+    Obj = Σ C.Obj (λ x → Category.Obj $ P₀ x)
+
+    _⇒_ : Obj → Obj → Set (ℓ ⊔ ℓ′)
+    (x₁ , a₁) ⇒ (x₂ , a₂) = Σ (x₁ C.⇒ x₂) λ f → P₀ x₁ [ a₁ , P₁ f $₀ a₂ ]
+
+    -- Pairwise equivalence
+    --
+    -- The second components of equal morphisms don't live in the same
+    -- homset because their domains don't agree 'on the nose'.  Hence
+    -- the second components are equal only up to coherent iso.  This
+    -- substantially complicates the proofs of associativity, the unit
+    -- laws and functionality of composition.
+
+    _≈_ : ∀ {A B} (f₁ f₂ : A ⇒ B) → Set (e ⊔ e′)
+    _≈_ {x₁ , a₁} {x₂ , a₂} (f₁ , g₁) (f₂ , g₂) =
+      Σ (f₁ C.≈ f₂) λ eq → η (P₂ $ eq) a₂ D.∘ g₁ D.≈ g₂
+      where module D = Category (P₀ x₁)
+
+    -- Identity and composition
+
+    id : ∀ {A} → A ⇒ A
+    id {_ , a} = C.id , η (unitˡ.η _) a
+
+    _∘_ : ∀ {A B C} → B ⇒ C → A ⇒ B → A ⇒ C
+    _∘_ {x₁ , a₁} {_ , a₂} {_ , a₃} (f₁ , g₁) (f₂ , g₂) =
+      f₁ C.∘ f₂ , (η (Hom.η (f₂ , f₁)) a₃ D.∘ P₁ f₂ $₁ g₁) D.∘ g₂
+      where module D = Category (P₀ x₁)
+
+    -- Associativity and unit laws.
+    --
+    -- Because the second component of equality only holds up to
+    -- coherent iso, we need to invoke the coherence conditions
+    -- associated with the pseudofunctor P to establish associativity.
+    --
+    -- Once we realize this, the proofs are not particularly hard, but
+    -- long and tedious (especially that of associativity), mostly
+    -- because they involve re-arranging lots of parentheses via
+    -- manual application of the underlying associativity laws.
+
+    assoc : ∀ {A B C D} {f : A ⇒ B} {g : B ⇒ C} {h : C ⇒ D} →
+            (h ∘ g) ∘ f ≈ h ∘ (g ∘ f)
+    assoc {x₁ , _} {x₂ , _} {x₃ , a₃} {_ , a₄} {f₁ , g₁} {f₂ , g₂} {f₃ , g₃} =
+      C.assoc ,
+      (begin
+        η (P₂ C.assoc) a₄ ∙
+        (η (Hom.η (f₁ , f₃ C.∘ f₂)) a₄ ∙
+         P₁ f₁ $₁ ((η (Hom.η (f₂ , f₃)) a₄ E.∘ P₁ f₂ $₁ g₃) E.∘ g₂)) ∙ g₁
+      ≈⟨ ∘-resp-≈ʳ $ ∘-resp-≈ˡ $ ∘-resp-≈ʳ $ F-resp-≈ (P₁ f₁) E.assoc  ⟩
+        η (P₂ C.assoc) a₄ ∙
+        (η (Hom.η (f₁ , f₃ C.∘ f₂)) a₄ ∙
+         P₁ f₁ $₁ (η (Hom.η (f₂ , f₃)) a₄ E.∘ P₁ f₂ $₁ g₃ E.∘ g₂)) ∙ g₁
+      ≈⟨ ∘-resp-≈ʳ $ ∘-resp-≈ˡ $ ∘-resp-≈ʳ $ homomorphism (P₁ f₁) ⟩
+        η (P₂ C.assoc) a₄ ∙
+        (η (Hom.η (f₁ , f₃ C.∘ f₂)) a₄ ∙
+         P₁ f₁ $₁ η (Hom.η (f₂ , f₃)) a₄ ∙
+         P₁ f₁ $₁ (P₁ f₂ $₁ g₃ E.∘ g₂)) ∙ g₁
+      ≈˘⟨ D.assoc                          then
+          D.Equiv.sym $ ∘-resp-≈ʳ D.assoc  then
+          ∘-resp-≈ʳ $ ∘-resp-≈ˡ $ D.assoc  ⟩
+        (η (P₂ C.assoc) a₄ ∙
+         η (Hom.η (f₁ , f₃ C.∘ f₂)) a₄ ∙
+         P₁ f₁ $₁ η (Hom.η (f₂ , f₃)) a₄) ∙
+        P₁ f₁ $₁ (P₁ f₂ $₁ g₃ E.∘ g₂) ∙ g₁
+      ≈˘⟨ ∘-resp-≈ˡ $ ∘-resp-≈ʳ $ ∘-resp-≈ʳ (D.identityʳ then D.identityʳ) ⟩
+        (η (P₂ C.assoc) a₄ ∙
+         η (Hom.η (f₁ , f₃ C.∘ f₂)) a₄ ∙
+         (P₁ f₁ $₁ η (Hom.η (f₂ , f₃)) a₄ ∙ D.id) ∙ D.id) ∙
+        P₁ f₁ $₁ ((P₁ f₂ $₁ g₃) E.∘ g₂) ∙ g₁
+      ≈˘⟨ ∘-resp-≈ˡ $ ∘-resp-≈ʳ P-assoc ⟩
+        (η (P₂ C.assoc) a₄ ∙
+         η (P₂ (C.Equiv.sym C.assoc)) a₄ ∙
+         η (Hom.η (f₂ C.∘ f₁ , f₃)) a₄ ∙ P₁ (f₂ C.∘ f₁) $₁ F.id ∙
+         η (Hom.η (f₁ , f₂)) (P₁ f₃ $₀ a₄)) ∙
+        P₁ f₁ $₁ ((P₁ f₂ $₁ g₃) E.∘ g₂) ∙ g₁
+      ≈˘⟨ ∘-resp-≈ˡ D.assoc ⟩
+        ((η (P₂ C.assoc) a₄ ∙ η (P₂ (C.Equiv.sym C.assoc)) a₄) ∙
+         η (Hom.η (f₂ C.∘ f₁ , f₃)) a₄ ∙ P₁ (f₂ C.∘ f₁) $₁ F.id ∙
+         η (Hom.η (f₁ , f₂)) (P₁ f₃ $₀ a₄)) ∙
+        P₁ f₁ $₁ ((P₁ f₂ $₁ g₃) E.∘ g₂) ∙ g₁
+      ≈⟨ ∘-resp-≈ˡ $ ∘-resp-≈ˡ $ Iso.isoʳ (P-resp-Iso C.assoc) ⟩
+        (D.id ∙
+         η (Hom.η (f₂ C.∘ f₁ , f₃)) a₄ ∙ P₁ (f₂ C.∘ f₁) $₁ F.id ∙
+         η (Hom.η (f₁ , f₂)) (P₁ f₃ $₀ a₄)) ∙
+        P₁ f₁ $₁ ((P₁ f₂ $₁ g₃) E.∘ g₂) ∙ g₁
+      ≈⟨ ∘-resp-≈ D.identityˡ (∘-resp-≈ˡ $ homomorphism (P₁ f₁) ) ⟩
+        (η (Hom.η (f₂ C.∘ f₁ , f₃)) a₄ ∙ P₁ (f₂ C.∘ f₁) $₁ F.id ∙
+         η (Hom.η (f₁ , f₂)) (P₁ f₃ $₀ a₄)) ∙
+        (P₁ f₁ $₁ (P₁ f₂ $₁ g₃) ∙ P₁ f₁ $₁ g₂) ∙ g₁
+      ≈⟨ ∘-resp-≈ (D.Equiv.sym D.assoc) D.assoc  then
+         D.assoc                                 then
+         ∘-resp-≈ʳ (D.Equiv.sym D.assoc)         ⟩
+        (η (Hom.η (f₂ C.∘ f₁ , f₃)) a₄ ∙ P₁ (f₂ C.∘ f₁) $₁ F.id) ∙
+        (η (Hom.η (f₁ , f₂)) (P₁ f₃ $₀ a₄) ∙ P₁ f₁ $₁ (P₁ f₂ $₁ g₃)) ∙
+        P₁ f₁ $₁ g₂ ∙ g₁
+      ≈⟨ ∘-resp-≈ʳ $ ∘-resp-≈ˡ (commute (Hom.η (f₁ , f₂)) g₃) ⟩
+        (η (Hom.η (f₂ C.∘ f₁ , f₃)) a₄ ∙ P₁ (f₂ C.∘ f₁) $₁ F.id) ∙
+        (P₁ (f₂ C.∘ f₁) $₁ g₃ ∙ η (Hom.η (f₁ , f₂)) a₃) ∙
+        P₁ f₁ $₁ g₂ ∙ g₁
+      ≈⟨ ∘-resp-≈ˡ (∘-resp-≈ʳ (identity (P₁ (f₂ C.∘ f₁))) then D.identityʳ) ⟩
+        η (Hom.η (f₂ C.∘ f₁ , f₃)) a₄ ∙
+        (P₁ (f₂ C.∘ f₁) $₁ g₃ ∙ η (Hom.η (f₁ , f₂)) a₃) ∙
+        P₁ f₁ $₁ g₂ ∙ g₁
+      ≈⟨ ∘-resp-≈ʳ D.assoc                then
+         D.Equiv.sym D.assoc              then
+         ∘-resp-≈ʳ (D.Equiv.sym D.assoc)  ⟩
+        (η (Hom.η (f₂ C.∘ f₁ , f₃)) a₄ ∙ (P₁ (f₂ C.∘ f₁) $₁ g₃)) ∙
+        (η (Hom.η (f₁ , f₂)) a₃ ∙ (P₁ f₁ $₁ g₂)) ∙ g₁
+      ∎)
+      where
+        module D = Category (P₀ x₁)
+        module E = Category (P₀ x₂)
+        module F = Category (P₀ x₃)
+        open D renaming (_∘_ to _∙_)
+        infixl -5 _then_
+        _then_ = Equiv.trans
+        open HomReasoning
+
+    identityˡ : ∀ {A B} {f : A ⇒ B} → id ∘ f ≈ f
+    identityˡ {x₁ , _} {_ , a₂} {f , g} =
+      C.identityˡ ,
+      (begin
+        η (P₂ C.identityˡ) a₂ ∙
+        ((η (Hom.η (f , C.id)) a₂ ∙ P₁ f $₁ η (unitˡ.η _) a₂) ∙ g)
+      ≈˘⟨ D.assoc ⟩
+        (η (P₂ C.identityˡ) a₂ ∙
+         (η (Hom.η (f , C.id)) a₂ ∙ P₁ f $₁ η (unitˡ.η _) a₂)) ∙ g
+      ≈˘⟨ ∘-resp-≈ˡ (∘-resp-≈ʳ (∘-resp-≈ʳ D.identityʳ)) ⟩
+        (η (P₂ C.identityˡ) a₂ ∙
+         (η (Hom.η (f , C.id)) a₂ ∙ (P₁ f $₁ η (unitˡ.η _) a₂ ∙ D.id))) ∙ g
+      ≈⟨ ∘-resp-≈ˡ unitaryʳ ⟩
+        D.id ∙ g
+      ≈⟨ D.identityˡ ⟩
+        g
+      ∎)
+      where
+        module D = Category (P₀ x₁)
+        open D renaming (_∘_ to _∙_)
+        open HomReasoning
+
+    identityʳ : ∀ {A B} {f : A ⇒ B} → f ∘ id ≈ f
+    identityʳ {x₁ , a₁} {_ , a₂} {f , g} =
+      C.identityʳ ,
+      (begin
+        η (P₂ C.identityʳ) a₂ ∙
+        ((η (Hom.η (C.id , f)) a₂ ∙ P₁ C.id $₁ g) ∙ η (unitˡ.η _) a₁)
+      ≈⟨ ∘-resp-≈ʳ D.assoc ⟩
+        η (P₂ C.identityʳ) a₂ ∙
+        (η (Hom.η (C.id , f)) a₂ ∙ (P₁ C.id $₁ g ∙ η (unitˡ.η _) a₁))
+      ≈˘⟨ ∘-resp-≈ʳ $ ∘-resp-≈ʳ $ commute (unitˡ.η _) g ⟩
+        η (P₂ C.identityʳ) a₂ ∙
+        (η (Hom.η (C.id , f)) a₂ ∙ (η (unitˡ.η _) (P₁ f $₀ a₂) ∙ g))
+      ≈˘⟨ ∘-resp-≈ʳ D.assoc ⟩
+        η (P₂ C.identityʳ) a₂ ∙
+        ((η (Hom.η (C.id , f)) a₂ ∙ η (unitˡ.η _) (P₁ f $₀ a₂)) ∙ g)
+      ≈˘⟨ D.assoc ⟩
+        (η (P₂ C.identityʳ) a₂ ∙
+         (η (Hom.η (C.id , f)) a₂ ∙ η (unitˡ.η _) (P₁ f $₀ a₂))) ∙ g
+      ≈˘⟨ ∘-resp-≈ˡ $ ∘-resp-≈ʳ $ ∘-resp-≈ʳ D.identityˡ ⟩
+        (η (P₂ C.identityʳ) a₂ ∙
+         (η (Hom.η (C.id , f)) a₂ ∙ (D.id ∙ η (unitˡ.η _) (P₁ f $₀ a₂)))) ∙ g
+      ≈˘⟨ ∘-resp-≈ˡ $ ∘-resp-≈ʳ $ ∘-resp-≈ʳ $
+          ∘-resp-≈ˡ $ identity (P₁ C.id) ⟩
+        (η (P₂ C.identityʳ) a₂ ∙
+         (η (Hom.η (C.id , f)) a₂ ∙
+          ((P₁ C.id $₁ D.id) ∙ η (unitˡ.η _) (P₁ f $₀ a₂)))) ∙ g
+      ≈⟨ ∘-resp-≈ˡ unitaryˡ ⟩
+        D.id ∙ g
+      ≈⟨ D.identityˡ ⟩
+        g
+      ∎)
+      where
+        module D = Category (P₀ x₁)
+        open D renaming (_∘_ to _∙_)
+        open HomReasoning
+
+    -- Pair-wise equality is an equivalence
+
+    refl : ∀ {A B} {f : A ⇒ B} → f ≈ f
+    refl {x , _} =
+      C.Equiv.refl , D.Equiv.trans (D.∘-resp-≈ˡ (identity PF)) D.identityˡ
+      where module D = Category (P₀ x)
+
+    sym : ∀ {A B} {f g : A ⇒ B} → f ≈ g → g ≈ f
+    sym {x₁ , _} {_ , a₂} {_ , g₁} {_ , g₂} (f₁≈f₂ , g₁≈g₂) =
+      C.Equiv.sym f₁≈f₂ ,
+      (begin
+         η (P₂ $ C.Equiv.sym f₁≈f₂) a₂ ∙ g₂
+       ≈˘⟨ ∘-resp-≈ʳ g₁≈g₂ ⟩
+         η (P₂ $ C.Equiv.sym f₁≈f₂) a₂ ∙ η (P₂ f₁≈f₂) a₂ ∙ g₁
+       ≈˘⟨ D.assoc ⟩
+         (η (P₂ $ C.Equiv.sym f₁≈f₂) a₂ ∙ η (P₂ f₁≈f₂) a₂) ∙ g₁
+       ≈⟨ ∘-resp-≈ˡ $ Iso.isoˡ $ P-resp-Iso f₁≈f₂ ⟩
+         D.id ∙ g₁
+       ≈⟨ D.identityˡ ⟩
+         g₁
+       ∎)
+      where
+        module D = Category (P₀ x₁)
+        open D renaming (_∘_ to _∙_)
+        open HomReasoning
+
+    trans : ∀ {A B} {f g h : A ⇒ B} → f ≈ g → g ≈ h → f ≈ h
+    trans {x₁ , _} {_ , a₂} {_ , g₁} {_ , g₂} {_ , g₃}
+          (f₁≈f₂ , g₁≈g₂) (f₂≈f₃ , g₂≈g₃) =
+      C.Equiv.trans f₁≈f₂ f₂≈f₃ ,
+      (begin
+         η (P₂ $ C.Equiv.trans f₁≈f₂ f₂≈f₃) a₂ ∙ g₁
+       ≈⟨ ∘-resp-≈ˡ $ homomorphism PF ⟩
+         (η (P₂ f₂≈f₃) a₂ ∙ η (P₂ f₁≈f₂) a₂) ∙ g₁
+       ≈⟨ D.assoc ⟩
+         η (P₂ f₂≈f₃) a₂ ∙ η (P₂ f₁≈f₂) a₂ ∙ g₁
+       ≈⟨ ∘-resp-≈ʳ g₁≈g₂ ⟩
+         η (F₁ PF f₂≈f₃) a₂ ∙ g₂
+       ≈⟨ g₂≈g₃ ⟩
+         g₃
+       ∎)
+      where
+        module D = Category (P₀ x₁)
+        open D renaming (_∘_ to _∙_)
+        open HomReasoning
+
+    ≈-equiv : ∀ {A B} → IsEquivalence (_≈_ {A} {B})
+    ≈-equiv = record
+      { refl  = refl
+      ; sym   = sym
+      ; trans = trans
+      }
+
+    -- Functionality of composition
+    --
+    -- The key here is to use naturality of P-homomorphism to relate
+    -- functionality of composition (∘) in C to functoriality of
+    -- composition (⊚) in (P₀ x₁).
+
+    ∘-resp-≈ : ∀ {A B C} {f h : B ⇒ C} {g i : A ⇒ B} →
+               f ≈ h → g ≈ i → f ∘ g ≈ h ∘ i
+    ∘-resp-≈ {x₁ , _} {x₂ , a₂} {_ , a₃}
+             {f₁ , g₁} {f₂ , g₂} {f₃ , g₃} {f₄ , g₄}
+             (f₁≈f₂ , g₁≈g₂) (f₃≈f₄ , g₃≈g₄) =
+             C.∘-resp-≈ f₁≈f₂ f₃≈f₄ ,
+             (begin
+                η (P₂ $ C.∘-resp-≈ f₁≈f₂ f₃≈f₄) a₃ ∙
+                (η (Hom.η (f₃ , f₁)) a₃ ∙ P₁ f₃ $₁ g₁) ∙ g₃
+              ≈⟨ ∘-resp-≈ʳ D.assoc  then  D.Equiv.sym D.assoc ⟩
+                (η (P₂ $ C.∘-resp-≈ f₁≈f₂ f₃≈f₄) a₃ ∙ η (Hom.η (f₃ , f₁)) a₃) ∙
+                P₁ f₃ $₁ g₁ ∙ g₃
+              ≈˘⟨ ∘-resp-≈ˡ $ Hom.commute (f₃≈f₄ , f₁≈f₂) ⟩
+                (η (Hom.η (f₄ , f₂)) a₃ ∙
+                 P₁ f₄ $₁ (η (P₂ f₁≈f₂) a₃) ∙ η (P₂ f₃≈f₄) (P₁ f₁ $₀ a₃)) ∙
+                P₁ f₃ $₁ g₁ ∙ g₃
+              ≈⟨ D.assoc                                   then
+                 ∘-resp-≈ʳ D.assoc                         then
+                 ∘-resp-≈ʳ $ ∘-resp-≈ʳ $ Equiv.sym D.assoc ⟩
+                η (Hom.η (f₄ , f₂)) a₃ ∙
+                P₁ f₄ $₁ (η (P₂ f₁≈f₂) a₃) ∙
+                (η (P₂ f₃≈f₄) (P₁ f₁ $₀ a₃) ∙ P₁ f₃ $₁ g₁) ∙ g₃
+              ≈⟨ ∘-resp-≈ʳ $ ∘-resp-≈ʳ $ ∘-resp-≈ˡ (commute (P₂ f₃≈f₄) g₁) ⟩
+                η (Hom.η (f₄ , f₂)) a₃ ∙
+                P₁ f₄ $₁ (η (P₂ f₁≈f₂) a₃) ∙
+                (P₁ f₄ $₁ g₁ ∙ η (P₂ f₃≈f₄) a₂) ∙ g₃
+              ≈⟨ ∘-resp-≈ʳ $ ∘-resp-≈ʳ D.assoc    then
+                 Equiv.sym $ ∘-resp-≈ʳ $ D.assoc  then
+                 Equiv.sym $ D.assoc              ⟩
+                (η (Hom.η (f₄ , f₂)) a₃ ∙
+                 P₁ f₄ $₁ (η (P₂ f₁≈f₂) a₃) ∙ P₁ f₄ $₁ g₁) ∙
+                η (P₂ f₃≈f₄) a₂ ∙ g₃
+              ≈˘⟨ ∘-resp-≈ˡ $ ∘-resp-≈ʳ $ homomorphism (P₁ f₄) ⟩
+                (η (Hom.η (f₄ , f₂)) a₃ ∙
+                 P₁ f₄ $₁ (η (P₂ f₁≈f₂) a₃ E.∘ g₁)) ∙
+                η (P₂ f₃≈f₄) a₂ ∙ g₃
+              ≈⟨ D.∘-resp-≈ (∘-resp-≈ʳ (F-resp-≈ (P₁ f₄) g₁≈g₂)) g₃≈g₄ ⟩
+                (η (Hom.η (f₄ , f₂)) a₃ ∙ P₁ f₄ $₁ g₂) ∙ g₄
+              ∎)
+      where
+        module D = Category (P₀ x₁)
+        module E = Category (P₀ x₂)
+        open D renaming (_∘_ to _∙_)
+        infixl -5 _then_
+        _then_ = Equiv.trans
+        open HomReasoning
+
+  Grothendieck : Category (o ⊔ o′) (ℓ ⊔ ℓ′) (e ⊔ e′)
+  Grothendieck = record
+    { Obj = Obj
+    ; _⇒_ = _⇒_
+    ; _≈_ = _≈_
+    ; id  = id
+    ; _∘_ = _∘_
+    ; assoc     = assoc
+    ; identityˡ = identityˡ
+    ; identityʳ = identityʳ
+    ; equiv     = ≈-equiv
+    ; ∘-resp-≈  = ∘-resp-≈
+    }
+    where

--- a/Everything.agda
+++ b/Everything.agda
@@ -5,6 +5,7 @@ import Categories.Adjoint.Mate
 import Categories.Adjoint.Properties
 import Categories.Bicategory
 import Categories.Bicategory.Bigroupoid
+import Categories.Bicategory.Construction.1-Category
 import Categories.Bicategory.Instance.Cats
 import Categories.Category
 import Categories.Category.BicartesianClosed


### PR DESCRIPTION
Now (hopefully) with the correct notion of equality on arrows.

Differences w.r.t. the old version:
 * The fixed version turned out _a lot_ more complicated. 
 * This version uses pseudofunctors (rather than plain functors). The associativity and unit laws require coherence conditions which plain functors don't provide. I believe it should be possible to instead give a construction using plain functors into `StrictCats` (instead of `Cats`), but the version using pseudofunctors is more general.
 * Interestingly, because of the way the coherence conditions are defined in `Pseudofuctor`, it was easier to prove the contravariant version of the construction.
