### PR TITLE
Add 'heterogeneous' identities.

### DIFF
--- a/Categories/Morphism/HeterogeneousIdentity.agda
+++ b/Categories/Morphism/HeterogeneousIdentity.agda
@@ -1,0 +1,80 @@
+{-# OPTIONS --without-K --safe #-}
+open import Categories.Category using (Category)
+
+-- 'Heterogeneous' identity morphism and some laws about them.
+
+module Categories.Morphism.HeterogeneousIdentity {o ℓ e} (C : Category o ℓ e) where
+
+open import Level
+open import Relation.Binary.PropositionalEquality
+
+import Categories.Morphism as Morphism
+
+open Category C
+open Morphism C
+
+
+-- If Agda was an extensional type theory, any pair of morphisms
+--
+--   f : A ⇒ B   and   g : A ⇒ C,
+--
+-- where `A ≡ B`, would belong to the same homset, even if `A` and `B`
+-- are not definitionally equal.  In particular, the identity on `B`
+-- could be given the type |id {B} : B ⇒ C|.
+--
+-- But Agda is an intensional type theory, so the identity cannot have
+-- this type, in general.  Instead one needs to manually 'transport'
+-- |id {B}| into the homset |B ⇒ C|.  Given |p : B ≡ C| one obtains
+--
+--   subst (B ⇒_) p (id {B})
+--
+-- Morphisms like thes are no longer identities (in the strict
+-- sense) but they still enjoy many of the properties identities do.
+--
+-- To make this precise, this module introduces a notion of
+-- 'heterogeneous identity', which is an identity morphism whose
+-- domain and codomain are propositionally equal (but not necessarily
+-- syntically equal).
+
+
+-- A heterogeneous identity is just the transport of an identity
+-- along a 'strict' equation of objects.
+
+hid : ∀ {A B} (p : A ≡ B) → A ⇒ B
+hid {A} p = subst (A ⇒_) p id
+
+-- Lemmas about heterogeneous identities
+
+hid-refl : ∀ {A : Obj} → hid refl ≈ id {A}
+hid-refl = Equiv.refl
+
+hid-trans : ∀ {A B C} (p : B ≡ C) (q : A ≡ B) →
+            hid p ∘ hid q ≈ hid (trans q p)
+hid-trans refl refl = identityˡ
+
+hid-symˡ : ∀ {A B} (p : A ≡ B) → hid (sym p) ∘ hid p ≈ id {A}
+hid-symˡ refl = identityˡ
+
+hid-symʳ : ∀ {A B} (p : A ≡ B) → hid p ∘ hid (sym p) ≈ id {B}
+hid-symʳ refl = identityˡ
+
+hid-iso : ∀ {A B} (p : A ≡ B) → Iso (hid p) (hid (sym p))
+hid-iso p = record { isoˡ = hid-symˡ p ; isoʳ = hid-symʳ p }
+
+hid-cong : ∀ {A B} {p q : A ≡ B} → p ≡ q → hid p ≈ hid q
+hid-cong refl = Equiv.refl
+
+-- Transporting the domain/codomain is the same as
+-- pre/post-composing with heterogeneous identity.
+
+hid-subst-dom : ∀ {A B C} (p : A ≡ B) (f : A ⇒ C) →
+                subst (_⇒ C) p f ≈ f ∘ hid (sym p)
+hid-subst-dom refl f = Equiv.sym identityʳ
+
+hid-subst-cod : ∀ {A B C} (p : B ≡ C) (f : A ⇒ B) →
+                subst (A ⇒_) p f ≈ hid p ∘ f
+hid-subst-cod refl f = Equiv.sym identityˡ
+
+hid-subst₂ : ∀ {A B C D} (p : A ≡ B) (q : C ≡ D) (f : A ⇒ C) →
+             subst₂ (_⇒_) p q f ≈ hid q ∘ f ∘ hid (sym p)
+hid-subst₂ refl refl f = Equiv.sym (Equiv.trans identityˡ identityʳ)

--- a/Categories/Morphism/HeterogeneousIdentity/Properties.agda
+++ b/Categories/Morphism/HeterogeneousIdentity/Properties.agda
@@ -1,0 +1,70 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Some properties of 'heterogeneous' identity morphisms
+
+module Categories.Morphism.HeterogeneousIdentity.Properties where
+
+open import Level
+open import Data.Product using (curry) renaming (_,_ to _,,_)
+open import Relation.Binary.PropositionalEquality
+
+open import Categories.Category using (Category; _[_,_]; _[_≈_])
+open import Categories.Category.Product
+open import Categories.Functor using (Functor) renaming (id to idF)
+open import Categories.Functor.Bifunctor
+open import Categories.Morphism.HeterogeneousIdentity
+
+private
+  variable
+    o ℓ e o′ ℓ′ e′ o″ ℓ″ e″ o‴ ℓ‴ e‴ : Level
+
+open Category using (Obj; id)
+
+-- Functor identity laws lifted to heterogeneous identities.
+
+hid-identity : (C : Category o ℓ e) (D : Category o′ ℓ′ e′)
+               {F₀ : Obj C → Obj D}
+               (F₁ : ∀ {A B} → C [ A , B ] → D [ F₀ A , F₀ B ]) →
+               (∀ {A} → D [ F₁ (id C {A}) ≈ id D ]) →
+               ∀ {A B} (p : A ≡ B) → D [ F₁ (hid C p) ≈ hid D (cong F₀ p) ]
+hid-identity C D F₁ hyp refl = hyp
+
+hid-identity₂ : (C₁ : Category o ℓ e) (C₂ : Category o′ ℓ′ e′)
+                (D : Category o″ ℓ″ e″)
+                {F₀ : Obj C₁ → Obj C₂ → Obj D}
+                (F₁ : ∀ {A₁ A₂ B₁ B₂} → C₁ [ A₁ , B₁ ] → C₂ [ A₂ , B₂ ] →
+                      D [ F₀ A₁ A₂ , F₀ B₁ B₂ ]) →
+                (∀ {A₁ A₂} → D [ F₁ (id C₁ {A₁}) (id C₂ {A₂}) ≈ id D ]) →
+                ∀ {A₁ A₂ B₁ B₂} (p : A₁ ≡ B₁) (q : A₂ ≡ B₂) →
+                D [ F₁ (hid C₁ p) (hid C₂ q) ≈ hid D (cong₂ F₀ p q) ]
+hid-identity₂ C₁ C₂ D F₁ hyp refl refl = hyp
+
+module _ {C : Category o ℓ e} {D : Category o′ ℓ′ e′}
+         (F : Functor C D) where
+  open Category D
+  open Functor F
+
+  -- functors preserve heterogeneous identities
+
+  F-hid : ∀ {A B} (p : A ≡ B) → F₁ (hid C p) ≈ hid D (cong F₀ p)
+  F-hid = hid-identity C D F₁ identity
+
+module _ {C₁ : Category o ℓ e} {C₂ : Category o′ ℓ′ e′}
+         {D : Category o″ ℓ″ e″} (F : Bifunctor C₁ C₂ D) where
+  open Category D
+  open Functor F
+
+  -- bifunctors preserve heterogeneous identities
+
+  BF-hid : ∀ {A₁ A₂ B₁ B₂} (p : A₁ ≡ B₁) (q : A₂ ≡ B₂) →
+           F₁ (hid C₁ p ,, hid C₂ q) ≈ hid D (cong₂ (curry F₀) p q)
+  BF-hid = hid-identity₂ C₁ C₂ D (curry F₁) identity
+
+module _ (C : Category o ℓ e) (D : Category o′ ℓ′ e′) where
+  open Category (Product C D)
+
+  -- products preserve heterogeneous identities
+
+  ×-hid : ∀ {A₁ A₂ B₁ B₂} (p : A₁ ≡ B₁) (q : A₂ ≡ B₂) →
+          (hid C p ,, hid D q) ≈ hid (Product C D) (cong₂ _,,_ p q)
+  ×-hid p q = BF-hid {C₁ = C} {C₂ = D} (idF ⁂ idF) p q


### PR DESCRIPTION
(This is a subset of #42, refactored into its own PR.) 

If Agda was an extensional type theory, any pair of morphisms `f : A ⇒ B` and `g : A ⇒ C` with `A ≡ B` would belong to the same homset, even if `A` and `B` are not definitionally equal. In particular, the identity on `B` could be given the type `id {B} : B ⇒ C`.

But Agda is an intensional type theory, so the identity cannot have this type, in general. Instead one needs to manually "transport" `id {B}` into the homset `B ⇒ C`. Given `p : B ≡ C`,
```agda
  idBC : B ⇒ C
  idBC = subst (B ⇒_) p (id {B})
```
Morphisms like `idBC` are no longer identities (in the strict sense) but they still enjoy many of the properties identities do.

To make this precise, this PR introduces a notion of 'heterogeneous identity', which is an identity morphism whose domain and codomain are propositionally equal (but not necessarily syntically equal).

For now, heterogeneous identities are used only to implement an improved functor equality (se PR #42), but my hope is that this construction is also useful in other circumstances.

**A note on naming.** The name "heterogeneous identity" suggests that some form of heterogeneous equality is at play here. There isn't. This is simply the transport of identity morphisms along homogeneous equalities. I realize, however, that this name might not sit easy with people because of the supposed association with heterogeneous equalities. I'm happy to change the name if we can agree on a better term. Two alternatives I have considered are "quasi-identities" and "transported identities".