### PR TITLE
Add bundled forms of Epi and Monomorphisms, as well as some useful notation

### DIFF
--- a/src/Categories/Morphism.agda
+++ b/src/Categories/Morphism.agda
@@ -27,8 +27,8 @@ Mono {A = A} f = ∀ {C} → (g₁ g₂ : C ⇒ A) → f ∘ g₁ ≈ f ∘ g₂
 
 record _↣_ (A B : Obj) : Set (o ⊔ ℓ ⊔ e) where
   field
-    mor : A ⇒ B
-    mono  : Mono mor
+    mor  : A ⇒ B
+    mono : Mono mor
 
 Epi : ∀ (f : A ⇒ B) → Set (o ⊔ ℓ ⊔ e)
 Epi {B = B} f = ∀ {C} → (g₁ g₂ : B ⇒ C) → g₁ ∘ f ≈ g₂ ∘ f → g₁ ≈ g₂
@@ -36,7 +36,7 @@ Epi {B = B} f = ∀ {C} → (g₁ g₂ : B ⇒ C) → g₁ ∘ f ≈ g₂ ∘ f 
 record _↠_ (A B : Obj) : Set (o ⊔ ℓ ⊔ e) where
   field
     mor : A ⇒ B
-    epi  : Epi mor
+    epi : Epi mor
 
 _SectionOf_ : (g : B ⇒ A) (f : A ⇒ B) → Set e
 g SectionOf f = f ∘ g ≈ id

--- a/src/Categories/Morphism.agda
+++ b/src/Categories/Morphism.agda
@@ -7,7 +7,7 @@
   - Isomorphism
   - (object) equivalence ('spelled' _≅_ ). Exported as the module ≅
 -}
-open import Categories.Category
+open import Categories.Category.Core
 
 module Categories.Morphism {o ℓ e} (𝒞 : Category o ℓ e) where
 
@@ -25,8 +25,18 @@ private
 Mono : ∀ (f : A ⇒ B) → Set (o ⊔ ℓ ⊔ e)
 Mono {A = A} f = ∀ {C} → (g₁ g₂ : C ⇒ A) → f ∘ g₁ ≈ f ∘ g₂ → g₁ ≈ g₂
 
+record _↣_ (A B : Obj) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    mor : A ⇒ B
+    mono  : Mono mor
+
 Epi : ∀ (f : A ⇒ B) → Set (o ⊔ ℓ ⊔ e)
 Epi {B = B} f = ∀ {C} → (g₁ g₂ : B ⇒ C) → g₁ ∘ f ≈ g₂ ∘ f → g₁ ≈ g₂
+
+record _↠_ (A B : Obj) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    mor : A ⇒ B
+    epi  : Epi mor
 
 _SectionOf_ : (g : B ⇒ A) (f : A ⇒ B) → Set e
 g SectionOf f = f ∘ g ≈ id

--- a/src/Categories/Morphism/Notation.agda
+++ b/src/Categories/Morphism/Notation.agda
@@ -1,0 +1,24 @@
+{-# OPTIONS --without-K --safe #-}
+
+{-
+  Useful notation for Epimorphisms, Mononmorphisms, and isomorphisms
+-}
+module Categories.Morphism.Notation where
+
+open import Level
+
+open import Categories.Category.Core
+open import Categories.Morphism
+
+private
+  variable
+    o ℓ e : Level
+
+_[_↣_] : (𝒞 : Category o ℓ e) → (A B : Category.Obj 𝒞) → Set (o ⊔ ℓ ⊔ e)
+𝒞 [ A ↣ B ] = _↣_ 𝒞 A B
+
+_[_↠_] : (𝒞 : Category o ℓ e) → (A B : Category.Obj 𝒞) → Set (o ⊔ ℓ ⊔ e)
+𝒞 [ A ↠ B ] = _↠_ 𝒞 A B
+
+_[_≅_] : (𝒞 : Category o ℓ e) → (A B : Category.Obj 𝒞) → Set (ℓ ⊔ e)
+𝒞 [ A ≅ B ] = _≅_ 𝒞 A B


### PR DESCRIPTION
This PR adds a bundled forms of Epi and Monomorphisms, which can make some type signatures a little bit nicer. It also adds some notation similar to that found in `Categories.Category` for Epi, Mono, and Isomorphisms, which can make things nicer in contexts where you have multiple categories.

## Notes
I'm not super set on the name of `Categories.Morphism.Notation`, but I didn't want to do something like `Categories.Morphism.Core`, as doing so might break existing imports of the form `open import Categories.Morphism C`.
However, maybe it is best to just make the (slight) breaking change.