### PR TITLE
Strict core adjunction

### DIFF
--- a/Categories/Adjoint/Instance/StrictCore.agda
+++ b/Categories/Adjoint/Instance/StrictCore.agda
@@ -1,0 +1,97 @@
+{-# OPTIONS --without-K --safe #-}
+
+module Categories.Adjoint.Instance.StrictCore where
+
+-- The adjunction between the forgetful functor from (strict) Cats to
+-- (strict) Groupoids and the (strict) Core functor.
+
+open import Data.Product
+open import Level using (_⊔_)
+import Function
+open import Relation.Binary using (IsEquivalence)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import Categories.Adjoint
+open import Categories.Category using (Category)
+open import Categories.Category.Groupoid using (Groupoid)
+import Categories.Category.Construction.Core as C
+open import Categories.Category.Instance.StrictCats
+open import Categories.Category.Instance.StrictGroupoids
+open import Categories.Functor renaming (id to idF)
+open import Categories.Functor.Equivalence
+open import Categories.Functor.Instance.StrictCore
+import Categories.Morphism as Morphism
+import Categories.Morphism.Reasoning as MR
+open import Categories.Morphism.IsoEquiv using (⌞_⌟; _≃_)
+
+-- The forgetful functor from StrictGroupoids to StrictCats
+
+Forgetful : ∀ {o ℓ e} → Functor (Groupoids o ℓ e) (Cats o ℓ e)
+Forgetful {o} {ℓ} {e} = record
+  { F₀ = Groupoid.category
+  ; F₁ = Function.id
+  ; identity     = λ {G} → Groupoids.Equiv.refl {G} {G} {idF}
+  ; homomorphism = λ {G H K F H} → Groupoids.Equiv.refl {G} {K} {H ∘F F}
+  ; F-resp-≈     = Function.id
+  }
+  where
+    module Groupoids = Category (Groupoids o ℓ e)
+
+-- Core is right-adjoint to the forgetful functor from Groupoids to
+-- Cats
+
+CoreAdj : ∀ {o ℓ e} → Forgetful {o} {ℓ ⊔ e} {e} ⊣ Core
+CoreAdj = record
+  { unit   = record { η = unit   ; commute = λ {G} {H} F → unit-commute {G} {H} F }
+  ; counit = record { η = counit ; commute = counit-commute }
+  ; zig    = λ {G} → zig {G}
+  ; zag    = zag
+  }
+  where
+    open Groupoid using (category)
+    module Core = Functor Core
+
+    unit : ∀ G → Functor (category G) (C.Core (category G))
+    unit G = record
+      { F₀ = Function.id
+      ; F₁ = λ f → record { from = f ; to = f ⁻¹ ; iso = iso }
+      ; identity     = ⌞ Equiv.refl ⌟
+      ; homomorphism = ⌞ Equiv.refl ⌟
+      ; F-resp-≈     = ⌞_⌟
+      }
+      where open Groupoid G
+
+    unit-commute : ∀ {G H} (F : Functor (category G) (category H)) →
+                   unit H ∘F F ≡F Core.F₁ F ∘F unit G
+    unit-commute {_} {H} F = record
+      { eq₀ = λ _ → refl
+      ; eq₁ = λ _ → ⌞ MR.id-comm-sym (category H) ⌟
+      }
+
+    counit : ∀ C → Functor (C.Core C) C
+    counit C = record
+      { F₀ = Function.id
+      ; F₁ = _≅_.from
+      ; identity     = Equiv.refl
+      ; homomorphism = Equiv.refl
+      ; F-resp-≈     = _≃_.from-≈
+      }
+      where
+        open Category C
+        open Morphism C
+
+    counit-commute : ∀ {C D} (F : Functor C D) →
+                     counit D ∘F Core.F₁ F ≡F F ∘F counit C
+    counit-commute {C} {D} F = record
+      { eq₀ = λ _ → refl
+      ; eq₁ = λ _ → MR.id-comm-sym D
+      }
+
+    zig : ∀ {G} → counit (category G) ∘F unit G ≡F idF
+    zig {G} = record
+      { eq₀ = λ _ → refl
+      ; eq₁ = λ _ → MR.id-comm-sym (category G)
+      }
+
+    zag : ∀ {B} → Core.F₁ (counit B) ∘F unit (Core.F₀ B) ≡F idF
+    zag {B} = record { eq₀ = λ _ → refl ; eq₁ = λ _ → ⌞ MR.id-comm-sym B ⌟ }

--- a/Categories/Functor/Instance/StrictCore.agda
+++ b/Categories/Functor/Instance/StrictCore.agda
@@ -1,0 +1,69 @@
+{-# OPTIONS --without-K --safe #-}
+
+module Categories.Functor.Instance.StrictCore where
+
+-- The 'strict' core functor (from StrictCats to StrictGroupoids).
+-- This is the right-adjoint of the forgetful functor from
+-- StrictGroupoids to StrictCats
+-- (see Categories.Functor.Adjoint.Instance.StrictCore)
+
+open import Data.Product
+open import Level using (_⊔_)
+open import Function using (_on_; _$_) renaming (id to idf)
+open import Relation.Binary.PropositionalEquality as ≡ using (cong; cong-id)
+
+open import Categories.Category
+import Categories.Category.Construction.Core as C
+open import Categories.Category.Instance.StrictCats
+open import Categories.Category.Instance.StrictGroupoids
+open import Categories.Functor
+open import Categories.Functor.Equivalence
+open import Categories.Functor.Instance.Core renaming (Core to WeakCore)
+open import Categories.Functor.Properties using ([_]-resp-≅)
+import Categories.Morphism as Morphism
+import Categories.Morphism.Reasoning as MR
+import Categories.Morphism.HeterogeneousIdentity as HId
+import Categories.Morphism.HeterogeneousIdentity.Properties as HIdProps
+open import Categories.Morphism.IsoEquiv using (⌞_⌟)
+
+Core : ∀ {o ℓ e} → Functor (Cats o ℓ e) (Groupoids o (ℓ ⊔ e) e)
+Core {o} {ℓ} {e} = record
+   { F₀ = F₀
+   ; F₁ = F₁
+   ; identity = λ {A} →
+       record { eq₀ = λ _ → ≡.refl ; eq₁ = λ _ → ⌞ MR.id-comm-sym A ⌟ }
+   ; homomorphism = λ {A B C} →
+       record { eq₀ = λ _ → ≡.refl ; eq₁ = λ _ → ⌞ MR.id-comm-sym C ⌟ }
+   ; F-resp-≈ = λ {A B F G} → CoreRespFEq {A} {B} {F} {G}
+   }
+   where
+     open Functor WeakCore
+
+     CoreRespFEq : {A B : Category o ℓ e} {F G : Functor A B} →
+                   F ≡F G → F₁ F ≡F F₁ G
+     CoreRespFEq {A} {B} {F} {G} F≡G = record
+       { eq₀ = eq₀
+       ; eq₁ = λ {X} {Y} f → ⌞ begin
+           (from $ hid BC $ eq₀ Y) ∘ F.F₁ (from f)
+         ≈⟨ ∘-resp-≈ˡ (hid-identity BC B from Equiv.refl (eq₀ Y)) ⟩
+           (hid B $ ≡.cong idf $ eq₀ Y) ∘ F.F₁ (from f)
+         ≡⟨ cong (λ p → hid B p ∘ _) (cong-id (eq₀ Y)) ⟩
+           hid B (eq₀ Y) ∘ F.F₁ (from f)
+         ≈⟨ eq₁ (from f) ⟩
+           G.F₁ (from f) ∘ hid B (eq₀ X)
+         ≡˘⟨ cong (λ p → _ ∘ hid B p) (cong-id (eq₀ X)) ⟩
+           G.F₁ (from f) ∘ (hid B $ cong idf $ eq₀ X)
+         ≈˘⟨ ∘-resp-≈ʳ (hid-identity BC B from Equiv.refl (eq₀ X)) ⟩
+           G.F₁ (from f) ∘ (from $ hid BC $ eq₀ X)
+         ∎ ⌟
+       }
+       where
+         BC = C.Core B
+         module F = Functor F
+         module G = Functor G
+         open Category B
+         open HomReasoning hiding (refl)
+         open HId
+         open HIdProps
+         open _≡F_ F≡G
+         open Morphism._≅_

--- a/Everything.agda
+++ b/Everything.agda
@@ -3,6 +3,7 @@ import Categories.Adjoint
 import Categories.Adjoint.Equivalence
 import Categories.Adjoint.Instance.0-Truncation
 import Categories.Adjoint.Instance.Core
+import Categories.Adjoint.Instance.StrictCore
 import Categories.Adjoint.Mate
 import Categories.Adjoint.Properties
 import Categories.Adjoint.RAPL
@@ -125,6 +126,7 @@ import Categories.Functor.Instance.0-Truncation
 import Categories.Functor.Instance.Core
 import Categories.Functor.Instance.Discrete
 import Categories.Functor.Instance.SetoidDiscrete
+import Categories.Functor.Instance.StrictCore
 import Categories.Functor.Monoidal
 import Categories.Functor.Power
 import Categories.Functor.Power.Functorial


### PR DESCRIPTION
(Depends on #73.)

A "strict" version of the the adjunction between the forgetful functor from strict `Cats` to `Groupoids` and the core functor (akin to the "weak" version in `Categories.Adjoint.Instance.Core`).