### PR TITLE
Functor instance for List

### DIFF
--- a/src/Categories/Functor/Instance/Sets.agda
+++ b/src/Categories/Functor/Instance/Sets.agda
@@ -1,0 +1,23 @@
+{-# OPTIONS --safe --without-K #-}
+module Categories.Functor.Instance.Sets where
+
+open import Level
+open import Categories.Functor using (Endofunctor)
+open import Categories.Category.Instance.Sets
+open import Relation.Binary.PropositionalEquality as ≡ using (_≡_)
+
+open import Function using (id; λ-; _$-)
+open import Categories.Category
+import Data.List as List
+import Data.List.Properties
+
+ListFunctor : ∀ {o} → Endofunctor (Sets o)
+ListFunctor = record
+  { F₀ = List.List
+  ; F₁ = List.map
+  ; identity = map-id $-
+  ; homomorphism = map-compose $-
+  ; F-resp-≈ = λ f≈g → map-cong (λ- f≈g) $-
+  }
+  where
+    open Data.List.Properties


### PR DESCRIPTION
Add proof of a functor instance for List from the agda stdlib.

Thinking of putting functor instances all in one module per-category like this
since they're pretty short, let me know if I should do something else.


----

#