### PR TITLE
Implement Subobjects, as well as the subobject presheaf

### DIFF
--- a/Everything.agda
+++ b/Everything.agda
@@ -296,6 +296,8 @@ import Categories.Object.Product.Indexed
 import Categories.Object.Product.Indexed.Properties
 import Categories.Object.Product.Limit
 import Categories.Object.Product.Morphisms
+import Categories.Object.Subobject
+import Categories.Object.Subobject.Properties
 import Categories.Object.Terminal
 import Categories.Object.Terminal.Limit
 import Categories.Object.Zero

--- a/src/Categories/Category/Instance/Posets.agda
+++ b/src/Categories/Category/Instance/Posets.agda
@@ -53,5 +53,4 @@ Posets c ℓ₁ ℓ₂ = record
   ; equiv     = ≗-isEquivalence
   ; ∘-resp-≈  = λ {_ _ C _ h} f≈h g≈i → Eq.trans C f≈h (fun-resp-≈ h g≈i)
   }
-  where
 

--- a/src/Categories/Diagram/Pullback/Properties.agda
+++ b/src/Categories/Diagram/Pullback/Properties.agda
@@ -63,6 +63,25 @@ module _ (p : Pullback f g) where
     ; p₂∘universal≈h₂ = p₂∘universal≈h₂
     }
 
+-- Some facts about pulling back along identity
+module _ (p : Pullback id f) where
+  open Pullback p
+
+  -- This is a more subtle way of saying that 'p₂ ≈ id', without involving heterogenous equality.
+  pullback-identity : universal id-comm-sym ∘ p₂ ≈ id
+  pullback-identity = begin
+    universal Basic.id-comm-sym ∘ p₂ ≈⟨ unique ( pullˡ p₁∘universal≈h₁ ) (pullˡ p₂∘universal≈h₂)  ⟩
+    universal eq                     ≈⟨ universal-resp-≈ (⟺ commute ○ identityˡ) identityˡ ⟩
+    universal commute                ≈˘⟨ Pullback.id-unique p ⟩
+    id ∎
+    where
+      eq : id ∘ f ∘ p₂ ≈ f ∘ id ∘ p₂
+      eq = begin
+        (id ∘ f ∘ p₂) ≈⟨ elimˡ Equiv.refl ⟩
+        (f ∘ p₂)      ≈˘⟨ refl⟩∘⟨ identityˡ ⟩
+        (f ∘ id ∘ p₂) ∎
+
+
 module _ (pullbacks : ∀ {X Y Z} (f : X ⇒ Z) (g : Y ⇒ Z) → Pullback f g)
          (cartesian : Cartesian) where
   open Cartesian cartesian

--- a/src/Categories/Object/Subobject.agda
+++ b/src/Categories/Object/Subobject.agda
@@ -1,0 +1,77 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category
+
+module Categories.Object.Subobject {o ℓ e} (𝒞 : Category o ℓ e) where
+
+open import Level
+open import Data.Product
+open import Data.Unit
+
+open import Relation.Binary using (Poset)
+
+open import Categories.Functor
+open import Categories.Category.Construction.Comma
+open import Categories.Category.SubCategory
+open import Categories.Category.Construction.Thin
+import Categories.Morphism as Mor
+import Categories.Morphism.Reasoning as MR
+open import Categories.Morphism.Notation
+
+private
+  module 𝒞 = Category 𝒞
+
+-- The Full Subcategory of the over category 𝒞/c on monomorphisms
+over-mono : 𝒞.Obj → Category _ _ _
+over-mono c = FullSubCategory (𝒞 / c) {I = Σ[ α ∈ 𝒞.Obj ](α ↣ c)} λ (_ , i) → record
+  { f = mor i
+  }
+  where open Mor 𝒞
+        open _↣_
+
+-- Poset of subobjects for some c ∈ 𝒞
+Subobjects : 𝒞.Obj → Poset _ _ _
+Subobjects c = record
+  { Carrier = 𝒞ᶜ.Obj
+  ; _≈_ = 𝒞ᶜ [_≅_]
+  ; _≤_ = 𝒞ᶜ [_,_]
+  ; isPartialOrder = record
+    { isPreorder = record
+      { isEquivalence = Mor.≅-isEquivalence 𝒞ᶜ
+      ; reflexive = λ iso → Mor._≅_.from iso
+      ; trans = λ {(α , f) (β , g) (γ , h)} i j → record
+        { g = 𝒞 [ Comma⇒.g j ∘ Comma⇒.g i ]
+        ; h = lift tt
+        ; commute =  𝒞.identityˡ ○ ⟺ (chase f g h i j)
+        }
+      }
+    ; antisym = λ {(α , f) (β , g)} h i → record
+      { from = h
+      ; to = i
+      ; iso = record
+        { isoˡ = mono f _ _ (chase f g f h i ○ ⟺ 𝒞.identityʳ) , lift tt
+        ; isoʳ = mono g _ _ (chase g f g i h ○ ⟺ 𝒞.identityʳ) , lift tt
+        }
+      }
+    }
+  }
+  where
+    𝒞ᶜ : Category _ _ _
+    𝒞ᶜ = over-mono c
+
+    module 𝒞ᶜ = Category 𝒞ᶜ
+
+    open Mor 𝒞 using (_↣_)
+    open MR 𝒞
+    open 𝒞.HomReasoning
+    open _↣_
+
+    chase : ∀ {α β γ : 𝒞.Obj} (f : 𝒞 [ α ↣ c ]) (g : 𝒞 [ β ↣ c ]) (h : 𝒞 [ γ ↣ c ])
+            → (i : 𝒞ᶜ [ (α , f) , (β , g) ]) → (j : 𝒞ᶜ [ (β , g) , (γ , h) ])
+            → 𝒞 [ 𝒞 [ mor h ∘ 𝒞 [ Comma⇒.g j ∘ Comma⇒.g i ] ] ≈ mor f ]
+    chase f g h i j = begin
+      𝒞 [ mor h ∘ 𝒞 [ Comma⇒.g j ∘ Comma⇒.g i ] ] ≈⟨ pullˡ (⟺ (Comma⇒.commute j)) ⟩
+      𝒞 [ 𝒞 [ 𝒞.id ∘ mor g ] ∘ Comma⇒.g i ]       ≈⟨ 𝒞.identityˡ ⟩∘⟨refl ⟩
+      𝒞 [ mor g ∘ Comma⇒.g i ]                    ≈˘⟨ Comma⇒.commute i ⟩
+      𝒞 [ 𝒞.id ∘ mor f ]                          ≈⟨ 𝒞.identityˡ ⟩
+      mor f ∎

--- a/src/Categories/Object/Subobject.agda
+++ b/src/Categories/Object/Subobject.agda
@@ -11,7 +11,7 @@ open import Data.Unit
 open import Relation.Binary using (Poset)
 
 open import Categories.Functor
-open import Categories.Category.Construction.Comma
+open import Categories.Category.Slice
 open import Categories.Category.SubCategory
 open import Categories.Category.Construction.Thin
 import Categories.Morphism as Mor
@@ -22,10 +22,8 @@ private
   module 𝒞 = Category 𝒞
 
 -- The Full Subcategory of the over category 𝒞/c on monomorphisms
-over-mono : 𝒞.Obj → Category _ _ _
-over-mono c = FullSubCategory (𝒞 / c) {I = Σ[ α ∈ 𝒞.Obj ](α ↣ c)} λ (_ , i) → record
-  { f = mor i
-  }
+slice-mono : 𝒞.Obj → Category _ _ _
+slice-mono c = FullSubCategory (Slice 𝒞 c) {I = Σ[ α ∈ 𝒞.Obj ](α ↣ c)} λ (_ , i) → sliceobj (mor i)
   where open Mor 𝒞
         open _↣_
 
@@ -39,25 +37,21 @@ Subobjects c = record
     { isPreorder = record
       { isEquivalence = Mor.≅-isEquivalence 𝒞ᶜ
       ; reflexive = λ iso → Mor._≅_.from iso
-      ; trans = λ {(α , f) (β , g) (γ , h)} i j → record
-        { g = 𝒞 [ Comma⇒.g j ∘ Comma⇒.g i ]
-        ; h = lift tt
-        ; commute =  𝒞.identityˡ ○ ⟺ (chase f g h i j)
-        }
+      ; trans = λ {(α , f) (β , g) (γ , h)} i j → slicearr (chase f g h i j)
       }
     ; antisym = λ {(α , f) (β , g)} h i → record
       { from = h
       ; to = i
       ; iso = record
-        { isoˡ = mono f _ _ (chase f g f h i ○ ⟺ 𝒞.identityʳ) , lift tt
-        ; isoʳ = mono g _ _ (chase g f g i h ○ ⟺ 𝒞.identityʳ) , lift tt
+        { isoˡ = mono f _ _ (chase f g f h i ○ ⟺ 𝒞.identityʳ)
+        ; isoʳ = mono g _ _ (chase g f g i h ○ ⟺ 𝒞.identityʳ)
         }
       }
     }
   }
   where
     𝒞ᶜ : Category _ _ _
-    𝒞ᶜ = over-mono c
+    𝒞ᶜ = slice-mono c
 
     module 𝒞ᶜ = Category 𝒞ᶜ
 
@@ -68,10 +62,8 @@ Subobjects c = record
 
     chase : ∀ {α β γ : 𝒞.Obj} (f : 𝒞 [ α ↣ c ]) (g : 𝒞 [ β ↣ c ]) (h : 𝒞 [ γ ↣ c ])
             → (i : 𝒞ᶜ [ (α , f) , (β , g) ]) → (j : 𝒞ᶜ [ (β , g) , (γ , h) ])
-            → 𝒞 [ 𝒞 [ mor h ∘ 𝒞 [ Comma⇒.g j ∘ Comma⇒.g i ] ] ≈ mor f ]
+            → 𝒞 [ 𝒞 [ mor h ∘ 𝒞 [ Slice⇒.h j ∘ Slice⇒.h i ] ] ≈ mor f ]
     chase f g h i j = begin
-      𝒞 [ mor h ∘ 𝒞 [ Comma⇒.g j ∘ Comma⇒.g i ] ] ≈⟨ pullˡ (⟺ (Comma⇒.commute j)) ⟩
-      𝒞 [ 𝒞 [ 𝒞.id ∘ mor g ] ∘ Comma⇒.g i ]       ≈⟨ 𝒞.identityˡ ⟩∘⟨refl ⟩
-      𝒞 [ mor g ∘ Comma⇒.g i ]                    ≈˘⟨ Comma⇒.commute i ⟩
-      𝒞 [ 𝒞.id ∘ mor f ]                          ≈⟨ 𝒞.identityˡ ⟩
+      𝒞 [ mor h ∘ 𝒞 [ Slice⇒.h j ∘ Slice⇒.h i ] ] ≈⟨ pullˡ (Slice⇒.△ j)  ⟩
+      𝒞 [ mor g ∘ Slice⇒.h i ]                    ≈⟨ Slice⇒.△ i ⟩
       mor f ∎

--- a/src/Categories/Object/Subobject/Properties.agda
+++ b/src/Categories/Object/Subobject/Properties.agda
@@ -31,7 +31,6 @@ module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f
   private
     module 𝒞 = Category 𝒞
 
-  open 𝒞
   open 𝒞.HomReasoning
   open 𝒞.Equiv
 
@@ -40,7 +39,7 @@ module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f
   open _↣_
 
   -- The Subobject functor, into the category of posets
-  -- FIXME I should probably tidy up this proof a lot
+  -- FIXME: I should probably tidy up this proof a lot
   -- For starters, we only ever use composition/equality in 𝒞.
   -- Then, it feels like the 'homomorphism' and 'F-resp-≈' cases
   -- are pretty much the same
@@ -141,7 +140,6 @@ module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f
         }
 
   -- The subobject functor as a presheaf on Setoids.
-  -- This is just Subₚ composedd with the 'Core'
-  -- functor
+  -- This is just Subₚ composed with the 'Core'
   Sub : Presheaf 𝒞 (Setoids (o ⊔ ℓ ⊔ e) (ℓ ⊔ e))
   Sub =  Core ∘F Subₚ

--- a/src/Categories/Object/Subobject/Properties.agda
+++ b/src/Categories/Object/Subobject/Properties.agda
@@ -14,11 +14,14 @@ open import Relation.Binary.OrderMorphism
 
 open import Categories.Category
 open import Categories.Functor
+open import Categories.Functor.Presheaf
 open import Categories.Category.Construction.Comma
 open import Categories.Object.Subobject
 open import Categories.Diagram.Pullback renaming (glue to glue-pullback)
 open import Categories.Diagram.Pullback.Properties
 open import Categories.Category.Instance.Posets
+open import Categories.Category.Instance.Setoids
+open import Categories.Adjoint.Instance.PosetCore
 import Categories.Morphism as Mor
 import Categories.Morphism.Reasoning as MR
 open import Categories.Morphism.Notation
@@ -42,7 +45,7 @@ module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f
   -- Then, it feels like the 'homomorphism' and 'F-resp-≈' cases
   -- are pretty much the same
   -- We also should probably open Pullback at 𝒞
-  Subₚ : Functor 𝒞.op (Posets (o ⊔ ℓ ⊔ e) (ℓ ⊔ e) (ℓ ⊔ e))
+  Subₚ : Presheaf 𝒞 (Posets (o ⊔ ℓ ⊔ e) (ℓ ⊔ e) (ℓ ⊔ e))
   Subₚ = record
     { F₀ = Subobjects 𝒞
     ; F₁ = λ f → record
@@ -136,3 +139,9 @@ module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f
           Pullback.p₁ pm ≈˘⟨ Pullback.p₁∘universal≈h₁ pn ⟩
           𝒞 [ Pullback.p₁ pn ∘ Pullback.universal pn _ ] ∎
         }
+
+  -- The subobject functor as a presheaf on Setoids.
+  -- This is just Subₚ composedd with the 'Core'
+  -- functor
+  Sub : Presheaf 𝒞 (Setoids (o ⊔ ℓ ⊔ e) (ℓ ⊔ e))
+  Sub =  Core ∘F Subₚ

--- a/src/Categories/Object/Subobject/Properties.agda
+++ b/src/Categories/Object/Subobject/Properties.agda
@@ -15,7 +15,7 @@ open import Relation.Binary.OrderMorphism
 open import Categories.Category
 open import Categories.Functor
 open import Categories.Functor.Presheaf
-open import Categories.Category.Construction.Comma
+open import Categories.Category.Slice
 open import Categories.Object.Subobject
 open import Categories.Diagram.Pullback renaming (glue to glue-pullback)
 open import Categories.Diagram.Pullback.Properties
@@ -39,11 +39,6 @@ module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f
   open _↣_
 
   -- The Subobject functor, into the category of posets
-  -- FIXME: I should probably tidy up this proof a lot
-  -- For starters, we only ever use composition/equality in 𝒞.
-  -- Then, it feels like the 'homomorphism' and 'F-resp-≈' cases
-  -- are pretty much the same
-  -- We also should probably open Pullback at 𝒞
   Subₚ : Presheaf 𝒞 (Posets (o ⊔ ℓ ⊔ e) (ℓ ⊔ e) (ℓ ⊔ e))
   Subₚ = record
     { F₀ = Subobjects 𝒞
@@ -55,18 +50,16 @@ module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f
       let pid = has-pullbacks 𝒞.id (mor m)
       in record
         { from = record
-          { g = Pullback.p₂ pid
-          ; h = lift tt
-          ; commute = Pullback.commute pid
+          { h = Pullback.p₂ pid
+          ; △ = ⟺ (Pullback.commute pid) ○ 𝒞.identityˡ
           }
         ; to = record
-          { g = Pullback.universal pid id-comm-sym
-          ; h = lift tt
-          ; commute = 𝒞.identityˡ ○ ⟺ (Pullback.p₁∘universal≈h₁ pid)
+          { h = Pullback.universal pid id-comm-sym
+          ; △ = Pullback.p₁∘universal≈h₁ pid
           }
         ; iso = record
-          { isoˡ = (pullback-identity 𝒞 pid) , lift tt
-          ; isoʳ = (Pullback.p₂∘universal≈h₂ pid) , lift tt
+          { isoˡ = pullback-identity 𝒞 pid
+          ; isoʳ = Pullback.p₂∘universal≈h₂ pid
           }
         }
     ; homomorphism = λ {X} {Y} {Z} {f} {g} {(α , m)} →
@@ -77,18 +70,16 @@ module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f
           module iso = _≅_ iso
       in record
         { from = record
-          { g = iso.from
-          ; h = lift tt
-          ; commute = 𝒞.identityˡ ○ ⟺ (Pullback.p₁∘universal≈h₁ pg)
+          { h = iso.from
+          ; △ = Pullback.p₁∘universal≈h₁ pg
           }
         ; to = record
-          { g = iso.to
-          ; h = lift tt
-          ; commute = 𝒞.identityˡ ○ ⟺ (Pullback.p₁∘universal≈h₁ pfg)
+          { h = iso.to
+          ; △ = Pullback.p₁∘universal≈h₁ pfg
           }
         ; iso = record
-          { isoˡ = iso.isoˡ , lift tt
-          ; isoʳ = iso.isoʳ , lift tt
+          { isoˡ = iso.isoˡ
+          ; isoʳ = iso.isoʳ
           }
         }
     ; F-resp-≈ = λ {A B f g} eq {(α , m)} →
@@ -98,18 +89,16 @@ module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f
           module iso = _≅_ iso
       in record
         { from = record
-          { g = iso.from
-          ; h = lift tt
-          ; commute = 𝒞.identityˡ ○ ⟺ (Pullback.p₁∘universal≈h₁ pg)
+          { h = iso.from
+          ; △ = Pullback.p₁∘universal≈h₁ pg
           }
         ; to = record
-          { g = iso.to
-          ; h = lift tt
-          ; commute = 𝒞.identityˡ ○ ⟺ (Pullback.p₁∘universal≈h₁ pf)
+          { h = iso.to
+          ; △ = Pullback.p₁∘universal≈h₁ pf
           }
         ; iso = record
-          { isoˡ = iso.isoˡ , lift tt
-          ; isoʳ = iso.isoʳ , lift tt
+          { isoˡ = iso.isoˡ
+          ; isoʳ = iso.isoʳ
           }
         }
     }
@@ -127,17 +116,12 @@ module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f
         let pm = has-pullbacks f (mor m)
             pn = has-pullbacks f (mor n)
         in record
-        { g = Pullback.universal pn $ begin
-          𝒞 [ f ∘ Pullback.p₁ pm ] ≈˘⟨ 𝒞.identityˡ ⟩
-          𝒞 [ 𝒞.id ∘ 𝒞 [ f ∘ Pullback.p₁ pm ] ] ≈⟨ pushʳ (Pullback.commute pm) ⟩
-          𝒞 [ 𝒞 [ 𝒞.id ∘ mor m ] ∘ Pullback.p₂ pm ] ≈⟨ pushˡ (Comma⇒.commute h) ⟩
-          𝒞 [ mor n ∘ 𝒞 [ Comma⇒.g h ∘ Pullback.p₂ pm ] ] ∎
-        ; h = lift tt
-        ; commute = begin
-          𝒞 [ 𝒞.id ∘ Pullback.p₁ pm ] ≈⟨ 𝒞.identityˡ ⟩
-          Pullback.p₁ pm ≈˘⟨ Pullback.p₁∘universal≈h₁ pn ⟩
-          𝒞 [ Pullback.p₁ pn ∘ Pullback.universal pn _ ] ∎
-        }
+          { h = Pullback.universal pn $ begin
+              𝒞 [ f ∘ Pullback.p₁ pm ] ≈⟨ Pullback.commute pm ⟩
+              𝒞 [ mor m ∘ Pullback.p₂ pm ] ≈⟨ pushˡ (⟺ (Slice⇒.△ h)) ⟩
+              𝒞 [ mor n ∘ 𝒞 [ Slice⇒.h h ∘ Pullback.p₂ pm ] ] ∎
+          ; △ = Pullback.p₁∘universal≈h₁ pn
+          }
 
   -- The subobject functor as a presheaf on Setoids.
   -- This is just Subₚ composed with the 'Core'

--- a/src/Categories/Object/Subobject/Properties.agda
+++ b/src/Categories/Object/Subobject/Properties.agda
@@ -1,0 +1,138 @@
+{-# OPTIONS --without-K --safe #-}
+
+
+module Categories.Object.Subobject.Properties where
+
+open import Level
+open import Data.Product
+open import Data.Unit
+open import Function using (_$_)
+
+open import Relation.Binary using (_=[_]⇒_)
+open import Relation.Binary.Bundles
+open import Relation.Binary.OrderMorphism
+
+open import Categories.Category
+open import Categories.Functor
+open import Categories.Category.Construction.Comma
+open import Categories.Object.Subobject
+open import Categories.Diagram.Pullback renaming (glue to glue-pullback)
+open import Categories.Diagram.Pullback.Properties
+open import Categories.Category.Instance.Posets
+import Categories.Morphism as Mor
+import Categories.Morphism.Reasoning as MR
+open import Categories.Morphism.Notation
+
+
+module _ {o ℓ e} {𝒞 : Category o ℓ e} (has-pullbacks : ∀ {A B X} → (f : 𝒞 [ A , X ]) → (g : 𝒞 [ B , X ]) → Pullback 𝒞 f g) where
+  private
+    module 𝒞 = Category 𝒞
+
+  open 𝒞
+  open 𝒞.HomReasoning
+  open 𝒞.Equiv
+
+  open Mor 𝒞
+  open MR 𝒞
+  open _↣_
+
+  -- The Subobject functor, into the category of posets
+  -- FIXME I should probably tidy up this proof a lot
+  -- For starters, we only ever use composition/equality in 𝒞.
+  -- Then, it feels like the 'homomorphism' and 'F-resp-≈' cases
+  -- are pretty much the same
+  -- We also should probably open Pullback at 𝒞
+  Subₚ : Functor 𝒞.op (Posets (o ⊔ ℓ ⊔ e) (ℓ ⊔ e) (ℓ ⊔ e))
+  Subₚ = record
+    { F₀ = Subobjects 𝒞
+    ; F₁ = λ f → record
+      { fun = morphism f
+      ; monotone = λ {(α , m) (β , n)} h → monotone f {(α , m)} {β , n} h
+      }
+    ; identity = λ {A} {(α , m)} →
+      let pid = has-pullbacks 𝒞.id (mor m)
+      in record
+        { from = record
+          { g = Pullback.p₂ pid
+          ; h = lift tt
+          ; commute = Pullback.commute pid
+          }
+        ; to = record
+          { g = Pullback.universal pid id-comm-sym
+          ; h = lift tt
+          ; commute = 𝒞.identityˡ ○ ⟺ (Pullback.p₁∘universal≈h₁ pid)
+          }
+        ; iso = record
+          { isoˡ = (pullback-identity 𝒞 pid) , lift tt
+          ; isoʳ = (Pullback.p₂∘universal≈h₂ pid) , lift tt
+          }
+        }
+    ; homomorphism = λ {X} {Y} {Z} {f} {g} {(α , m)} →
+      let pfg = has-pullbacks (𝒞 [ f ∘ g ]) (mor m)
+          pf = has-pullbacks f (mor m)
+          pg = has-pullbacks g (Pullback.p₁ pf)
+          iso = up-to-iso 𝒞 pfg (glue-pullback 𝒞 pf pg)
+          module iso = _≅_ iso
+      in record
+        { from = record
+          { g = iso.from
+          ; h = lift tt
+          ; commute = 𝒞.identityˡ ○ ⟺ (Pullback.p₁∘universal≈h₁ pg)
+          }
+        ; to = record
+          { g = iso.to
+          ; h = lift tt
+          ; commute = 𝒞.identityˡ ○ ⟺ (Pullback.p₁∘universal≈h₁ pfg)
+          }
+        ; iso = record
+          { isoˡ = iso.isoˡ , lift tt
+          ; isoʳ = iso.isoʳ , lift tt
+          }
+        }
+    ; F-resp-≈ = λ {A B f g} eq {(α , m)} →
+      let pf = has-pullbacks f (mor m)
+          pg = has-pullbacks g (mor m)
+          iso = up-to-iso 𝒞 pf (pullback-resp-≈ 𝒞 pg (sym eq) refl)
+          module iso = _≅_ iso
+      in record
+        { from = record
+          { g = iso.from
+          ; h = lift tt
+          ; commute = 𝒞.identityˡ ○ ⟺ (Pullback.p₁∘universal≈h₁ pg)
+          }
+        ; to = record
+          { g = iso.to
+          ; h = lift tt
+          ; commute = 𝒞.identityˡ ○ ⟺ (Pullback.p₁∘universal≈h₁ pf)
+          }
+        ; iso = record
+          { isoˡ = iso.isoˡ , lift tt
+          ; isoʳ = iso.isoʳ , lift tt
+          }
+        }
+    }
+    where
+      morphism : ∀ {A B} → (f : 𝒞 [ B , A ]) → Σ[ α ∈ 𝒞.Obj ] (α ↣ A) → Σ[ β ∈ 𝒞.Obj ] (β ↣ B)
+      morphism f (α , m) = 
+        let pb = has-pullbacks f (mor m)
+        in Pullback.P pb , record
+          { mor = Pullback.p₁ pb
+          ; mono = Pullback-resp-Mono 𝒞 pb (mono m)
+          }
+
+      monotone : ∀ {A B} (f : 𝒞 [ B , A ]) → Poset._≤_ (Subobjects 𝒞 A) =[ morphism f ]⇒ Poset._≤_ (Subobjects 𝒞 B)
+      monotone f {(α , m)} {(β , n)} h =
+        let pm = has-pullbacks f (mor m)
+            pn = has-pullbacks f (mor n)
+        in record
+        { g = Pullback.universal pn $ begin
+          𝒞 [ f ∘ Pullback.p₁ pm ] ≈˘⟨ 𝒞.identityˡ ⟩
+          𝒞 [ 𝒞.id ∘ 𝒞 [ f ∘ Pullback.p₁ pm ] ] ≈⟨ pushʳ (Pullback.commute pm) ⟩
+          𝒞 [ 𝒞 [ 𝒞.id ∘ mor m ] ∘ Pullback.p₂ pm ] ≈⟨ pushˡ (Comma⇒.commute h) ⟩
+          𝒞 [ mor n ∘ 𝒞 [ Comma⇒.g h ∘ Pullback.p₂ pm ] ] ∎
+        ; h = lift tt
+        ; commute = begin
+          𝒞 [ 𝒞.id ∘ Pullback.p₁ pm ] ≈⟨ 𝒞.identityˡ ⟩
+          Pullback.p₁ pm ≈˘⟨ Pullback.p₁∘universal≈h₁ pn ⟩
+          𝒞 [ Pullback.p₁ pn ∘ Pullback.universal pn _ ] ∎
+        }


### PR DESCRIPTION
This PR defines a notion of subobject, and also implements the subobject presheaf. This PR builds off of #202, so that should get merged before this. This should also close #203.

## Notes
Interestingly, we don't need to say that 𝒞 is well-powered for this to work! I'm a bit of a novice on size issues in general, but I suspect that the notion of "well-poweredness" does not apply for this library.

## References
https://ncatlab.org/nlab/show/subobject
Categories For the Working Mathematician, V.7
Sheaves in Geometry and Logic, I.3