### PR TITLE
Refactor proof that Cats is a CCC to make its parts more reusable.

### DIFF
--- a/Categories/Category/CartesianClosed/Canonical.agda
+++ b/Categories/Category/CartesianClosed/Canonical.agda
@@ -1,0 +1,161 @@
+{-# OPTIONS --without-K --safe #-}
+open import Categories.Category using (Category)
+
+-- A "canonical" presentation of cartesian closed categories.
+--
+-- This presentation is equivalent to the one in
+-- Categories.Category.CartesianClosed but it is easier to work with
+-- in some circumstances.
+--
+-- Here, exponentials are not defined in terms of arbitrary products,
+-- but in terms of a family of "canonical" products.  Since products
+-- are defined only up to isomorphism the choice of product does not
+-- matter for the property of being cartesian closed, but working with
+-- a fixed choice of representatives simplifies the constructions of
+-- some instances of CCCs (e.g. Cats).
+
+module Categories.Category.CartesianClosed.Canonical {o ℓ e} (𝒞 : Category o ℓ e) where
+
+open import Level using (levelOfTerm)
+open import Function using (flip)
+
+open import Categories.Category.Cartesian 𝒞 using (Cartesian)
+import Categories.Category.CartesianClosed 𝒞 as 𝒞-CC
+open import Categories.Object.Exponential 𝒞 using (Exponential)
+open import Categories.Object.Product 𝒞
+open import Categories.Object.Terminal 𝒞 using (Terminal)
+open import Categories.Morphism.Reasoning 𝒞
+
+private
+  module 𝒞 = Category 𝒞
+  open Category 𝒞
+  open HomReasoning
+
+  variable
+    A B C : Obj
+    f g h f₁ f₂ g₁ g₂ : A ⇒ B
+
+-- A (canonical) cartesian closed category is a category with all
+-- (canonical) products and exponentials
+--
+-- This presentation is equivalent to the one in
+-- Categories.Category.CartesianClosed.CartesianClosed.
+record CartesianClosed : Set (levelOfTerm 𝒞) where
+  infixr 7 _×_
+  infixr 9 _^_
+  infix 10 ⟨_,_⟩
+
+  field
+
+    -- Canonical products
+
+    ⊤    : Obj
+    _×_  : Obj → Obj → Obj
+
+    !     : A ⇒ ⊤
+    π₁    : A × B ⇒ A
+    π₂    : A × B ⇒ B
+    ⟨_,_⟩ : C ⇒ A → C ⇒ B → C ⇒ A × B
+
+    !-unique : (f : A ⇒ ⊤) → ! ≈ f
+
+    π₁-comp  : π₁ ∘ ⟨ f , g ⟩ ≈ f
+    π₂-comp  : π₂ ∘ ⟨ f , g ⟩ ≈ g
+
+    ⟨,⟩-unique : π₁ ∘ h ≈ f → π₂ ∘ h ≈ g → ⟨ f , g ⟩ ≈ h
+
+  -- The above defines canonical finite products, making 𝒞 cartesian.
+
+  ⊤-terminal : Terminal
+  ⊤-terminal = record { !-unique = !-unique }
+
+  ×-product : ∀ {A B} → Product A B
+  ×-product {A} {B} =
+    record { project₁ = π₁-comp; project₂ = π₂-comp; unique = ⟨,⟩-unique }
+
+  isCartesian : Cartesian
+  isCartesian = record
+    { terminal = ⊤-terminal
+    ; products = record { product = ×-product }
+    }
+
+  module cartesian = Cartesian isCartesian
+  open cartesian public
+    hiding (_×_; π₁; π₂; ⟨_,_⟩)
+    renaming (⟨⟩-cong₂ to ⟨,⟩-resp-≈)
+
+
+  field
+
+    -- Canonical exponentials (w.r.t. the canonical products)
+
+    _^_   : Obj → Obj → Obj
+    eval  : B ^ A × A ⇒ B
+    curry : C × A ⇒ B → C ⇒ B ^ A
+
+    eval-comp  : eval ∘ (curry f ⁂ id) ≈ f
+
+    curry-resp-≈ : f ≈ g → curry f ≈ curry g
+    curry-unique : eval ∘ (f ⁂ id) ≈ g → f ≈ curry g
+
+  -- The above defines canonical exponentials, making 𝒞 cartesian closed.
+  --
+  -- NOTE: below we use "⊗" to indicate "non-canonical" products.
+
+  ^-exponential : ∀ {A B} → Exponential A B
+  ^-exponential {A} {B} = record
+    { B^A      = B ^ A
+    ; product  = ×-product
+    ; eval     = eval
+    ; λg       = λ C⊗A f → curry (f ∘ repack ×-product C⊗A)
+    ; β        = λ {C} C⊗A {g} →
+      begin
+        eval ∘ [ C⊗A ⇒ ×-product ] curry (g ∘ repack ×-product C⊗A) ×id
+      ≈˘⟨ pullʳ [ ×-product ⇒ ×-product ]×∘⟨⟩ ⟩
+        (eval ∘ (curry (g ∘ repack ×-product C⊗A) ⁂ id)) ∘ repack C⊗A ×-product
+      ≈⟨ eval-comp ⟩∘⟨refl ⟩
+        (g ∘ repack ×-product C⊗A) ∘ repack C⊗A ×-product
+      ≈⟨ cancelʳ (repack∘repack≈id ×-product C⊗A) ⟩
+        g
+      ∎
+    ; λ-unique = λ {C} C⊗A {g} {f} hyp →
+      curry-unique (begin
+        eval ∘ (f ⁂ id)
+      ≈˘⟨ pullʳ [ C⊗A ⇒ ×-product ]×∘⟨⟩ ⟩
+        (eval ∘ [ C⊗A ⇒ ×-product ] f ×id) ∘ repack ×-product C⊗A
+      ≈⟨ hyp ⟩∘⟨refl ⟩
+        g ∘ repack ×-product C⊗A
+      ∎)
+    }
+
+module Equivalence where
+  open 𝒞-CC using () renaming (CartesianClosed to CartesianClosed′)
+
+  -- The two presentations of CCCs are equivalent
+
+  fromCanonical : CartesianClosed → CartesianClosed′
+  fromCanonical cc = record
+    { cartesian = CartesianClosed.isCartesian cc
+    ; exp       = CartesianClosed.^-exponential cc
+    }
+
+  toCanonical : CartesianClosed′ → CartesianClosed
+  toCanonical cc = record
+    { ⊤     = ⊤
+    ; _×_   = _×_
+    ; !     = !
+    ; π₁    = π₁
+    ; π₂    = π₂
+    ; ⟨_,_⟩ = ⟨_,_⟩
+    ; !-unique   = !-unique
+    ; π₁-comp    = project₁
+    ; π₂-comp    = project₂
+    ; ⟨,⟩-unique = unique
+    ; _^_   = _^_
+    ; eval  = eval′
+    ; curry = λg
+    ; eval-comp    = β′
+    ; curry-resp-≈ = λ-cong
+    ; curry-unique = λ-unique′
+    }
+    where open CartesianClosed′ cc

--- a/Categories/Category/Instance/Properties/Cats.agda
+++ b/Categories/Category/Instance/Properties/Cats.agda
@@ -2,295 +2,156 @@
 
 module Categories.Category.Instance.Properties.Cats where
 
-open import Data.Product
+open import Data.Product using (_,_)
 
 open import Categories.Category
-open import Categories.Category.Instance.Cats
-open import Categories.Category.Product
 open import Categories.Category.Construction.Functors
-open import Categories.Category.Cartesian
-open import Categories.Category.CartesianClosed
+  using (Functors; eval; module curry)
+open import Categories.Category.Cartesian using (Cartesian)
+import Categories.Category.CartesianClosed as CCC
+import Categories.Category.CartesianClosed.Canonical as Canonical
+open import Categories.Category.Instance.Cats using (Cats)
 open import Categories.Category.Monoidal.Instance.Cats
-open import Categories.Functor renaming (id to idF)
-open import Categories.Functor.Properties
-open import Categories.Functor.Bifunctor
-open import Categories.Functor.Bifunctor.Properties
-open import Categories.NaturalTransformation
-open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism; _≃_; _ⓘˡ_; _ⓘʳ_; module ≃)
-open import Categories.NaturalTransformation.Properties
-
-import Categories.Object.Product as P
+open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
+open import Categories.Functor.Bifunctor using (Bifunctor)
+open import Categories.Functor.Construction.Constant using (constNat)
 import Categories.Morphism.Reasoning as MR
+open import Categories.NaturalTransformation
+  using (NaturalTransformation; _∘ˡ_) renaming (id to idNT)
+open import Categories.NaturalTransformation.NaturalIsomorphism
+  using (NaturalIsomorphism; _≃_; module LeftRightId)
 
-private
-  module Car {l} = Cartesian (Product.Cats-is {l} {l} {l})
+-- It's easier to define exponentials with respect to the *canonical*
+-- product.  The more generic version can then be given by appealing
+-- to uniqueness (up to iso) of products.
 
-Cats-CCC : ∀ {l} → CartesianClosed (Cats l l l)
-Cats-CCC {l} = record
-  { cartesian = Product.Cats-is
-  ; exp       = λ {C D} → record
-    { B^A      = Functors C D
-    ; product  = Car.product
-    ; eval     = eval
-    ; λg       = λg
-    ; β        = β
-    ; λ-unique = λ-unique
+module CanonicallyCartesianClosed {l} where
+  private
+    module Cats = Category (Cats l l l)
+    module Cart = Cartesian (Product.Cats-is {l} {l} {l})
+  open Cats using (_⇒_) renaming (Obj to Cat)
+  open Cart hiding (η)
+
+  infixr 9 _^_
+
+  _^_ : Cat → Cat → Cat
+  B ^ A = Functors A B
+
+  -- The β law (aka computation principle) for exponential objects
+
+  eval-comp : ∀ {A B C} {G : C × A ⇒ B} → eval ∘F (curry.F₀ G ⁂ idF) ≃ G
+  eval-comp {A} {B} {C} {G} = record
+    { F⇒G = record
+      { η           = λ _ → id B
+      ; commute     = λ _ → ∘-resp-≈ʳ B commute ○ MR.id-comm-sym B
+      ; sym-commute = λ _ → ⟺ (∘-resp-≈ʳ B commute ○ MR.id-comm-sym B)
+      }
+    ; F⇐G = record
+      { η           = λ _ → id B
+      ; commute     = λ _ → ⟺ (MR.id-comm B ○ ∘-resp-≈ʳ B commute)
+      ; sym-commute = λ _ → MR.id-comm B ○ ∘-resp-≈ʳ B commute
+      }
+    ; iso = iso-id-id
     }
-  }
-  where open P (Cats l l l) renaming (Product to Pro)
-        λg : ∀ {E C D : Category l l l} (p : Pro E C) → Functor (Pro.A×B p) D → Functor E (Functors C D)
-        λg {E} {C} {D} p F = record
-          { F₀           = λ e → record
-              { F₀           = λ c → F₀ (rewrap.F₀ (e , c))
-              ; F₁           = λ f → F₁ (rewrap.F₁ (E.id , f))
-              ; identity     = begin
-                  F₁ (rewrap.F₁ (E.id , C.id)) ≈⟨ F-resp-≈ rewrap.identity ⟩
-                  F₁ EC.id                     ≈⟨ identity ⟩
-                  D.id                         ∎
-              ; homomorphism = λ {_ _ _} {f g} → begin
-                F₁ (rewrap.F₁ (E.id , g C.∘ f))                         ≈⟨ F-resp-≈ (Functor.homomorphism (appˡ rewrap e)) ⟩
-                F₁ (rewrap.F₁ (E.id , g) EC.∘ rewrap.F₁ (E.id , f))     ≈⟨ homomorphism ⟩
-                F₁ (rewrap.F₁ (E.id , g)) D.∘ F₁ (rewrap.F₁ (E.id , f)) ∎
-              ; F-resp-≈     = λ {_ _} {f g} eq → F-resp-≈ (Functor.F-resp-≈ (appˡ rewrap e) eq)
-              }
-          ; F₁           = λ {A B} f → ntHelper record
-            { η       = λ c → F₁ (rewrap.F₁ (f , C.id))
-            ; commute = λ g → begin
-              F₁ (rewrap.F₁ (f , C.id)) D.∘ F₁ (rewrap.F₁ (E.id , g)) ≈˘⟨ homomorphism ⟩
-              F₁ (rewrap.F₁ (f , C.id) EC.∘ rewrap.F₁ (E.id , g))     ≈˘⟨ F-resp-≈ [ rewrap ]-commute ⟩
-              F₁ (rewrap.F₁ (E.id , g) EC.∘ rewrap.F₁ (f , C.id))     ≈⟨ homomorphism ⟩
-              F₁ (rewrap.F₁ (E.id , g)) D.∘ F₁ (rewrap.F₁ (f , C.id)) ∎
-            }
-          ; identity     = F-resp-≈ rewrap.identity ○ identity
-          ; homomorphism = λ {_ _ _} {f g} → begin
-            F₁ (rewrap.F₁ (g E.∘ f , C.id))                         ≈⟨ F-resp-≈ (Functor.homomorphism (appʳ rewrap _)) ⟩
-            F₁ (rewrap.F₁ (g , C.id) EC.∘ rewrap.F₁ (f , C.id))     ≈⟨ homomorphism ⟩
-            F₁ (rewrap.F₁ (g , C.id)) D.∘ F₁ (rewrap.F₁ (f , C.id)) ∎
-          ; F-resp-≈     = λ eq → F-resp-≈ (Functor.F-resp-≈ (appʳ rewrap _) eq)
-          }
-          where module E = Category E
-                module C = Category C
-                module D = Category D
-                open Functor F
-                open Pro p renaming (A×B to EC)
-                module EC = Category EC
-                open D.HomReasoning
-                rewrap : Bifunctor E C EC
-                rewrap = ⟨ πˡ , πʳ ⟩
-                module rewrap = Functor rewrap
+    where
+      open Functor G renaming (F₀ to G₀; F₁ to G₁)
+      open Category hiding (_∘_)
+      open Category B using (_∘_)
+      open HomReasoning B
+      open LeftRightId G
 
-        β : ∀ {E C D : Category l l l} (p : Pro E C) {F : Functor (Pro.A×B p) D} →
-              eval ∘F (λg p F ∘F Pro.π₁ p ※ idF ∘F Pro.π₂ p) ≃ F
-        β {E} {C} {D} p {F} = record
-          { F⇒G = ntHelper record
-            { η       = natiso.⇒.η
-            ; commute = λ {X Y} f → begin
-              natiso.⇒.η Y D.∘ Functor.F₁ (eval ∘F (λg p F ∘F π₁ ※ idF ∘F π₂)) f
-                ≡⟨⟩
-              natiso.⇒.η Y D.∘ F₁ (rewrap.F₁ (Functor.F₁ π₁ f , C.id)) D.∘ F₁ (rewrap.F₁ (E.id , Functor.F₁ π₂ f))
-                ≈˘⟨ refl⟩∘⟨ (F-resp-≈ [ rewrap ]-decompose₁ ○ homomorphism) ⟩
-              natiso.⇒.η Y D.∘ F₁ (Functor.F₁ (⟨ πˡ , πʳ ⟩ ∘F (π₁ ※ π₂)) f)
-                ≈⟨ natiso.⇒.commute f ⟩
-              F₁ f D.∘ natiso.⇒.η X
-                ∎
-            }
-          ; F⇐G = ntHelper record
-            { η       = natiso.⇐.η
-            ; commute = λ {X Y} f → begin
-              natiso.⇐.η Y D.∘ F₁ f
-                ≈⟨ natiso.⇐.commute f ⟩
-              F₁ (Functor.F₁ (⟨ πˡ , πʳ ⟩ ∘F (π₁ ※ π₂)) f) D.∘ natiso.⇐.η X
-                ≈⟨ (F-resp-≈ [ rewrap ]-decompose₁ ○ homomorphism) ⟩∘⟨refl ⟩
-              Functor.F₁ (eval ∘F (λg p F ∘F π₁ ※ idF ∘F π₂)) f D.∘ natiso.⇐.η X
-                ∎
-            }
-          ; iso = natiso.iso
-          }
-          where module E = Category E
-                module C = Category C
-                module D = Category D
-                open Functor F
-                open Pro p renaming (A×B to EC)
-                module EC = Category EC
-                open D.HomReasoning
-                rewrap : Bifunctor E C EC
-                rewrap = ⟨ πˡ , πʳ ⟩
-                module rewrap = Functor rewrap
-                natiso : F ∘F ⟨ πˡ , πʳ ⟩ ∘F (π₁ ※ π₂) ≃ F ∘F idF
-                natiso = F ⓘˡ repack∘repack≈id Car.product p
-                module natiso = NaturalIsomorphism natiso
+      commute : ∀ {a₁ a₂ b₁ b₂} {f₁ : C [ a₁ , b₁ ]} {f₂ : A [ a₂ , b₂ ]} →
+                B [ (G₁ (f₁ , id A) ∘ G₁ (id C , f₂)) ≈ G₁ (f₁ , f₂) ]
+      commute {_} {_} {_} {_} {f₁} {f₂} = begin
+          G₁ (f₁ , id A) ∘ G₁ (id C , f₂)
+        ≈˘⟨ homomorphism ⟩
+          G₁ (C [ f₁ ∘ id C ] , A [ id A ∘ f₂ ])
+        ≈⟨ F-resp-≈ (identityʳ C , identityˡ A) ⟩
+          G₁ (f₁ , f₂)
+        ∎
 
-        λg-cong : ∀ {E C D : Category l l l} (p : Pro E C) {F G : Functor (Pro.A×B p) D} (F≃G : F ≃ G) →
-                    λg p F ≃ λg p G
-        λg-cong {E} {C} {D} p {F} {G} F≃G = record
-          { F⇒G = ntHelper record
-            { η       = λ e → ntHelper record
-              { η       = λ c → mapped.⇒.η (e , c)
-              ; commute = λ f → mapped.⇒.commute (E.id , f)
-              }
-            ; commute = λ f → mapped.⇒.commute (f , C.id)
-            }
-          ; F⇐G = ntHelper record
-            { η       = λ e → ntHelper record
-              { η       = λ c → mapped.⇐.η (e , c)
-              ; commute = λ f → mapped.⇐.commute (E.id , f)
-              }
-            ; commute = λ f → mapped.⇐.commute (f , C.id)
-            }
-          ; iso = λ e → record
-            { isoˡ = mapped.iso.isoˡ _
-            ; isoʳ = mapped.iso.isoʳ _
-            }
-          }
-          where module E = Category E
-                module C = Category C
-                open Pro p renaming (A×B to EC)
-                rewrap = ⟨ πˡ , πʳ ⟩
-                module rewrap = Functor rewrap
-                mapped = F≃G ⓘʳ rewrap
-                module mapped = NaturalIsomorphism mapped
+  -- The η law (aka uniqueness principle) for exponential objects
 
-        λ-unique : ∀ {E C D : Category l l l} (p : Pro E C) {F : Functor (Pro.A×B p) D} {G : Functor E (Functors C D)} →
-                     eval ∘F (G ∘F Pro.π₁ p ※ idF ∘F Pro.π₂ p) ≃ F →
-                     G ≃ (λg p F)
-        λ-unique {E} {C} {D} p {F} {G} iso = ≃.trans (≃.sym cancel) (λg-cong p iso)
-          where module E = Category E
-                module C = Category C
-                module D = Category D
-                module G = Functor G
-                open Functor F
-                open Pro p renaming (A×B to EC)
-                module EC = Category EC
-                open D.HomReasoning
-                open MR D
-                rewrap : Bifunctor E C EC
-                rewrap = ⟨ πˡ , πʳ ⟩
-                module rewrap = Functor rewrap
-                natiso : F ∘F ⟨ πˡ , πʳ ⟩ ∘F (π₁ ※ π₂) ≃ F ∘F idF
-                natiso = F ⓘˡ repack∘repack≈id Car.product p
-                module natiso = NaturalIsomorphism natiso
-                project₁′ = project₁ {h = πˡ} {πʳ}
-                module project₁′ = NaturalIsomorphism project₁′
-                project₂′ = project₂ {h = πˡ} {πʳ}
-                module project₂′ = NaturalIsomorphism project₂′
-                Gproject₁′ = G ⓘˡ project₁ {h = πˡ} {πʳ}
-                module Gproject₁′ = NaturalIsomorphism Gproject₁′
-                module π₂r = Functor (π₂ ∘F rewrap)
-                module π₁r = Functor (π₁ ∘F rewrap)
+  η-exp : ∀ {A B C} {H : C ⇒ B ^ A} → H ≃ curry.F₀ (eval ∘F (H ⁂ idF))
+  η-exp {A} {B} {C} {H} = record
+    { F⇒G = record
+      { η = λ _ → record
+        { η           = λ _ → id B
+        ; commute     = λ f → ⟺ (MR.id-comm B ○ ∘-resp-≈ʳ B (commute₁ f))
+        ; sym-commute = λ f → MR.id-comm B ○ ∘-resp-≈ʳ B (commute₁ f)
+        }
+      ; commute       = λ f → ⟺ (MR.id-comm B ○ ∘-resp-≈ʳ B (commute₂ f))
+      ; sym-commute   = λ f → MR.id-comm B ○ ∘-resp-≈ʳ B (commute₂ f)
+      }
+    ; F⇐G = record
+      { η = λ _ → record
+        { η           = λ _ → id B
+        ; commute     = λ f → ∘-resp-≈ʳ B (commute₁ f) ○ MR.id-comm-sym B
+        ; sym-commute = λ f → ⟺ (∘-resp-≈ʳ B (commute₁ f) ○ MR.id-comm-sym B)
+        }
+      ; commute       = λ f → ∘-resp-≈ʳ B (commute₂ f) ○ MR.id-comm-sym B
+      ; sym-commute   = λ f → ⟺ (∘-resp-≈ʳ B (commute₂ f) ○ MR.id-comm-sym B)
+      }
+    ; iso = λ _ → record { isoˡ = identity² B; isoʳ = identity² B }
+    }
+    where
+      open Functor using (identity) renaming (F₁ to _$₁_)
+      open Functor H hiding (identity) renaming (F₀ to H₀; F₁ to H₁)
+      open Category hiding (_∘_)
+      open Category B using (_∘_)
+      open HomReasoning B
+      open NaturalTransformation
+      open LeftRightId H
 
-                cancel : λg p (eval ∘F (G ∘F Pro.π₁ p ※ idF ∘F Pro.π₂ p)) ≃ G
-                cancel = record
-                  { F⇒G = ntHelper record
-                    { η       = λ e → 
-                      let module Ge  = Functor (G.F₀ e)
-                      in ntHelper record
-                      { η       = λ c →
-                        let module α = NaturalTransformation (Gproject₁′.⇒.η (e , c))
-                        in Ge.F₁ (project₂′.⇒.η (e , c)) D.∘ α.η (π₂r.F₀ (e , c))
-                      ; commute = λ {X Y} f →
-                        let module α = NaturalTransformation (Gproject₁′.⇒.η (e , X))
-                            module γ = NaturalTransformation (Gproject₁′.⇒.η (e , Y))
-                            module δ = NaturalTransformation (G.F₁ (π₁r.F₁ (E.id , f)))
-                        in begin
-                          (Ge.F₁ (project₂′.⇒.η (e , Y)) D.∘ γ.η (π₂r.F₀ (e , Y))) D.∘
-                            Functor.F₁ (Functor.F₀ (λg p (eval ∘F (G ∘F π₁ ※ idF ∘F π₂))) e) f
-                            ≡⟨⟩
-                          (Ge.F₁ (project₂′.⇒.η (e , Y)) D.∘ γ.η (π₂r.F₀ (e , Y))) D.∘
-                            δ.η (π₂r.F₀ (e , Y)) D.∘ Functor.F₁ (G.F₀ (π₁r.F₀ (e , X))) (π₂r.F₁ (E.id , f))
-                            ≈⟨ refl⟩∘⟨ δ.commute (π₂r.F₁ (E.id , f)) ⟩
-                          (Ge.F₁ (project₂′.⇒.η (e , Y)) D.∘ γ.η (π₂r.F₀ (e , Y))) D.∘
-                            Functor.F₁ (G.F₀ (π₁r.F₀ (e , Y))) (π₂r.F₁ (E.id , f)) D.∘ δ.η (π₂r.F₀ (e , X))
-                            ≈⟨ center (γ.commute (π₂r.F₁ (E.id , f))) ⟩
-                          Ge.F₁ (project₂′.⇒.η (e , Y)) D.∘
-                          (Ge.F₁ (π₂r.F₁ (E.id , f)) D.∘ γ.η (π₂r.F₀ (e , X))) D.∘
-                          δ.η (π₂r.F₀ (e , X))
-                            ≈⟨ center⁻¹ refl ([ G ]-resp-∘ (E.Equiv.trans (project₁′.⇒.commute (E.id , f)) E.identityˡ)) ⟩
-                          (Ge.F₁ (project₂′.⇒.η (e , Y)) D.∘ Ge.F₁ (π₂r.F₁ (E.id , f))) D.∘ α.η (π₂r.F₀ (e , X))
-                            ≈⟨ pushˡ ([ G.F₀ e ]-resp-square (project₂′.⇒.commute (E.id , f))) ⟩
-                          Ge.F₁ f D.∘ Ge.F₁ (project₂′.⇒.η (e , X)) D.∘ α.η (π₂r.F₀ (e , X))
-                            ∎
-                      }
-                    ; commute = λ {X Y} f {c} →
-                      let module GX = Functor (G.F₀ X)
-                          module GY = Functor (G.F₀ Y)
-                          module α  = NaturalTransformation (Gproject₁′.⇒.η (X , c))
-                          module γ  = NaturalTransformation (Gproject₁′.⇒.η (Y , c))
-                          module δ  = NaturalTransformation (G.F₁ (π₁r.F₁ (f , C.id)))
-                       in begin
-                         (GY.F₁ (project₂′.⇒.η (Y , c)) D.∘ γ.η (π₂r.F₀ (Y , c))) D.∘
-                         NaturalTransformation.η (Functor.F₁ (λg p (eval ∘F (G ∘F π₁ ※ idF ∘F π₂))) f) c
-                           ≡⟨⟩
-                         (GY.F₁ (project₂′.⇒.η (Y , c)) D.∘ γ.η (π₂r.F₀ (Y , c))) D.∘
-                         δ.η (π₂r.F₀ (Y , c)) D.∘ Functor.F₁ (G.F₀ (π₁r.F₀ (X , c))) (π₂r.F₁ (f , C.id))
-                           ≈⟨ refl⟩∘⟨ δ.commute (π₂r.F₁ (f , C.id)) ⟩
-                         (GY.F₁ (project₂′.⇒.η (Y , c)) D.∘ γ.η (π₂r.F₀ (Y , c))) D.∘
-                         Functor.F₁ (G.F₀ (π₁r.F₀ (Y , c))) (π₂r.F₁ (f , C.id)) D.∘ δ.η (π₂r.F₀ (X , c))
-                           ≈⟨ center (γ.commute (π₂r.F₁ (f , C.id))) ⟩
-                         GY.F₁ (project₂′.⇒.η (Y , c)) D.∘
-                         (GY.F₁ (π₂r.F₁ (f , C.id)) D.∘ γ.η (π₂r.F₀ (X , c))) D.∘
-                         δ.η (π₂r.F₀ (X , c))
-                           ≈⟨ center⁻¹ ([ G.F₀ Y ]-resp-square (project₂′.⇒.commute (f , C.id)))
-                                       ([ G ]-resp-square (project₁′.⇒.commute (f , C.id))) ⟩
-                         (GY.F₁ C.id D.∘ GY.F₁ (project₂′.⇒.η (X , c))) D.∘
-                         NaturalTransformation.η (G.F₁ f) (π₂r.F₀ (X , c)) D.∘ α.η (π₂r.F₀ (X , c))
-                           ≈⟨ elimˡ GY.identity ⟩∘⟨refl ⟩
-                         GY.F₁ (project₂′.⇒.η (X , c)) D.∘ NaturalTransformation.η (G.F₁ f) (π₂r.F₀ (X , c)) D.∘ α.η (π₂r.F₀ (X , c))
-                           ≈⟨ pullˡ (⟺ (NaturalTransformation.commute (G.F₁ f) (project₂′.⇒.η (X , c)))) ○ D.assoc ⟩
-                         NaturalTransformation.η (G.F₁ f) c D.∘ GX.F₁ (project₂′.⇒.η (X , c)) D.∘ α.η (π₂r.F₀ (X , c))
-                           ∎
-                    }
-                  ; F⇐G = ntHelper record
-                    { η       = λ e →
-                      let module Ge  = Functor (G.F₀ e)
-                      in ntHelper record
-                      { η       = λ c →
-                        let module α = NaturalTransformation (Gproject₁′.⇐.η (e , c))
-                        in α.η (π₂r.F₀ (e , c)) D.∘ Ge.F₁ (project₂′.⇐.η (e , c))
-                      ; commute = λ {X Y} f →
-                        let module α = NaturalTransformation (Gproject₁′.⇐.η (e , X))
-                            module γ = NaturalTransformation (Gproject₁′.⇐.η (e , Y))
-                            module δ = NaturalTransformation (G.F₁ (π₁r.F₁ (E.id , f)))
-                        in begin
-                          (γ.η (π₂r.F₀ (e , Y)) D.∘ Ge.F₁ (project₂′.⇐.η (e , Y))) D.∘ Ge.F₁ f
-                            ≈⟨ D.assoc ⟩
-                          γ.η (π₂r.F₀ (e , Y)) D.∘ Ge.F₁ (project₂′.⇐.η (e , Y)) D.∘ Ge.F₁ f
-                            ≈˘⟨ center⁻¹ ([ G ]-resp-∘ (E.Equiv.trans (E.Equiv.sym (project₁′.⇐.commute (E.id , f))) E.identityʳ))
-                                         ([ G.F₀ e ]-resp-square (C.Equiv.sym (project₂′.⇐.commute (E.id , f)))) ⟩
-                          δ.η (π₂r.F₀ (e , Y)) D.∘
-                          (α.η (π₂r.F₀ (e , Y)) D.∘ Ge.F₁ (π₂r.F₁ (E.id , f))) D.∘
-                          Ge.F₁ (project₂′.⇐.η (e , X))
-                            ≈˘⟨ center (⟺ (α.commute (π₂r.F₁ (E.id , f)))) ⟩
-                          (δ.η (π₂r.F₀ (e , Y)) D.∘ Functor.F₁ (G.F₀ (π₁r.F₀ (e , X))) (π₂r.F₁ (E.id , f)))
-                            D.∘ α.η (π₂r.F₀ (e , X)) D.∘ Ge.F₁ (project₂′.⇐.η (e , X))
-                            ∎
-                      }
-                    ; commute = λ {X Y} f {c} →
-                      let module GX = Functor (G.F₀ X)
-                          module GY = Functor (G.F₀ Y)
-                          module α  = NaturalTransformation (Gproject₁′.⇐.η (X , c))
-                          module γ  = NaturalTransformation (Gproject₁′.⇐.η (Y , c))
-                          module δ  = NaturalTransformation (G.F₁ (π₁r.F₁ (f , C.id)))
-                       in begin
-                         (γ.η (π₂r.F₀ (Y , c)) D.∘ GY.F₁ (project₂′.⇐.η (Y , c))) D.∘ NaturalTransformation.η (G.F₁ f) c
-                           ≈˘⟨ pullʳ (NaturalTransformation.commute (G.F₁ f) (project₂′.⇐.η (Y , c))) ○ D.sym-assoc ⟩
-                         (γ.η (π₂r.F₀ (Y , c)) D.∘ NaturalTransformation.η (G.F₁ f) (π₂r.F₀ (Y , c))) D.∘ GX.F₁ (project₂′.⇐.η (Y , c))
-                           ≈˘⟨ center⁻¹ ([ G ]-resp-square (E.Equiv.sym (project₁′.⇐.commute (f , C.id))))
-                                        ([ G.F₀ X ]-resp-square (C.Equiv.sym (project₂′.⇐.commute (f , C.id))) ○ elimʳ GX.identity) ⟩
-                         δ.η (π₂r.F₀ (Y , c)) D.∘
-                         (α.η (π₂r.F₀ (Y , c)) D.∘ GX.F₁ (π₂r.F₁ (f , C.id))) D.∘
-                         GX.F₁ (project₂′.⇐.η (X , c))
-                           ≈˘⟨ center (⟺ (α.commute (π₂r.F₁ (f , C.id)))) ⟩
-                         (δ.η (π₂r.F₀ (Y , c)) D.∘ Functor.F₁ (G.F₀ (π₁r.F₀ (X , c))) (π₂r.F₁ (f , C.id))) D.∘
-                         α.η (π₂r.F₀ (X , c)) D.∘ GX.F₁ (project₂′.⇐.η (X , c))
-                           ∎
-                    }
-                  ; iso = λ e → record
-                    { isoˡ = center ([ G.F₀ e ]-resp-∘ (project₂′.iso.isoˡ _)) ○
-                             D.∘-resp-≈ʳ (elimˡ (Functor.identity (G.F₀ e))) ○
-                             Gproject₁′.iso.isoˡ _
-                    ; isoʳ = center (Gproject₁′.iso.isoʳ _) ○
-                             D.∘-resp-≈ʳ D.identityˡ ○
-                             [ G.F₀ e ]-resp-∘ (project₂′.iso.isoʳ _) ○
-                             Functor.identity (G.F₀ e)
-                    }
-                  }
+      commute₁ : ∀ {a b c} (f : A [ a , b ]) →
+                 B [ (η (H₁ (id C)) b ∘ (H₀ c $₁ f)) ≈ H₀ c $₁ f ]
+      commute₁ {_} {b} {c} f = begin
+        η (H₁ (id C)) b ∘ (H₀ c $₁ f)  ≈⟨ ∘-resp-≈ˡ B (identity H) ⟩
+        id B ∘ (H₀ c $₁ f)             ≈⟨ identityˡ B ⟩
+        H₀ c $₁ f                      ∎
+
+      commute₂ : ∀ {c₁ c₂} (f : C [ c₁ , c₂ ]) {a} →
+                 B [ (η (H₁ f) a ∘ (H₀ c₁ $₁ id A)) ≈ η (H₁ f) a ]
+      commute₂ {c} {_} f {a} = begin
+        η (H₁ f) a ∘ (H₀ c $₁ id A)    ≈⟨ ∘-resp-≈ʳ B (identity (H₀ c)) ⟩
+        η (H₁ f) a ∘ id B              ≈⟨ identityʳ B ⟩
+        η (H₁ f) a                     ∎
+
+  curry-unique : ∀ {A B C} {G : C ⇒ B ^ A} {H : C × A ⇒ B} →
+                 eval ∘F (G ⁂ idF) ≃ H → G ≃ curry.F₀ H
+  curry-unique {A} {B} {C} {G} {H} hyp =
+    begin
+      G
+    ≈⟨ η-exp {A} {B} {C} {G} ⟩
+      curry.F₀ (eval ∘F (G ⁂ idF))
+    ≈⟨ curry.resp-NI {F = eval ∘F (G ⁂ idF)} {H} hyp ⟩
+      curry.F₀ H
+    ∎
+    where
+      open Functor
+      open Cats.HomReasoning
+
+  Cats-CCC : Canonical.CartesianClosed (Cats l l l)
+  Cats-CCC = record
+    { !            = !
+    ; π₁           = π₁
+    ; π₂           = π₂
+    ; ⟨_,_⟩        = ⟨_,_⟩
+    ; !-unique     = !-unique
+    ; π₁-comp      = λ {_} {_} {F} {_} {G} → project₁ {h = F} {i = G}
+    ; π₂-comp      = λ {_} {_} {F} {_} {G} → project₂ {h = F} {i = G}
+    ; ⟨,⟩-unique   = unique
+    ; eval         = eval
+    ; curry        = curry.F₀
+    ; eval-comp    = λ {_} {_} {_} {G} → eval-comp {G = G}
+    ; curry-resp-≈ = λ {_} {_} {_} {G} {H} → curry.resp-NI {F = G} {H}
+    ; curry-unique = λ {_} {_} {_} {G} {H} → curry-unique {G = G} {H}
+    }
+
+  open Canonical.CartesianClosed Cats-CCC
+
+Cats-CCC : ∀ {l} → CCC.CartesianClosed (Cats l l l)
+Cats-CCC =
+  Canonical.Equivalence.fromCanonical _ CanonicallyCartesianClosed.Cats-CCC
+
+module CartesianClosed {l} = CCC.CartesianClosed (Cats-CCC {l})

--- a/Everything.agda
+++ b/Everything.agda
@@ -19,6 +19,7 @@ import Categories.Category.BicartesianClosed
 import Categories.Category.Cartesian
 import Categories.Category.Cartesian.Properties
 import Categories.Category.CartesianClosed
+import Categories.Category.CartesianClosed.Canonical
 import Categories.Category.CartesianClosed.Locally
 import Categories.Category.CartesianClosed.Locally.Properties
 import Categories.Category.Closed


### PR DESCRIPTION
I decided to develop @HuStmpHrrr's insight from #61 a bit further.

**Recap.** The current definition of CCCs is very generic, unlike the 'typical' presentations where exponentials are defined in terms of a canonical choice of products. Thanks to the universal property of products, this does not matter. One can just repack products to work with whatever isomorphic presentation one desires.

**This PR.** This is of course not specific to `Cats`. Indeed, it is completely independent from the actual CCC one is working with, so the work of converting from/to the canonical products can be done once and for all, in a generic fashion. To this end, I added the module `Categories.Category.CartesianClosed.Canonical` which is closer to the 'typical' presentation of CCCs. It completely unfolds the definition of CCCs and defines exponentials w.r.t. to the canonical choice of products. Since this presentation is (provably) equivalent to the current one, we may prove that an instance (e.g. `Cats`) is 'canonically cartesian closed', and then convert the proof to the usual definition.

**Future work.** There are at least four equivalent definitions of CCCs that I can think of.
 1. the current, generic one (in terms of exponentials),
 2. the new, canonical one,
 3. one requiring a category to be a) cartesian, and b) monoidal-closed w.r.t. products,
 4. one in terms of an adjoint tripple of functors (diagonal, product, hom).

It would be nice to implement 3 and 4 as well, and prove them equivalent to the others.