### PR TITLE
Simplify the equality on isomorphism

### DIFF
--- a/Categories/Adjoint/Instance/Core.agda
+++ b/Categories/Adjoint/Instance/Core.agda
@@ -17,6 +17,7 @@ open import Categories.Category.Instance.Groupoids using (Groupoids)
 open import Categories.Functor using (Functor; _∘F_; id)
 open import Categories.Functor.Instance.Core using (Core)
 import Categories.Morphism as Morphism
+open import Categories.Morphism.IsoEquiv using (⌞_⌟)
 open import Categories.NaturalTransformation.NaturalIsomorphism using (refl; _≃_)
 
 -- The forgetful functor from Groupoids to Cats
@@ -45,34 +46,34 @@ CoreAdj = record
     open Groupoid using (category)
     module Core = Functor Core
 
-    unit : ∀ G → Functor (category G) (C.Core′ (category G))
+    unit : ∀ G → Functor (category G) (C.Core (category G))
     unit G = record
       { F₀ = Function.id
       ; F₁ = λ f → record { from = f ; to = f ⁻¹ ; iso = iso }
-      ; identity     = Equiv.refl
-      ; homomorphism = Equiv.refl
-      ; F-resp-≈     = Function.id
+      ; identity     = ⌞ Equiv.refl ⌟
+      ; homomorphism = ⌞ Equiv.refl ⌟
+      ; F-resp-≈     = λ eq → ⌞ eq ⌟
       }
       where open Groupoid G
 
     unit-commute : ∀ {G H} (F : Functor (category G) (category H)) →
                    unit H ∘F F ≃ Core.F₁ F ∘F unit G
     unit-commute {G} {H} F = record
-      { F⇒G = record { η = λ _ → ≅-refl  ; commute = λ _ → Equiv.sym id-comm }
-      ; F⇐G = record { η = λ _ → ≅-refl  ; commute = λ _ → Equiv.sym id-comm }
-      ; iso = λ _ → record { isoˡ = identityˡ ; isoʳ = identityˡ }
+      { F⇒G = record { η = λ _ → ≅-refl  ; commute = λ _ → ⌞ Equiv.sym id-comm ⌟ }
+      ; F⇐G = record { η = λ _ → ≅-refl  ; commute = λ _ → ⌞ Equiv.sym id-comm ⌟ }
+      ; iso = λ _ → record { isoˡ = ⌞ identityˡ ⌟ ; isoʳ = ⌞ identityˡ ⌟ }
       }
       where
         open Groupoid H
         open Morphism (category H)
 
-    counit : ∀ C → Functor (C.Core′ C) C
+    counit : ∀ C → Functor (C.Core C) C
     counit C = record
       { F₀ = Function.id
       ; F₁ = _≅_.from
       ; identity     = Equiv.refl
       ; homomorphism = Equiv.refl
-      ; F-resp-≈     = Function.id
+      ; F-resp-≈     = λ where ⌞ eq ⌟ → eq
       }
       where
         open Category C
@@ -101,9 +102,9 @@ CoreAdj = record
 
     zag : ∀ {B} → Core.F₁ (counit B) ∘F unit (Core.F₀ B) ≃ id
     zag {B} = record
-      { F⇒G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
-      ; F⇐G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
-      ; iso = λ _ → record { isoˡ = identityˡ ; isoʳ = identityˡ }
+      { F⇒G = record { η = λ _ → ≅-refl ; commute = λ _ → ⌞ Equiv.sym id-comm ⌟ }
+      ; F⇐G = record { η = λ _ → ≅-refl ; commute = λ _ → ⌞ Equiv.sym id-comm ⌟ }
+      ; iso = λ _ → record { isoˡ = ⌞ identityˡ ⌟ ; isoʳ = ⌞ identityˡ ⌟ }
       }
       where
         open Category B

--- a/Categories/Category/Construction/Cones.agda
+++ b/Categories/Category/Construction/Cones.agda
@@ -16,7 +16,7 @@ import Categories.Morphism.Reasoning as Reas
 open Category C
 open HomReasoning
 open Mor C using (_≅_)
-open IsoEquiv C using (_≃_)
+open IsoEquiv C using (_≃_; ⌞_⌟)
 open Reas C
 
 open Co F
@@ -100,10 +100,7 @@ iso-cone⇒iso-apex K⇔K′ = record
 
 
 ↮⇒-≃ : ∀ {i₁ i₂ : K ⇔ K′} → i₁ ↮ i₂ → iso-cone⇒iso-apex i₁ ≃ iso-cone⇒iso-apex i₂
-↮⇒-≃ i₁↮i₂ = record
-  { from-≈ = from-≈
-  ; to-≈   = to-≈
-  }
+↮⇒-≃ i₁↮i₂ = ⌞ from-≈ ⌟
   where open _↮_ i₁↮i₂
 
 -- -- .up-to-iso-cone-unique : ∀ L L′ → (i : proj-cone L ⇿ proj-cone L′) → up-to-iso-cone L L′ ≜ⁱ i

--- a/Categories/Category/Construction/Core.agda
+++ b/Categories/Category/Construction/Core.agda
@@ -15,6 +15,7 @@ open import Categories.Morphism 𝒞
 open import Categories.Morphism.IsoEquiv 𝒞
 
 open Category 𝒞
+open _≃_
 
 Core : Category o (ℓ ⊔ e) e
 Core = record
@@ -23,63 +24,16 @@ Core = record
   ; _≈_       = _≃_
   ; id        = ≅.refl
   ; _∘_       = flip ≅.trans
-  ; assoc     = record { from-≈ = assoc     ; to-≈ = Equiv.sym assoc }
-  ; identityˡ = record { from-≈ = identityˡ ; to-≈ = identityʳ }
-  ; identityʳ = record { from-≈ = identityʳ ; to-≈ = identityˡ }
+  ; assoc     = ⌞ assoc     ⌟
+  ; identityˡ = ⌞ identityˡ ⌟
+  ; identityʳ = ⌞ identityʳ ⌟
   ; equiv     = ≃-isEquivalence
-  ; ∘-resp-≈  = λ eq₁ eq₂ → record
-      { from-≈ = ∘-resp-≈ (from-≈ eq₁) (from-≈ eq₂)
-      ; to-≈   = ∘-resp-≈ (to-≈ eq₂)   (to-≈ eq₁)
-      }
+  ; ∘-resp-≈  = λ where ⌞ eq₁ ⌟ ⌞ eq₂ ⌟ → ⌞ ∘-resp-≈ eq₁ eq₂ ⌟
   }
-  where open _≃_
 
 Core-isGroupoid : IsGroupoid Core
 Core-isGroupoid = record
   { _⁻¹ = ≅.sym
-  ; iso = record
-    { isoˡ = sym∘ᵢ≃refl
-    ; isoʳ = ∘ᵢsym≃refl
-    }
-  }
-  where
-    open Category Core renaming (_∘_ to _∘ᵢ_)
-
-    sym∘ᵢ≃refl : ∀ {A B} {f : A ≅ B} → ≅.sym f ∘ᵢ f ≃ ≅.refl
-    sym∘ᵢ≃refl {f = f} = record
-      { from-≈ = isoˡ
-      ; to-≈   = isoˡ
-      }
-      where open _≅_ f
-
-    ∘ᵢsym≃refl : ∀ {A B} {f : A ≅ B} → f ∘ᵢ ≅.sym f ≃ ≅.refl
-    ∘ᵢsym≃refl {f = f} = record
-      { from-≈ = isoʳ
-      ; to-≈   = isoʳ
-      }
-      where open _≅_ f
-
--- An alternative (but equivalent) version of the core that uses _≃′_
--- as the equality.  It's often easier to prove things about this
--- version because the equality is simpler.
-
-Core′ : Category o (ℓ ⊔ e) e
-Core′ = record
-  { Obj       = Obj
-  ; _⇒_       = _≅_
-  ; _≈_       = _≃′_
-  ; id        = ≅.refl
-  ; _∘_       = flip ≅.trans
-  ; assoc     = assoc
-  ; identityˡ = identityˡ
-  ; identityʳ = identityʳ
-  ; equiv     = ≃′-isEquivalence
-  ; ∘-resp-≈  = ∘-resp-≈
-  }
-
-Core′-isGroupoid : IsGroupoid Core′
-Core′-isGroupoid = record
-  { _⁻¹ = ≅.sym
-  ; iso = λ {_ _ f} → record { isoˡ = isoˡ f ; isoʳ = isoʳ f }
+  ; iso = λ {_ _ f} → record { isoˡ = ⌞ isoˡ f ⌟ ; isoʳ = ⌞ isoʳ f ⌟ }
   }
   where open _≅_

--- a/Categories/Category/Monoidal.agda
+++ b/Categories/Category/Monoidal.agda
@@ -28,7 +28,7 @@ open import Categories.NaturalTransformation renaming (id to idN)
 open import Categories.NaturalTransformation.NaturalIsomorphism
   hiding (unitorˡ; unitorʳ; associator; _≃_)
 open import Categories.Morphism C using (_≅_; module ≅)
-open import Categories.Morphism.IsoEquiv C using (_≃_)
+open import Categories.Morphism.IsoEquiv C using (_≃_; ⌞_⌟)
 open import Categories.Morphism.Isomorphism C using (_∘ᵢ_; lift-triangle′; lift-pentagon′)
 
 private
@@ -181,7 +181,4 @@ record Monoidal : Set (o ⊔ ℓ ⊔ e) where
   pentagon-iso = lift-pentagon′ pentagon
 
   refl⊗refl≃refl : ≅.refl {A} ⊗ᵢ ≅.refl {B} ≃ ≅.refl
-  refl⊗refl≃refl = record
-    { from-≈ = identity
-    ; to-≈   = identity
-    }
+  refl⊗refl≃refl = ⌞ identity ⌟

--- a/Categories/Category/Monoidal/Properties.agda
+++ b/Categories/Category/Monoidal/Properties.agda
@@ -18,7 +18,7 @@ open import Categories.Functor.Bifunctor
 open import Categories.Functor.Properties
 open import Categories.Category.Groupoid using (IsGroupoid)
 open import Categories.Morphism C
-open import Categories.Morphism.IsoEquiv C using (_≃_)
+open import Categories.Morphism.IsoEquiv C using (_≃_; ⌞_⌟)
 open import Categories.Morphism.Isomorphism C
 import Categories.Morphism.Reasoning as MR
 
@@ -32,13 +32,8 @@ private
   { F₀           = uncurry′ _⊗₀_
   ; F₁           =  λ where (f , g) → f ⊗ᵢ g
   ; identity     = refl⊗refl≃refl
-  ; homomorphism = record { from-≈ = homomorphism ; to-≈ = homomorphism }
-  ; F-resp-≈     = λ where
-    (eq₁ , eq₂) → record
-      { from-≈ = F-resp-≈ (from-≈ eq₁ , from-≈ eq₂)
-      ; to-≈   = F-resp-≈ (to-≈ eq₁ , to-≈ eq₂)
-      }
-
+  ; homomorphism = ⌞ homomorphism ⌟
+  ; F-resp-≈     = λ where (⌞ eq₁ ⌟ , ⌞ eq₂ ⌟) → ⌞ F-resp-≈ (eq₁ , eq₂) ⌟
   }
   where open Functor ⊗
         open _≃_

--- a/Categories/Functor/Instance/Core.agda
+++ b/Categories/Functor/Instance/Core.agda
@@ -14,10 +14,11 @@ open import Categories.Category.Groupoid using (Groupoid)
 open import Categories.Category.Instance.Cats using (Cats)
 open import Categories.Category.Instance.Groupoids using (Groupoids)
 open import Categories.Functor using (Functor; _∘F_; id)
-open import Categories.Functor.Properties using ([_]-resp-≅)
+open import Categories.Functor.Properties using ([_]-resp-≅; [_]-resp-≃)
 open import Categories.NaturalTransformation.NaturalIsomorphism
   using (NaturalIsomorphism)
 import Categories.Morphism as Morphism
+open import Categories.Morphism.IsoEquiv using (⌞_⌟)
 
 Core : ∀ {o ℓ e} → Functor (Cats o ℓ e) (Groupoids o (ℓ ⊔ e) e)
 Core {o} {ℓ} {e} = record
@@ -30,26 +31,26 @@ Core {o} {ℓ} {e} = record
    where
      CoreGrpd : Category o ℓ e → Groupoid o (ℓ ⊔ e) e
      CoreGrpd C = record
-       { category   = C.Core′ C
-       ; isGroupoid = C.Core′-isGroupoid C
+       { category   = C.Core C
+       ; isGroupoid = C.Core-isGroupoid C
        }
 
      CoreFunctor : {A B : Category o ℓ e} →
-                   Functor A B → Functor (C.Core′ A) (C.Core′ B)
+                   Functor A B → Functor (C.Core A) (C.Core B)
      CoreFunctor {A} {B} F = record
        { F₀ = F₀
        ; F₁ = [ F ]-resp-≅
-       ; identity     = identity
-       ; homomorphism = homomorphism
-       ; F-resp-≈     = F-resp-≈
+       ; identity     = ⌞ identity     ⌟
+       ; homomorphism = ⌞ homomorphism ⌟
+       ; F-resp-≈     = [ F ]-resp-≃
        }
        where open Functor F
 
      CoreId : {A : Category o ℓ e} → NaturalIsomorphism (CoreFunctor {A} id) id
      CoreId {A} = record
-       { F⇒G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
-       ; F⇐G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
-       ; iso = λ _ → record { isoˡ = identityˡ ; isoʳ = identityˡ }
+       { F⇒G = record { η = λ _ → ≅-refl ; commute = λ _ → ⌞ Equiv.sym id-comm ⌟ }
+       ; F⇐G = record { η = λ _ → ≅-refl ; commute = λ _ → ⌞ Equiv.sym id-comm ⌟ }
+       ; iso = λ _ → record { isoˡ = ⌞ identityˡ ⌟ ; isoʳ = ⌞ identityˡ ⌟ }
        }
        where
          open Category A
@@ -60,9 +61,9 @@ Core {o} {ℓ} {e} = record
                NaturalIsomorphism (CoreFunctor (G ∘F F))
                                   (CoreFunctor G ∘F CoreFunctor F)
      CoreHom {A} {B} {C} {F} {G} = record
-       { F⇒G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
-       ; F⇐G = record { η = λ _ → ≅-refl ; commute = λ _ → Equiv.sym id-comm }
-       ; iso = λ _ → record { isoˡ = identityˡ ; isoʳ = identityˡ }
+       { F⇒G = record { η = λ _ → ≅-refl ; commute = λ _ → ⌞ Equiv.sym id-comm ⌟ }
+       ; F⇐G = record { η = λ _ → ≅-refl ; commute = λ _ → ⌞ Equiv.sym id-comm ⌟ }
+       ; iso = λ _ → record { isoˡ = ⌞ identityˡ ⌟ ; isoʳ = ⌞ identityˡ ⌟ }
        }
        where
          open Category C
@@ -72,9 +73,9 @@ Core {o} {ℓ} {e} = record
                   NaturalIsomorphism F G →
                   NaturalIsomorphism (CoreFunctor F) (CoreFunctor G)
      CoreRespNI {A} {B} {F} {G} μ = record
-       { F⇒G = record { η = λ _ →       FX≅GX ; commute = λ _ → ⇒.commute _ }
-       ; F⇐G = record { η = λ _ → ≅-sym FX≅GX ; commute = λ _ → ⇐.commute _ }
-       ; iso = λ X → record { isoˡ = iso.isoˡ X ; isoʳ = iso.isoʳ X }
+       { F⇒G = record { η = λ _ →       FX≅GX ; commute = λ _ → ⌞ ⇒.commute _ ⌟ }
+       ; F⇐G = record { η = λ _ → ≅-sym FX≅GX ; commute = λ _ → ⌞ ⇐.commute _ ⌟ }
+       ; iso = λ X → record { isoˡ = ⌞ iso.isoˡ X ⌟ ; isoʳ = ⌞ iso.isoʳ X ⌟ }
        }
        where
          open NaturalIsomorphism μ

--- a/Categories/Functor/Properties.agda
+++ b/Categories/Functor/Properties.agda
@@ -81,17 +81,10 @@ module _ (F : Functor C D) where
     where open _≅_ i≅j
 
   [_]-resp-≃ : ∀ {f g :  _≅_ C A B} → f IsoC.≃ g → [ f ]-resp-≅ IsoD.≃ [ g ]-resp-≅
-  [_]-resp-≃ eq = record
-    { from-≈ = F-resp-≈ from-≈
-    ; to-≈   = F-resp-≈ to-≈
-    }
-    where open _≃_ eq
+  [_]-resp-≃ ⌞ eq ⌟ = ⌞ F-resp-≈ eq ⌟
 
   homomorphismᵢ : ∀ {f : _≅_ C B E} {g : _≅_ C A B} → [ _∘ᵢ_ C f g ]-resp-≅ IsoD.≃ (_∘ᵢ_ D [ f ]-resp-≅ [ g ]-resp-≅ )
-  homomorphismᵢ = record
-    { from-≈ = homomorphism
-    ; to-≈   = homomorphism
-    }
+  homomorphismᵢ = ⌞ homomorphism ⌟
 
   -- Uses a strong version of Essential Surjectivity.
   EssSurj×Full×Faithful⇒Invertible : EssentiallySurjective F → Full F → Faithful F → Functor D C

--- a/Categories/Morphism/IsoEquiv.agda
+++ b/Categories/Morphism/IsoEquiv.agda
@@ -17,61 +17,7 @@ private
   variable
     A B C : Obj
 
-infix 4 _≃_
-record _≃_ (i j : A ≅ B) : Set e where
-  open _≅_
-  field
-    from-≈ : from i ≈ from j
-    to-≈   : to i ≈ to j
-
-≃-isEquivalence : IsEquivalence (_≃_ {A} {B})
-≃-isEquivalence = record
-  { refl  = record
-    { from-≈ = refl
-    ; to-≈   = refl
-    }
-  ; sym   = λ where
-    record { from-≈ = from-≈ ; to-≈ = to-≈ } → record
-      { from-≈ = sym from-≈
-      ; to-≈   = sym to-≈
-      }
-  ; trans = λ where
-    record { from-≈ = from-≈ ; to-≈ = to-≈ } record { from-≈ = from-≈′ ; to-≈ = to-≈′ } → record
-      { from-≈ = trans from-≈ from-≈′
-      ; to-≈   = trans to-≈ to-≈′
-      }
-  }
-  where open _≅_
-        open Equiv
-
-≃-setoid : ∀ {A B : Obj} → Setoid _ _
-≃-setoid {A} {B} = record
-  { Carrier       = A ≅ B
-  ; _≈_           = _≃_
-  ; isEquivalence = ≃-isEquivalence
-  }
-
-----------------------------------------------------------------------
-
--- An alternative notion of equality on isomorphisms that only
--- considers the first arrow in the iso pair.  The two notions of
--- equality turn out to be equivalent.
-
-infix 4 _≃′_
-_≃′_ : Rel (A ≅ B) e
-_≃′_ = _≈_ on _≅_.from
-
-≃′-isEquivalence : IsEquivalence (_≃′_ {A} {B})
-≃′-isEquivalence = On.isEquivalence _≅_.from equiv
-
-≃′-setoid : ∀ {A B : Obj} → Setoid _ _
-≃′-setoid {A} {B} = record
-  { Carrier       = A ≅ B
-  ; _≈_           = _≃′_
-  ; isEquivalence = ≃′-isEquivalence
-  }
-
--- If they exist, inverses are unique.
+-- Two lemmas to set things up: if they exist, inverses are unique.
 
 to-unique : ∀ {f₁ f₂ : A ⇒ B} {g₁ g₂} →
             Iso f₁ g₁ → Iso f₂ g₂ → f₁ ≈ f₂ → g₁ ≈ g₂
@@ -95,14 +41,65 @@ from-unique iso₁ iso₂ hyp = to-unique iso₁⁻¹ iso₂⁻¹ hyp
     iso₁⁻¹ = record { isoˡ = Iso.isoʳ iso₁  ; isoʳ = Iso.isoˡ iso₁ }
     iso₂⁻¹ = record { isoˡ = Iso.isoʳ iso₂  ; isoʳ = Iso.isoˡ iso₂ }
 
+-- Equality of isomorphisms is just equality of the underlying morphism(s).
+--
+-- Only one equation needs to be given; the equation in the other
+-- direction holds automatically (by the above lemmas).
+--
+-- The reason for wrapping the underlying equality in a record at all
+-- is that this helps unification.  Concretely, it allows Agda to
+-- infer the isos |i| and |j| being related in function applications
+-- where only the equation |i ≃ j| is passed as an explicit argument.
+
+infix 4 _≃_
+record _≃_ (i j : A ≅ B) : Set e where
+  constructor ⌞_⌟
+  open _≅_
+  field from-≈ : from i ≈ from j
+
+  to-≈ : to i ≈ to j
+  to-≈ = to-unique (iso i) (iso j) from-≈
+
+open _≃_
+
+≃-isEquivalence : IsEquivalence (_≃_ {A} {B})
+≃-isEquivalence = record
+  { refl  = ⌞ refl ⌟
+  ; sym   = λ where ⌞ eq ⌟          → ⌞ sym eq ⌟
+  ; trans = λ where ⌞ eq₁ ⌟ ⌞ eq₂ ⌟ → ⌞ trans eq₁ eq₂ ⌟
+  }
+  where open Equiv
+
+≃-setoid : ∀ {A B : Obj} → Setoid _ _
+≃-setoid {A} {B} = record
+  { Carrier       = A ≅ B
+  ; _≈_           = _≃_
+  ; isEquivalence = ≃-isEquivalence
+  }
+
+----------------------------------------------------------------------
+
+-- An alternative, more direct notion of equality on isomorphisms that
+-- involves no wrapping/unwrapping.
+
+infix 4 _≃′_
+_≃′_ : Rel (A ≅ B) e
+_≃′_ = _≈_ on _≅_.from
+
+≃′-isEquivalence : IsEquivalence (_≃′_ {A} {B})
+≃′-isEquivalence = On.isEquivalence _≅_.from equiv
+
+≃′-setoid : ∀ {A B : Obj} → Setoid _ _
+≃′-setoid {A} {B} = record
+  { Carrier       = A ≅ B
+  ; _≈_           = _≃′_
+  ; isEquivalence = ≃′-isEquivalence
+  }
+
 -- The two notions of equality are equivalent
 
 ≃⇒≃′ : ∀ {i j : A ≅ B} → i ≃ j → i ≃′ j
-≃⇒≃′ eq = _≃_.from-≈ eq
+≃⇒≃′ eq = from-≈ eq
 
 ≃′⇒≃ : ∀ {i j : A ≅ B} → i ≃′ j → i ≃ j
-≃′⇒≃ {_} {_} {i} {j} eq = record
-  { from-≈ = eq
-  ; to-≈   = to-unique (iso i) (iso j) eq
-  }
-  where open _≅_
+≃′⇒≃ {_} {_} {i} {j} eq = ⌞ eq ⌟

--- a/Categories/Morphism/Isomorphism.agda
+++ b/Categories/Morphism/Isomorphism.agda
@@ -3,7 +3,6 @@ open import Categories.Category
 
 -- Mainly *properties* of isomorphisms, and a lot of other things too
 
--- TODO: are the uses of rewrite really necessary?
 -- TODO: split things up more semantically?
 
 module Categories.Morphism.Isomorphism {o ℓ e} (𝒞 : Category o ℓ e) where
@@ -19,13 +18,13 @@ open import Relation.Binary.PropositionalEquality as ≡ using (_≡_)
 import Categories.Category.Construction.Core as Core
 open import Categories.Category.Groupoid using (IsGroupoid)
 import Categories.Morphism as Morphism
-import Categories.Morphism.Properties as Morphismₚ
+import Categories.Morphism.Properties as MorphismProps
 import Categories.Morphism.IsoEquiv as IsoEquiv
 import Categories.Category.Construction.Path as Path
 
-open Core 𝒞
+open Core 𝒞 using (Core; Core-isGroupoid)
 open Morphism 𝒞
-open Morphismₚ 𝒞
+open MorphismProps 𝒞
 open IsoEquiv 𝒞 using (_≃_)
 open Path 𝒞
 
@@ -35,16 +34,15 @@ open Category 𝒞
 
 private
   module MCore where
-    open Morphismₚ Core public
-    open Morphism Core public
-    open Path Core public
+    open IsGroupoid    Core-isGroupoid public
+    open MorphismProps Core public
+    open Morphism      Core public
+    open Path          Core public
 
   variable
     A B C D E F : Obj
 
-open Category Core using () renaming (_∘_ to _∘ᵢ_) public
-open IsGroupoid.iso Core-isGroupoid using ()
-  renaming (isoˡ to sym∘ᵢ≃refl; isoʳ to ∘ᵢsym≃refl)
+open MCore using () renaming (_∘_ to _∘ᵢ_) public
 
 CommutativeIso = IsGroupoid.CommutativeSquare Core-isGroupoid
 
@@ -86,38 +84,51 @@ module _ where
   TransitiveClosure-groupoid : IsGroupoid TransitiveClosure
   TransitiveClosure-groupoid = record
     { _⁻¹ = reverse
-    ; iso = λ {_ _ f⁺} → record
-      { isoˡ = isoˡ′ f⁺
-      ; isoʳ = isoʳ′ f⁺
-      }
+    ; iso = λ {_ _ f⁺} → record { isoˡ = isoˡ′ f⁺ ; isoʳ = isoʳ′ f⁺ }
     }
-    where isoˡ′ : (f⁺ : A [ _≅_ ]⁺ B) → ∘ᵢ-tc (reverse f⁺) ∘ᵢ ∘ᵢ-tc f⁺ ≃ ≅.refl
-          isoˡ′ f⁺ rewrite reverse⇒≅-sym f⁺ = sym∘ᵢ≃refl
-          isoʳ′ : (f⁺ : A [ _≅_ ]⁺ B) → ∘ᵢ-tc f⁺ ∘ᵢ ∘ᵢ-tc (reverse f⁺) ≃ ≅.refl
-          isoʳ′ f⁺ rewrite reverse⇒≅-sym f⁺ = ∘ᵢsym≃refl
+    where
+      open MCore.HomReasoning
+
+      isoˡ′ : (f⁺ : A [ _≅_ ]⁺ B) → ∘ᵢ-tc (reverse f⁺) ∘ᵢ ∘ᵢ-tc f⁺ ≃ ≅.refl
+      isoˡ′ f⁺ = begin
+          ∘ᵢ-tc (reverse f⁺) ∘ᵢ ∘ᵢ-tc f⁺
+        ≡⟨ ≡.cong (_∘ᵢ ∘ᵢ-tc f⁺) (reverse⇒≅-sym f⁺) ⟩
+          ≅.sym (∘ᵢ-tc f⁺) ∘ᵢ ∘ᵢ-tc f⁺
+        ≈⟨ MCore.iso.isoˡ ⟩
+          ≅.refl
+        ∎
+
+      isoʳ′ : (f⁺ : A [ _≅_ ]⁺ B) → ∘ᵢ-tc f⁺ ∘ᵢ ∘ᵢ-tc (reverse f⁺) ≃ ≅.refl
+      isoʳ′ f⁺ = begin
+          ∘ᵢ-tc f⁺ ∘ᵢ ∘ᵢ-tc (reverse f⁺)
+        ≡⟨ ≡.cong (∘ᵢ-tc f⁺ ∘ᵢ_) (reverse⇒≅-sym f⁺) ⟩
+          ∘ᵢ-tc f⁺ ∘ᵢ ≅.sym (∘ᵢ-tc f⁺)
+        ≈⟨ MCore.iso.isoʳ ⟩
+          ≅.refl
+        ∎
 
   from-∘ᵢ-tc : (f⁺ : A [ _≅_ ]⁺ B) → from (∘ᵢ-tc f⁺) ≡ ∘-tc (≅⁺⇒⇒⁺ f⁺)
-  from-∘ᵢ-tc [ f ]                         = ≡.refl
-  from-∘ᵢ-tc (_ ∼⁺⟨ f⁺ ⟩ f⁺′)
-    rewrite from-∘ᵢ-tc f⁺ | from-∘ᵢ-tc f⁺′ = ≡.refl
+  from-∘ᵢ-tc [ f ]            = ≡.refl
+  from-∘ᵢ-tc (_ ∼⁺⟨ f⁺ ⟩ f⁺′) = ≡.cong₂ _∘_ (from-∘ᵢ-tc f⁺′) (from-∘ᵢ-tc f⁺) 
 
   ≅*⇒⇒*-cong : ≅⁺⇒⇒⁺ {A} {B} Preserves _≃⁺_ ⟶ _≈⁺_
   ≅*⇒⇒*-cong {_} {_} {f⁺} {g⁺} f⁺≃⁺g⁺ = begin
-    ∘-tc (≅⁺⇒⇒⁺ f⁺) ≡˘⟨ from-∘ᵢ-tc f⁺ ⟩
-    from (∘ᵢ-tc f⁺) ≈⟨ _≃_.from-≈ f⁺≃⁺g⁺ ⟩
-    from (∘ᵢ-tc g⁺) ≡⟨ from-∘ᵢ-tc g⁺ ⟩
-    ∘-tc (≅⁺⇒⇒⁺ g⁺) ∎
+    ∘-tc (≅⁺⇒⇒⁺ f⁺)  ≡˘⟨ from-∘ᵢ-tc f⁺ ⟩
+    from (∘ᵢ-tc f⁺)  ≈⟨ _≃_.from-≈ f⁺≃⁺g⁺ ⟩
+    from (∘ᵢ-tc g⁺)  ≡⟨ from-∘ᵢ-tc g⁺ ⟩
+    ∘-tc (≅⁺⇒⇒⁺ g⁺)  ∎
     where open HomReasoning
 
   ≅-shift : ∀ {f⁺ : A [ _≅_ ]⁺ B} {g⁺ : B [ _≅_ ]⁺ C} {h⁺ : A [ _≅_ ]⁺ C} →
               (_ ∼⁺⟨ f⁺ ⟩  g⁺) ≃⁺ h⁺ → g⁺ ≃⁺ (_ ∼⁺⟨ reverse f⁺ ⟩ h⁺)
   ≅-shift {f⁺ = f⁺} {g⁺ = g⁺} {h⁺ = h⁺} eq = begin
-    ∘ᵢ-tc g⁺                                     ≈⟨ introʳ (I.isoʳ f⁺) ⟩
-    ∘ᵢ-tc g⁺ ∘ᵢ (∘ᵢ-tc f⁺ ∘ᵢ ∘ᵢ-tc (reverse f⁺)) ≈⟨ pullˡ eq ⟩
-    ∘ᵢ-tc h⁺ ∘ᵢ ∘ᵢ-tc (reverse f⁺)               ∎
-    where open IsGroupoid.HomReasoning Core-isGroupoid
-          open MR Core
-          module I {A B} (f⁺ : A [ _≅_ ]⁺ B) = Morphism.Iso (IsGroupoid.iso TransitiveClosure-groupoid {f = f⁺})
+    ∘ᵢ-tc g⁺                                      ≈⟨ introʳ (I.isoʳ f⁺) ⟩
+    ∘ᵢ-tc g⁺ ∘ᵢ (∘ᵢ-tc f⁺ ∘ᵢ ∘ᵢ-tc (reverse f⁺))  ≈⟨ pullˡ eq ⟩
+    ∘ᵢ-tc h⁺ ∘ᵢ ∘ᵢ-tc (reverse f⁺)                ∎
+    where
+      open MCore.HomReasoning
+      open MR Core
+      module I {A B} (f⁺ : A [ _≅_ ]⁺ B) = Morphism.Iso (IsGroupoid.iso TransitiveClosure-groupoid {f = f⁺})
 
   lift : ∀ {f⁺ : A [ _⇒_ ]⁺ B} → IsoPlus f⁺ → A [ _≅_ ]⁺ B
   lift [ iso ]            = [ record
@@ -128,21 +139,29 @@ module _ where
   lift (_ ∼⁺⟨ iso ⟩ iso′) = _ ∼⁺⟨ lift iso ⟩ lift iso′
 
   reduce-lift : ∀ {f⁺ : A [ _⇒_ ]⁺ B} (f′ : IsoPlus f⁺) → from (∘ᵢ-tc (lift f′)) ≡ ∘-tc f⁺
-  reduce-lift [ f ]                         = ≡.refl
-  reduce-lift (_ ∼⁺⟨ f′ ⟩ f″)
-    rewrite reduce-lift f′ | reduce-lift f″ = ≡.refl
+  reduce-lift [ f ]           = ≡.refl
+  reduce-lift (_ ∼⁺⟨ f′ ⟩ f″) = ≡.cong₂ _∘_ (reduce-lift f″) (reduce-lift f′)
 
   lift-cong : ∀ {f⁺ g⁺ : A [ _⇒_ ]⁺ B} (f′ : IsoPlus f⁺) (g′ : IsoPlus g⁺) →
-                f⁺ ≈⁺ g⁺ → lift f′ ≃⁺ lift g′
-  lift-cong f′ g′ eq = record
+              f⁺ ≈⁺ g⁺ → lift f′ ≃⁺ lift g′
+  lift-cong {_} {_} {f⁺} {g⁺} f′ g′ eq = record
     { from-≈ = from-≈′
     ; to-≈   = Iso-≈ eq (helper f′) (helper g′)
     }
-    where from-≈′ : from (∘ᵢ-tc (lift f′)) ≈ from (∘ᵢ-tc (lift g′))
-          from-≈′ rewrite reduce-lift f′ | reduce-lift g′ = eq
-          helper : ∀ {f⁺ : A [ _⇒_ ]⁺ B} (f′ : IsoPlus f⁺) → Iso (∘-tc f⁺) (to (∘ᵢ-tc (lift f′)))
-          helper [ f ]           = f
-          helper (_ ∼⁺⟨ f′ ⟩ f″) = Iso-∘ (helper f′) (helper f″)
+    where
+      open HomReasoning
+
+      from-≈′ : from (∘ᵢ-tc (lift f′)) ≈ from (∘ᵢ-tc (lift g′))
+      from-≈′ = begin
+        from (∘ᵢ-tc (lift f′))  ≡⟨ reduce-lift f′ ⟩
+        ∘-tc f⁺                 ≈⟨ eq ⟩
+        ∘-tc g⁺                 ≡˘⟨ reduce-lift g′ ⟩
+        from (∘ᵢ-tc (lift g′))  ∎
+
+      helper : ∀ {f⁺ : A [ _⇒_ ]⁺ B} (f′ : IsoPlus f⁺) →
+               Iso (∘-tc f⁺) (to (∘ᵢ-tc (lift f′)))
+      helper [ f ]           = f
+      helper (_ ∼⁺⟨ f′ ⟩ f″) = Iso-∘ (helper f′) (helper f″)
 
   lift-triangle : {f : A ⇒ B} {g : C ⇒ A} {h : C ⇒ B} {k : B ⇒ C} {i : B ⇒ A} {j : A ⇒ C} →
     f ∘ g ≈ h → (f′ : Iso f i) → (g′ : Iso g j) → (h′ : Iso h k) →
@@ -185,16 +204,16 @@ module _ where
   lift-pentagon′ eq = lift-pentagon eq _ _ _ _ _
 
   open MR Core
-  open IsGroupoid Core-isGroupoid
-  open IsGroupoid.HomReasoning Core-isGroupoid
+  open MCore using (_⁻¹)
+  open MCore.HomReasoning
   open MR.GroupoidR _ Core-isGroupoid
 
   squares×≃⇒≃ : {f f′ : A ≅ B} {g : A ≅ C} {h : B ≅ D} {i i′ : C ≅ D} →
-                 CommutativeIso f g h i → CommutativeIso f′ g h i′ → i ≃ i′ → f ≃ f′
-  squares×≃⇒≃ {g = g} sq₁ sq₂ eq =
-    MCore.isos×≈⇒≈ eq helper₁ (IsEquivalence.sym MCore.≅-isEquivalence helper₂) sq₁ sq₂
-    where helper₁ = record { iso = IsGroupoid.iso Core-isGroupoid }
-          helper₂ = record { iso = IsGroupoid.iso Core-isGroupoid }
+                CommutativeIso f g h i → CommutativeIso f′ g h i′ → i ≃ i′ → f ≃ f′
+  squares×≃⇒≃ sq₁ sq₂ eq = MCore.isos×≈⇒≈ eq helper₁ (MCore.≅.sym helper₂) sq₁ sq₂
+    where
+      helper₁ = record { iso = MCore.iso }
+      helper₂ = record { iso = MCore.iso }
 
   -- imagine a triangle prism, if all the sides and the top face commute, the bottom face commute.
   triangle-prism : {i′ : A ≅ B} {f′ : C ≅ A} {h′ : C ≅ B} {i : D ≅ E} {j : D ≅ A}
@@ -202,31 +221,32 @@ module _ where
     i′ ∘ᵢ f′ ≃ h′ →
     CommutativeIso i j k i′ → CommutativeIso f g j f′ → CommutativeIso h g k h′ →
     i ∘ᵢ f ≃ h
-  triangle-prism {i′ = i′} {f′ = f′} {i = i} {k = k} {f = f} {g = g}
-                eq sq₁ sq₂ sq₃ = squares×≃⇒≃ glued sq₃ eq
-    where glued : CommutativeIso (i ∘ᵢ f) g k (i′ ∘ᵢ f′)
-          glued = sym (glue (sym sq₁) (sym sq₂))
+  triangle-prism {i′ = i′} {f′} {_} {i} {_} {k} {f} {g} {_} eq sq₁ sq₂ sq₃ =
+    squares×≃⇒≃ glued sq₃ eq
+    where
+      glued : CommutativeIso (i ∘ᵢ f) g k (i′ ∘ᵢ f′)
+      glued = sym (glue (sym sq₁) (sym sq₂))
 
   elim-triangleˡ : {f : A ≅ B} {g : C ≅ A} {h : D ≅ C} {i : D ≅ B} {j : D ≅ A} →
                    f ∘ᵢ g ∘ᵢ h ≃ i → f ∘ᵢ j ≃ i → g ∘ᵢ h ≃ j
   elim-triangleˡ {f = f} {g} {h} {i} {j} perim tri = begin
-    g ∘ᵢ h                ≈⟨ introˡ sym∘ᵢ≃refl ⟩
-    (f ⁻¹ ∘ᵢ f) ∘ᵢ g ∘ᵢ h ≈⟨ pullʳ perim ⟩
-    f ⁻¹ ∘ᵢ i             ≈˘⟨ switch-fromtoˡ′ tri ⟩
-    j                     ∎
+    g ∘ᵢ h                 ≈⟨ introˡ (MCore.iso.isoˡ {f = f}) ⟩
+    (f ⁻¹ ∘ᵢ f) ∘ᵢ g ∘ᵢ h  ≈⟨ pullʳ perim ⟩
+    f ⁻¹ ∘ᵢ i              ≈˘⟨ switch-fromtoˡ′ {f = f} {h = j} {k = i} tri ⟩
+    j                      ∎
 
   elim-triangleˡ′ : {f : A ≅ B} {g : C ≅ A} {h : D ≅ C} {i : D ≅ B} {j : C ≅ B} →
                     f ∘ᵢ g ∘ᵢ h ≃ i → j ∘ᵢ h ≃ i → f ∘ᵢ g ≃ j
   elim-triangleˡ′ {f = f} {g} {h} {i} {j} perim tri = begin
-    f ∘ᵢ g                  ≈⟨ introʳ sym∘ᵢ≃refl ⟩
-    (f ∘ᵢ g) ∘ᵢ (h ∘ᵢ h ⁻¹) ≈⟨ pullˡ (trans (Category.assoc Core) perim) ⟩
-    i ∘ᵢ h ⁻¹               ≈˘⟨ switch-fromtoʳ′ tri ⟩
-    j                       ∎
+    f ∘ᵢ g                   ≈⟨ introʳ (MCore.iso.isoʳ {f = h}) ⟩
+    (f ∘ᵢ g) ∘ᵢ (h ∘ᵢ h ⁻¹)  ≈⟨ pullˡ (trans MCore.assoc perim) ⟩
+    i ∘ᵢ h ⁻¹                ≈˘⟨ switch-fromtoʳ′ {h = j} {f = h} {k = i} tri ⟩
+    j                        ∎
 
   cut-squareʳ : {g : A ≅ B} {f : A ≅ C} {h : B ≅ D} {i : C ≅ D} {j : B ≅ C} →
-    CommutativeIso g f h i → i ∘ᵢ j ≃ h → j ∘ᵢ g ≃ f
+                CommutativeIso g f h i → i ∘ᵢ j ≃ h → j ∘ᵢ g ≃ f
   cut-squareʳ {g = g} {f = f} {h = h} {i = i} {j = j} sq tri = begin
-    j ∘ᵢ g           ≈⟨ switch-fromtoˡ′ tri ⟩∘⟨ refl ⟩
-    (i ⁻¹ ∘ᵢ h) ∘ᵢ g ≈⟨ Category.assoc Core ⟩
-    i ⁻¹ ∘ᵢ h ∘ᵢ g   ≈˘⟨ switch-fromtoˡ′ (sym sq) ⟩
-    f                ∎
+    j ∘ᵢ g            ≈⟨ switch-fromtoˡ′ {f = i} {h = j} {k = h} tri ⟩∘⟨ refl ⟩
+    (i ⁻¹ ∘ᵢ h) ∘ᵢ g  ≈⟨ MCore.assoc ⟩
+    i ⁻¹ ∘ᵢ h ∘ᵢ g    ≈˘⟨ switch-fromtoˡ′ {f = i} {h = f} {k = h ∘ᵢ g} (sym sq) ⟩
+    f                 ∎

--- a/Categories/Morphism/Isomorphism.agda
+++ b/Categories/Morphism/Isomorphism.agda
@@ -25,7 +25,7 @@ import Categories.Category.Construction.Path as Path
 open Core 𝒞 using (Core; Core-isGroupoid)
 open Morphism 𝒞
 open MorphismProps 𝒞
-open IsoEquiv 𝒞 using (_≃_)
+open IsoEquiv 𝒞 using (_≃_; ⌞_⌟)
 open Path 𝒞
 
 import Categories.Morphism.Reasoning as MR
@@ -144,10 +144,7 @@ module _ where
 
   lift-cong : ∀ {f⁺ g⁺ : A [ _⇒_ ]⁺ B} (f′ : IsoPlus f⁺) (g′ : IsoPlus g⁺) →
               f⁺ ≈⁺ g⁺ → lift f′ ≃⁺ lift g′
-  lift-cong {_} {_} {f⁺} {g⁺} f′ g′ eq = record
-    { from-≈ = from-≈′
-    ; to-≈   = Iso-≈ eq (helper f′) (helper g′)
-    }
+  lift-cong {_} {_} {f⁺} {g⁺} f′ g′ eq = ⌞ from-≈′ ⌟
     where
       open HomReasoning
 
@@ -157,11 +154,6 @@ module _ where
         ∘-tc f⁺                 ≈⟨ eq ⟩
         ∘-tc g⁺                 ≡˘⟨ reduce-lift g′ ⟩
         from (∘ᵢ-tc (lift g′))  ∎
-
-      helper : ∀ {f⁺ : A [ _⇒_ ]⁺ B} (f′ : IsoPlus f⁺) →
-               Iso (∘-tc f⁺) (to (∘ᵢ-tc (lift f′)))
-      helper [ f ]           = f
-      helper (_ ∼⁺⟨ f′ ⟩ f″) = Iso-∘ (helper f′) (helper f″)
 
   lift-triangle : {f : A ⇒ B} {g : C ⇒ A} {h : C ⇒ B} {k : B ⇒ C} {i : B ⇒ A} {j : A ⇒ C} →
     f ∘ g ≈ h → (f′ : Iso f i) → (g′ : Iso g j) → (h′ : Iso h k) →

--- a/Categories/Object/Initial.agda
+++ b/Categories/Object/Initial.agda
@@ -8,7 +8,7 @@ open import Relation.Binary.PropositionalEquality as ≡ using (_≡_)
 
 open Category C
 open import Categories.Morphism C using (Epi; _≅_)
-open import Categories.Morphism.IsoEquiv C using (_≃_)
+open import Categories.Morphism.IsoEquiv C using (_≃_; ⌞_⌟)
 open import Categories.Morphism.Reasoning C
 
 open HomReasoning
@@ -53,10 +53,7 @@ transport-by-iso i {X} i≅X = record
   where open _≅_ i≅X
 
 up-to-iso-unique : ∀ i i′ → (iso : ⊥ i ≅ ⊥ i′) → up-to-iso i i′ ≃ iso
-up-to-iso-unique i i′ iso = record
-  { from-≈ = !-unique i _
-  ; to-≈   = !-unique i′ _
-  }
+up-to-iso-unique i i′ iso = ⌞ !-unique i _ ⌟
 
 up-to-iso-invˡ : ∀ {t X} {i : ⊥ t ≅ X} → up-to-iso t (transport-by-iso t i) ≃ i
 up-to-iso-invˡ {t} {i = i} = up-to-iso-unique t (transport-by-iso t i) i

--- a/Categories/Object/Terminal.agda
+++ b/Categories/Object/Terminal.agda
@@ -11,7 +11,7 @@ open import Relation.Binary using (IsEquivalence; Setoid)
 open import Relation.Binary.PropositionalEquality as ≡ using (_≡_)
 
 open import Categories.Morphism C
-open import Categories.Morphism.IsoEquiv C using (_≃_)
+open import Categories.Morphism.IsoEquiv C using (_≃_; ⌞_⌟)
 open import Categories.Morphism.Reasoning C
 
 open Category C
@@ -57,10 +57,7 @@ transport-by-iso t {X} t≅X = record
   where open _≅_ t≅X
 
 up-to-iso-unique : ∀ t t′ → (i : ⊤ t ≅ ⊤ t′) → up-to-iso t t′ ≃ i
-up-to-iso-unique t t′ i = record
-  { from-≈ = !-unique t′ _
-  ; to-≈   = !-unique t _
-  }
+up-to-iso-unique t t′ i = ⌞ !-unique t′ _ ⌟
 
 up-to-iso-invˡ : ∀ {t X} {i : ⊤ t ≅ X} → up-to-iso t (transport-by-iso t i) ≃ i
 up-to-iso-invˡ {t} {i = i} = up-to-iso-unique t (transport-by-iso t i) i


### PR DESCRIPTION
Depends on #56 .

As discussed in the [comments on #47](https://github.com/agda/agda-categories/pull/47#issuecomment-536640064), this essentially combines the advantages of the two previous implementations of equality on isos.

The original equality `_≃_` works better with unification.  Concretely, it allows Agda to infer the isos `i` and `j` being related in function applications where only the equation `i ≃ j` is passed as an explicit argument. The alternative `_≃′_` equality, on the other hand, simplifies proofs because only one equality proof needs to be given (the other one holds automatically). 

With the new implementation, Agda can still infer which isos are involved, but the overhead is minimal. Essentially, just wrapping proofs using the `⌞_⌟` constructor.

There were quite a few dependencies to update, but the changes are all straightforward.
