### PR TITLE
Fix missing imports in Everything.agda.

### DIFF
--- a/Everything.agda
+++ b/Everything.agda
@@ -140,6 +140,8 @@ import Categories.Monad.Strong
 import Categories.Morphism
 import Categories.Morphism.Cartesian
 import Categories.Morphism.Duality
+import Categories.Morphism.HeterogeneousIdentity
+import Categories.Morphism.HeterogeneousIdentity.Properties
 import Categories.Morphism.IsoEquiv
 import Categories.Morphism.Isomorphism
 import Categories.Morphism.Properties


### PR DESCRIPTION
Trivial fix to add some missing imports to `Everything.agda`.