### PR TITLE
The bicategory of V-enriched categories.

### DIFF
--- a/Categories/Bicategory/Instance/EnrichedCats.agda
+++ b/Categories/Bicategory/Instance/EnrichedCats.agda
@@ -1,0 +1,131 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Level
+open import Categories.Category using () renaming (Category to Setoid-Category)
+open import Categories.Category.Monoidal using (Monoidal)
+
+module Categories.Bicategory.Instance.EnrichedCats
+  {o ℓ e} {V : Setoid-Category o ℓ e} (M : Monoidal V) (v : Level) where
+
+-- The 2-category of V-enriched categories
+
+open import Data.Product as Prod using (_,_)
+
+open import Categories.Bicategory using (Bicategory)
+open import Categories.Category.Construction.EnrichedFunctors M
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Enriched.Category M
+open import Categories.Enriched.Functor M renaming (id to idF)
+open import Categories.Enriched.NaturalTransformation M hiding (id)
+import Categories.Enriched.NaturalTransformation.NaturalIsomorphism M as NI
+open import Categories.Functor.Bifunctor using (Bifunctor)
+open import Categories.Functor.Construction.Constant using (const)
+open import Categories.NaturalTransformation using (ntHelper)
+
+open module V = Setoid-Category V using (_∘_)
+open Monoidal M
+open NaturalTransformation
+open NI.NaturalIsomorphism
+
+EnrichedCats : Bicategory (ℓ ⊔ e ⊔ v) (ℓ ⊔ e ⊔ v) (e ⊔ v) (o ⊔ ℓ ⊔ e ⊔ suc v)
+EnrichedCats = record
+  { enriched = record
+    { Obj = Category v
+    ; hom = EnrichedFunctors
+    ; id  = const idF
+    ; ⊚   = ⊚
+    ; ⊚-assoc = λ {_ _ C D} →
+      let module C  = Category C
+          module D  = Category D
+          module UC = Underlying C
+          module UD = Underlying D
+          open UD using () renaming (_∘_ to _∙_)
+      in record
+        { F⇒G = ntHelper record
+          { η       = λ { ((F , G) , H) → from (NI.associator {F = F} {G} {H}) }
+          ; commute = λ { {(_ , G₁) , H₁} {(F₂ , G₂) , _} ((α , β) , γ) {X} →
+            let module G₁ = Functor G₁
+                module H₁ = Functor H₁
+                module F₂ = Functor F₂
+                module G₂ = Functor G₂
+                module UF₂ = UnderlyingFunctor F₂
+            in begin
+              D.id ∙ ((F₂.₁ ∘ G₂.₁) ∘ γ [ X ]) ∙ (F₂.₁ ∘ β [ H₁.₀ X ]) ∙
+              α [ G₁.₀ (H₁.₀ X) ]
+            ≈⟨ UD.identityˡ ○ ⟺ UD.assoc ⟩
+              (((F₂.₁ ∘ G₂.₁) ∘ γ [ X ]) ∙ (F₂.₁ ∘ β [ H₁.₀ X ])) ∙
+              α [ G₁.₀ (H₁.₀ X) ]
+            ≈⟨ UD.∘-resp-≈ˡ (UD.∘-resp-≈ˡ V.assoc ○ ⟺ UF₂.homomorphism) ⟩
+              (F₂.₁ ∘ ((G₂.₁ ∘ γ [ X ]) UC.∘ β [ H₁.₀ X ])) ∙ α [ G₁.₀ (H₁.₀ X) ]
+            ≈˘⟨ UD.identityʳ ⟩
+              ((F₂.₁ ∘ ((G₂.₁ ∘ γ [ X ]) UC.∘ β [ H₁.₀ X ])) ∙
+                α [ G₁.₀ (H₁.₀ X) ]) ∙ D.id
+            ∎ }
+          }
+        ; F⇐G = ntHelper record
+          { η       = λ { ((F , G) , H) → to (NI.associator {F = F} {G} {H}) }
+          ; commute = λ { {_} {(F₂ , _) , _} _ →
+            -- the proof is analogous to the one above, so write it
+            -- combinator-style
+            let module UF₂ = UnderlyingFunctor F₂
+            in UD.identityˡ ○
+               UD.∘-resp-≈ˡ (UF₂.homomorphism ○ UD.∘-resp-≈ˡ (⟺ V.assoc)) ○
+               UD.assoc ○ ⟺ UD.identityʳ
+            }
+          }
+        ; iso = λ{ ((F , G) , H) → iso (NI.associator {F = F} {G} {H}) }
+        }
+    ; unitˡ = λ {_ B} →
+      let module UB = Underlying B
+      in record
+        { F⇒G = ntHelper record
+          { η       = λ _ → from NI.unitorˡ
+          ; commute = λ _ → UB.identityˡ ○ UB.∘-resp-≈ˡ V.identityˡ
+          }
+        ; F⇐G = ntHelper record
+          { η       = λ _ → to NI.unitorˡ
+          ; commute = λ _ →
+            UB.identityˡ ○ ⟺ (UB.identityʳ ○ UB.identityʳ ○ V.identityˡ)
+          }
+        ; iso = λ _ → iso NI.unitorˡ
+        }
+    ; unitʳ = λ {_ B} →
+      let module UB = Underlying B
+      in record
+        { F⇒G = ntHelper record
+          { η       = λ _ → from NI.unitorʳ
+          ; commute = λ{ {_} {G₂ , _} _ →
+            let module UG₂ = UnderlyingFunctor G₂
+            in UB.identityˡ ○ UB.∘-resp-≈ˡ UG₂.identity ○
+               UB.identityˡ ○ ⟺ UB.identityʳ
+            }
+          }
+        ; F⇐G = ntHelper record
+          { η       = λ _ → to NI.unitorʳ
+          ; commute = λ{ {_} {G₂ , _} _ →
+            let module UG₂ = UnderlyingFunctor G₂
+            in UB.identityˡ ○
+               ⟺ (UB.identityʳ ○ UB.∘-resp-≈ˡ UG₂.identity ○ UB.identityˡ)
+            }
+          }
+        ; iso = λ _ → iso NI.unitorʳ
+        }
+    }
+  ; triangle = λ {_ _ C} → Underlying.identityʳ C
+  ; pentagon = λ {_ B _ D E _ G H I} →
+    let module B  = Category B
+        module D  = Category D
+        module E  = Category E
+        module G  = Functor G
+        module H  = Functor H
+        module I  = Functor I
+        module UE = Underlying E
+        open UE using () renaming (_∘_ to _∙_)
+    in begin
+      ((I.₁ ∘ D.id) ∙ E.id) ∙ E.id ∙ ((I.₁ ∘ H.₁ ∘ G.₁) ∘ B.id) ∙ E.id
+    ≈⟨ UE.∘-resp-≈ UE.identityʳ (UE.identityˡ ○ UE.identityʳ) ⟩
+      (I.₁ ∘ D.id) ∙ ((I.₁ ∘ H.₁ ∘ G.₁) ∘ B.id)
+    ≈⟨ UE.∘-resp-≈ I.identity (Functor.identity (I ∘F H ∘F G)) ⟩
+      E.id ∙ E.id
+    ∎
+  }

--- a/Everything.agda
+++ b/Everything.agda
@@ -15,6 +15,7 @@ import Categories.Bicategory
 import Categories.Bicategory.Bigroupoid
 import Categories.Bicategory.Construction.1-Category
 import Categories.Bicategory.Instance.Cats
+import Categories.Bicategory.Instance.EnrichedCats
 import Categories.Category
 import Categories.Category.BicartesianClosed
 import Categories.Category.Cartesian


### PR DESCRIPTION
This completes the mechanization of Section 1.3 of [Kelly's book on enriched category theory](http://www.tac.mta.ca/tac/reprints/articles/10/tr10abs.html).

Type checking this module on my MacBook takes a ridiculous amounts of time (just over a 1min when I give it 6GM of memory).

I'm not sure what the problem is, though I suspect the culprits are the proofs of `⊚-assoc`, `unitˡ`, `unitʳ` and the coherence conditions, or rather, checking their types against the type signatures of the corresponding fields in the `Bicategory` record. Type checking time actually *went up* when I tried to first define functions corresponding to these fields separately and then use them to populate the record.

If someone has ideas on how to improve the performance, that would be great.