### PR TITLE
Fix #100: rename underlying* to Underlying*

### DIFF
--- a/Categories/Enriched/Category.agda
+++ b/Categories/Enriched/Category.agda
@@ -91,8 +91,8 @@ _[_,_] = Category.hom
 -- hom-objects of C forms a setoid.  This induces the *underlying*
 -- category of C.
 
-underlying : ∀ {c} (C : Category c) → Setoid-Category c ℓ e
-underlying C = categoryHelper (record
+Underlying : ∀ {c} (C : Category c) → Setoid-Category c ℓ e
+Underlying C = categoryHelper (record
   { Obj = Obj
   ; _⇒_ = λ A B → unit ⇒ hom A B
   ; _≈_ = λ f g → f ≈ g
@@ -135,4 +135,4 @@ underlying C = categoryHelper (record
   })
   where open Category C
 
-module Underlying {c} (C : Category c) = Setoid-Category (underlying C)
+module Underlying {c} (C : Category c) = Setoid-Category (Underlying C)

--- a/Categories/Enriched/Functor.agda
+++ b/Categories/Enriched/Functor.agda
@@ -75,7 +75,7 @@ _∘F_ {_} {_} {_} {C} {D} {E} G F = record
   ; homomorphism = begin
       (G.₁ ∘ F.₁) ∘ C.⊚                  ≈⟨ pullʳ F.homomorphism ⟩
       G.₁ ∘ (D.⊚ ∘ F.₁ ⊗₁ F.₁)           ≈⟨ pullˡ G.homomorphism ⟩
-      (E.⊚ ∘ G.₁ ⊗₁ G.₁) ∘ F.₁ ⊗₁ F.₁    ≈˘⟨ pushʳ ⊗.homomorphism ⟩
+      (E.⊚ ∘ G.₁ ⊗₁ G.₁) ∘ F.₁ ⊗₁ F.₁    ≈˘⟨ pushʳ ⊗-distrib-over-∘ ⟩
       E.⊚ ∘ (G.₁ ∘ F.₁) ⊗₁ (G.₁ ∘ F.₁)   ∎
   }
   where
@@ -84,15 +84,14 @@ _∘F_ {_} {_} {_} {C} {D} {E} G F = record
     module E = Category E
     module F = Functor F
     module G = Functor G
-    module ⊗ = Setoid-Functor ⊗
 
 -- A V-enriched functor induces an ordinary functor on the underlying
 -- categories.
 
 module _ {c d} {C : Category c} {D : Category d} where
 
-  underlyingFunctor : Functor C D → Setoid-Functor (underlying C) (underlying D)
-  underlyingFunctor F = record
+  UnderlyingFunctor : Functor C D → Setoid-Functor (Underlying C) (Underlying D)
+  UnderlyingFunctor F = record
     { F₀           = F.₀
     ; F₁           = F.₁ ∘_
     ; identity     = F.identity
@@ -109,4 +108,4 @@ module _ {c d} {C : Category c} {D : Category d} where
 
       λ⇐ = unitorˡ.to
 
-  module UnderlyingFunctor F = Setoid-Functor (underlyingFunctor F)
+  module UnderlyingFunctor F = Setoid-Functor (UnderlyingFunctor F)

--- a/Categories/Enriched/NaturalTransformation.agda
+++ b/Categories/Enriched/NaturalTransformation.agda
@@ -143,9 +143,9 @@ module _ {c d} {C : Category c} {D : Category d} where
   -- A V-enriched natural transformation induces an ordinary natural
   -- transformation on the underlying functors.
 
-  underlyingNT : {F G : Functor C D} → NaturalTransformation F G →
-                 Setoid-NT (underlyingFunctor F) (underlyingFunctor G)
-  underlyingNT {F} {G} α = ntHelper (record
+  UnderlyingNT : {F G : Functor C D} → NaturalTransformation F G →
+                 Setoid-NT (UnderlyingFunctor F) (UnderlyingFunctor G)
+  UnderlyingNT {F} {G} α = ntHelper (record
     { η       = comp α
     ; commute = λ {X Y} f →
       begin
@@ -161,7 +161,7 @@ module _ {c d} {C : Category c} {D : Category d} where
       module F = Functor F
       module G = Functor G
 
-  module UnderlyingNT {F} {G} α = Setoid-NT (underlyingNT {F} {G} α)
+  module UnderlyingNT {F} {G} α = Setoid-NT (UnderlyingNT {F} {G} α)
 
 module _ {c d e} {C : Category c} {D : Category d} {E : Category e} where
 

--- a/Categories/Enriched/NaturalTransformation/NaturalIsomorphism.agda
+++ b/Categories/Enriched/NaturalTransformation/NaturalIsomorphism.agda
@@ -44,7 +44,7 @@ module _ {c d} {C : Category c} {D : Category d} where
     private
       module F = Functor F
       module G = Functor G
-    open Morphism (underlying D) using (_≅_)
+    open Morphism (Underlying D) using (_≅_)
 
     -- Natural isomorphisms are pointwise isomorphisms: each component
     -- |α [ X ]| is an isomorphism |F X ≅ G X|.
@@ -75,8 +75,7 @@ module _ {c d} {C : Category c} {D : Category d} where
   α ⓘᵥ β = ≃.trans β α
 
   private
-    module D  = Category D
-    module UD = Underlying D
+    module D = Underlying D
 
   -- Left and right unitors
 
@@ -90,7 +89,7 @@ module _ {c d} {C : Category c} {D : Category d} where
       { comp    = λ _ → D.id
       ; commute = comm ○ (refl⟩∘⟨ ⟺ identityˡ ⟩⊗⟨refl ⟩∘⟨refl)
       }
-    ; iso = record { isoˡ = UD.identity² ; isoʳ = UD.identity² }
+    ; iso = record { isoˡ = D.identity² ; isoʳ = D.identity² }
     }
     where comm = commute (idNT {F = F})
 
@@ -104,7 +103,7 @@ module _ {c d} {C : Category c} {D : Category d} where
       { comp    = λ _ → D.id
       ; commute = comm ○ (refl⟩∘⟨ ⟺ identityʳ ⟩⊗⟨refl ⟩∘⟨refl)
       }
-    ; iso = record { isoˡ = UD.identity² ; isoʳ = UD.identity² }
+    ; iso = record { isoˡ = D.identity² ; isoʳ = D.identity² }
     }
     where comm = commute (idNT {F = F})
 
@@ -122,7 +121,7 @@ module _ {c d e} {C : Category c} {D : Category d} {E : Category e} where
     ; iso  = record { isoˡ = iso.isoˡ ; isoʳ = iso.isoʳ }
     }
     where
-      module iso {X} = Iso ([ underlyingFunctor H ]-resp-Iso (iso (α ᵢ[ X ])))
+      module iso {X} = Iso ([ UnderlyingFunctor H ]-resp-Iso (iso (α ᵢ[ X ])))
 
   _ⓘʳ_ : {G H : Functor D E} → G ≃ H → (F : Functor C D) → G ∘F F ≃ H ∘F F
   α ⓘʳ F = record

--- a/Categories/Pseudofunctor/Instance/EnrichedUnderlying.agda
+++ b/Categories/Pseudofunctor/Instance/EnrichedUnderlying.agda
@@ -43,10 +43,10 @@ private
 
 EnrichedUnderlying : Pseudofunctor (EnrichedCats v) (Cats v ℓ e)
 EnrichedUnderlying = record
-  { P₀ = underlying
+  { P₀ = Underlying
   ; P₁ = record
-    { F₀ = underlyingFunctor
-    ; F₁ = underlyingNT
+    { F₀ = UnderlyingFunctor
+    ; F₁ = UnderlyingNT
     ; identity     = V.Equiv.refl
     ; homomorphism = V.Equiv.refl
     ; F-resp-≈     = λ eq → eq


### PR DESCRIPTION
Fix #100: rename the components of the underlying functor from enriched to ordinary categories (and some minor cleanup).

