### PR TITLE
Fix levels for definitions of isos and their equality.

### DIFF
--- a/Categories/Morphism.agda
+++ b/Categories/Morphism.agda
@@ -30,7 +30,7 @@ Mono {A = A} f = ∀ {C} → (g₁ g₂ : C ⇒ A) → f ∘ g₁ ≈ f ∘ g₂
 Epi : ∀ (f : A ⇒ B) → Set _
 Epi {B = B} f = ∀ {C} → (g₁ g₂ : B ⇒ C) → g₁ ∘ f ≈ g₂ ∘ f → g₁ ≈ g₂
 
-record Iso (from : A ⇒ B) (to : B ⇒ A) : Set (ℓ ⊔ e) where
+record Iso (from : A ⇒ B) (to : B ⇒ A) : Set e where
   field
     isoˡ : to ∘ from ≈ id
     isoʳ : from ∘ to ≈ id

--- a/Categories/Morphism/IsoEquiv.agda
+++ b/Categories/Morphism/IsoEquiv.agda
@@ -17,7 +17,7 @@ private
     A B C : Obj
 
 infix 4 _≃_
-record _≃_ (i j : A ≅ B) : Set (o ⊔ ℓ ⊔ e) where
+record _≃_ (i j : A ≅ B) : Set e where
   open _≅_
   field
     from-≈ : from i ≈ from j


### PR DESCRIPTION
Trivial fix detected while refactoring `Categories.Morphism.{IsoEquiv,Isomorphism}`.