### PR TITLE
Proved part of the braiding coherence lB=r

### DIFF
--- a/Categories/Category/Monoidal/Braided.agda
+++ b/Categories/Category/Monoidal/Braided.agda
@@ -2,6 +2,8 @@
 
 open import Categories.Category
 open import Categories.Category.Monoidal
+import Categories.Category.Monoidal.Properties as MProperties
+import Categories.Morphism.Reasoning as Reasoning
 
 module Categories.Category.Monoidal.Braided {o ℓ e} {C : Category o ℓ e} (M : Monoidal C) where
 
@@ -17,7 +19,8 @@ open Commutation
 
 private
   variable
-    X Y Z : Obj
+    X Y Z W : Obj
+    f g h : X ⇒ Y
 
 -- braided monoidal category
 -- it has a braiding natural isomorphism has two hexagon identities.
@@ -33,6 +36,9 @@ record Braided : Set (levelOfTerm M) where
   private
     B : ∀ {X Y} → X ⊗₀ Y ⇒ Y ⊗₀ X
     B {X} {Y} = braiding.⇒.η (X , Y)
+
+    B-commute : ∀ {X Y Z W} → {f : X ⇒ Y} → {g : Z ⇒ W} → CommutativeSquare (f ⊗₁ g) B B (g ⊗₁ f)
+    B-commute {_} {_} {_} {_} {f} {g} = braiding.⇒.commute (f , g)
 
   field
     hexagon₁ : [ (X ⊗₀ Y) ⊗₀ Z ⇒ Y ⊗₀ Z ⊗₀ X ]⟨
@@ -51,3 +57,38 @@ record Braided : Set (levelOfTerm M) where
                  B                           ⇒⟨ Z ⊗₀ X ⊗₀ Y ⟩
                  associator.to
                ⟩
+
+  module Properties where
+    open MProperties M
+    open Reasoning C
+    open MonoidalReasoning
+
+    hexagon-lemma : [ (X ⊗₀ unit) ⊗₀ unit ⇒ unit ⊗₀ X ]⟨
+                      B  ⊗₁ id                    ⇒⟨ (unit ⊗₀ X) ⊗₀ unit ⟩
+                      associator.from             ⇒⟨ unit ⊗₀ X ⊗₀ unit ⟩
+                      id ⊗₁ B                     ⇒⟨ unit ⊗₀ unit ⊗₀ X ⟩
+                      unitorˡ.from
+                    ≈ unitorʳ.from                 ⇒⟨ X ⊗₀ unit ⟩
+                      B
+                    ⟩
+    hexagon-lemma = begin
+                    unitorˡ.from ∘ id ⊗₁ B ∘ associator.from ∘ B ⊗₁ id      ≈⟨ refl⟩∘⟨ hexagon₁ ⟩
+                    unitorˡ.from ∘ associator.from ∘ B ∘ associator.from     ≈⟨ pullˡ coherence₁ ⟩
+                    unitorˡ.from ⊗₁ id ∘ B ∘ associator.from                ≈⟨ pullˡ (⟺ B-commute) ⟩
+                    (B ∘ id ⊗₁ unitorˡ.from) ∘ associator.from              ≈⟨ pullʳ triangle ⟩
+                    B ∘ unitorʳ.from ⊗₁ id                                  ≈⟨ refl⟩∘⟨ unitor-coherenceʳ ⟩
+                    B ∘ unitorʳ.from
+                    ∎
+    braiding-coherence⊗unit : [ (X ⊗₀ unit) ⊗₀ unit ⇒ X ⊗₀ unit ]⟨
+                 B ⊗₁ id                       ⇒⟨ (unit ⊗₀ X) ⊗₀ unit ⟩
+                 unitorˡ.from ⊗₁ id
+               ≈ unitorʳ.from ⊗₁ id
+               ⟩
+    braiding-coherence⊗unit = cancel-fromˡ braiding.FX≅GX (
+      begin
+        B ∘ unitorˡ.from ⊗₁ id ∘ B ⊗₁ id                               ≈⟨ pullˡ (⟺ (glue◽◃ unitorˡ-commute-from coherence₁)) ⟩
+        (unitorˡ.from ∘ id ⊗₁ B ∘ associator.from) ∘ B ⊗₁ id           ≈⟨ assoc²' ⟩
+        unitorˡ.from ∘ id ⊗₁ B ∘ associator.from ∘ B ⊗₁ id             ≈⟨ hexagon-lemma ⟩
+        B ∘ unitorʳ.from                                                ≈˘⟨ refl⟩∘⟨ unitor-coherenceʳ ⟩
+        B ∘ unitorʳ.from ⊗₁ id
+      ∎)

--- a/Categories/Morphism/Reasoning/Core.agda
+++ b/Categories/Morphism/Reasoning/Core.agda
@@ -41,8 +41,11 @@ module Basic where
 open Basic public
 
 module Utils where
-  assoc² : ((i ∘ h) ∘ g) ∘ f ≈ i ∘ (h ∘ (g ∘ f))
+  assoc² : ((i ∘ h) ∘ g) ∘ f ≈ i ∘ h ∘ g ∘ f
   assoc² = trans assoc assoc
+
+  assoc²' : (i ∘ h ∘ g) ∘ f ≈ i ∘ h ∘ g ∘ f
+  assoc²' = trans assoc (∘-resp-≈ʳ assoc)
 
 open Utils public
 


### PR DESCRIPTION
Proved the -⊗1 version of the coherence theorem.
I might get around to proving the final identity later but for now I thought it would be useful to have this as a PR and other people can do it in the meantime if they want.
Also, I wasn't sure where exactly to write it so I created a new module inside Braided.agda. Feel free to move stuff around if that is not appropriate.