### PR TITLE
Add some extra equalities to Pullback

### DIFF
--- a/src/Categories/Diagram/Equalizer.agda
+++ b/src/Categories/Diagram/Equalizer.agda
@@ -66,3 +66,24 @@ Equalizer⇒Mono : (e : Equalizer h i) → Mono (Equalizer.arr e)
 Equalizer⇒Mono e f g eq =
   equalize-resp-≈′ equality-∘ equality-∘ eq (unique refl) (unique refl)
   where open Equalizer e
+
+up-to-iso : (e₁ e₂ : Equalizer h i) → Equalizer.obj e₁ ≅ Equalizer.obj e₂
+up-to-iso e₁ e₂ = record
+  { from = repack e₁ e₂
+  ; to = repack e₂ e₁
+  ; iso = record
+    { isoˡ = repack-cancel e₂ e₁
+    ; isoʳ = repack-cancel e₁ e₂
+    }
+  }
+  where
+    open Equalizer
+
+    repack : (e₁ e₂ : Equalizer h i) → obj e₁ ⇒ obj e₂
+    repack e₁ e₂ = equalize e₂ (equality e₁)
+
+    repack∘ : (e₁ e₂ e₃ : Equalizer h i) → repack e₂ e₃ ∘ repack e₁ e₂ ≈ repack e₁ e₃
+    repack∘ e₁ e₂ e₃ = unique e₃ (⟺ (glueTrianglesʳ (⟺ (universal e₃)) (⟺ (universal e₂))))
+
+    repack-cancel : (e₁ e₂ : Equalizer h i) → repack e₁ e₂ ∘ repack e₂ e₁ ≈ id
+    repack-cancel e₁ e₂ = repack∘ e₂ e₁ e₂ ○ ⟺ (id-equalize e₂)

--- a/src/Categories/Diagram/Pullback.agda
+++ b/src/Categories/Diagram/Pullback.agda
@@ -19,7 +19,7 @@ open import Categories.Morphism.Reasoning C as Square
 private
   variable
     A B X Y Z : Obj
-    f g h h₁ h₂ i i₁ i₂ j : A ⇒ B
+    f g h h₁ h₂ i i₁ i₂ j k : A ⇒ B
 
 -- Pullback of two arrows with a common codomain
 record Pullback (f : X ⇒ Z) (g : Y ⇒ Z) : Set (o ⊔ ℓ ⊔ e) where
@@ -45,6 +45,18 @@ record Pullback (f : X ⇒ Z) (g : Y ⇒ Z) : Set (o ⊔ ℓ ⊔ e) where
 
   id-unique : id ≈ universal commute
   id-unique = unique identityʳ identityʳ
+
+  universal-resp-≈ : ∀ {eq : f ∘ h₁ ≈ g ∘ h₂} {eq′ : f ∘ i₁ ≈ g ∘ i₂} → h₁ ≈ i₁ → h₂ ≈ i₂ → universal eq ≈ universal eq′
+  universal-resp-≈ h₁≈i₁ h₂≈i₂ = unique (p₁∘universal≈h₁ ○ h₁≈i₁) (p₂∘universal≈h₂ ○ h₂≈i₂)
+
+  universal-resp-≈′ : (eq : f ∘ h₁ ≈ g ∘ h₂) → (eq′ : f ∘ i₁ ≈ g ∘ i₂) →
+    h₁ ≈ i₁ → h₂ ≈ i₂ → j ≈ universal eq → k ≈ universal eq′ → j ≈ k
+  universal-resp-≈′ {j = j} {k = k} eq eq′ h₁≈i₁ h₂≈i₂ eqj eqk = begin
+    j ≈⟨ eqj ⟩
+    universal eq ≈⟨ universal-resp-≈ h₁≈i₁ h₂≈i₂ ⟩
+    universal eq′ ≈˘⟨ eqk ⟩
+    k ∎
+
 
   unique-diagram : p₁ ∘ h ≈ p₁ ∘ i →
                    p₂ ∘ h ≈ p₂ ∘ i →

--- a/src/Categories/Diagram/Pullback.agda
+++ b/src/Categories/Diagram/Pullback.agda
@@ -49,15 +49,6 @@ record Pullback (f : X ⇒ Z) (g : Y ⇒ Z) : Set (o ⊔ ℓ ⊔ e) where
   universal-resp-≈ : ∀ {eq : f ∘ h₁ ≈ g ∘ h₂} {eq′ : f ∘ i₁ ≈ g ∘ i₂} → h₁ ≈ i₁ → h₂ ≈ i₂ → universal eq ≈ universal eq′
   universal-resp-≈ h₁≈i₁ h₂≈i₂ = unique (p₁∘universal≈h₁ ○ h₁≈i₁) (p₂∘universal≈h₂ ○ h₂≈i₂)
 
-  universal-resp-≈′ : (eq : f ∘ h₁ ≈ g ∘ h₂) → (eq′ : f ∘ i₁ ≈ g ∘ i₂) →
-    h₁ ≈ i₁ → h₂ ≈ i₂ → j ≈ universal eq → k ≈ universal eq′ → j ≈ k
-  universal-resp-≈′ {j = j} {k = k} eq eq′ h₁≈i₁ h₂≈i₂ eqj eqk = begin
-    j ≈⟨ eqj ⟩
-    universal eq ≈⟨ universal-resp-≈ h₁≈i₁ h₂≈i₂ ⟩
-    universal eq′ ≈˘⟨ eqk ⟩
-    k ∎
-
-
   unique-diagram : p₁ ∘ h ≈ p₁ ∘ i →
                    p₂ ∘ h ≈ p₂ ∘ i →
                    h ≈ i

--- a/src/Categories/Diagram/Pullback.agda
+++ b/src/Categories/Diagram/Pullback.agda
@@ -11,8 +11,8 @@ open import Level
 open import Data.Product using (_,_; ∃)
 open import Function using (flip; _$_) renaming (_∘_ to _●_)
 open import Categories.Morphism C
-open import Categories.Object.Product C
-open import Categories.Diagram.Equalizer C
+open import Categories.Object.Product C hiding (up-to-iso; repack; repack∘; repack-cancel)
+open import Categories.Diagram.Equalizer C hiding (up-to-iso)
 open import Categories.Morphism.Reasoning C as Square
   renaming (glue to glue-square) hiding (id-unique)
 
@@ -66,6 +66,32 @@ record Pullback (f : X ⇒ Z) (g : Y ⇒ Z) : Set (o ⊔ ℓ ⊔ e) where
     universal eq ≈˘⟨ unique refl refl ⟩
     i            ∎
     where eq = extendʳ commute
+
+up-to-iso : (pullback pullback′ : Pullback f g) → Pullback.P pullback ≅ Pullback.P pullback′
+up-to-iso pullback pullback′ = record
+  { from = repack pullback pullback′
+  ; to = repack pullback′ pullback
+  ; iso = record
+    { isoˡ = repack-cancel pullback′ pullback
+    ; isoʳ = repack-cancel pullback pullback′
+    }
+  }
+  where
+    open Pullback
+
+    repack : (pullback pullback′ : Pullback f g) → P pullback ⇒ P pullback′
+    repack pullback pullback′ = universal pullback′ (commute pullback)
+
+    repack∘ : (pullback pullback′ pullback″ : Pullback f g) → repack pullback′ pullback″ ∘ repack pullback pullback′ ≈ repack pullback pullback″
+    repack∘ pullback pullback′ pullback″ =
+      unique pullback″
+             (glueTrianglesʳ (p₁∘universal≈h₁ pullback″) (p₁∘universal≈h₁ pullback′))
+             (glueTrianglesʳ (p₂∘universal≈h₂ pullback″) (p₂∘universal≈h₂ pullback′)) 
+
+    repack-cancel : (pullback pullback′ : Pullback f g) → repack pullback pullback′ ∘ repack pullback′ pullback ≈ id
+    repack-cancel pullback pullback′ = repack∘ pullback′ pullback pullback′ ○ ⟺ (id-unique pullback′)
+
+
 
 swap : Pullback f g → Pullback g f
 swap p = record


### PR DESCRIPTION
This PR adds some extra equality proofs to Pullback, mirroring similar proofs that can be found in [Categories.Diagram.Equalizer](https://github.com/agda/agda-categories/blob/master/src/Categories/Diagram/Equalizer.agda#L38). This also adds proofs that Equalizers and Pullbacks are unique up to isomorphism.