### PR TITLE
Rename 'limit⇒⊥' to 'limit⇒⊤' in 'Categories.Object.Terminal.Limit'

### DIFF
--- a/Everything.agda
+++ b/Everything.agda
@@ -269,6 +269,7 @@ import Categories.Morphism.HeterogeneousIdentity
 import Categories.Morphism.HeterogeneousIdentity.Properties
 import Categories.Morphism.IsoEquiv
 import Categories.Morphism.Isomorphism
+import Categories.Morphism.Notation
 import Categories.Morphism.Properties
 import Categories.Morphism.Reasoning
 import Categories.Morphism.Reasoning.Core

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ html: Everything.agda
 	agda ${RTSARGS} --html -i. Everything.agda
 
 Everything.agda:
-	find src/ -name '[^\.]*.agda' | sed -e 's|^src/[/]*|import |' -e 's|/|.|g' -e 's/.agda//' -e '/import Everything/d' | LC_COLLATE='C' sort > Everything.agda
+	git ls-tree --full-tree -r --name-only HEAD | grep '^src/[^\.]*.agda' | sed -e 's|^src/[/]*|import |' -e 's|/|.|g' -e 's/.agda//' -e '/import Everything/d' | LC_COLLATE='C' sort > Everything.agda
 
 clean:
 	find . -name '*.agdai' -exec rm \{\} \;

--- a/src/Categories/Category/Complete/Properties.agda
+++ b/src/Categories/Category/Complete/Properties.agda
@@ -43,7 +43,7 @@ module _ (Com : Complete o′ ℓ′ e′ C) where
   Complete⇒FinitelyComplete : FinitelyComplete C
   Complete⇒FinitelyComplete = record
     { cartesian = record
-      { terminal = limit⇒⊥ (Com (⊥⇒limit-F _ _ _))
+      { terminal = limit⇒⊤ (Com (⊤⇒limit-F _ _ _))
       ; products = record
         { product = λ {A B} → limit⇒product (Com (product⇒limit-F _ _ _ A B))
         }

--- a/src/Categories/Object/Terminal/Limit.agda
+++ b/src/Categories/Object/Terminal/Limit.agda
@@ -17,8 +17,8 @@ private
   open C
 
 module _ {o′ ℓ′ e′} {F : Functor (liftC o′ ℓ′ e′ (Discrete 0)) C} where
-  limit⇒⊥ : Limit F → Terminal
-  limit⇒⊥ L = record
+  limit⇒⊤ : Limit F → Terminal
+  limit⇒⊤ L = record
     { ⊤        = apex
     ; ⊤-is-terminal = record
       { !        = rep record
@@ -37,8 +37,8 @@ module _ {o′ ℓ′ e′} {F : Functor (liftC o′ ℓ′ e′ (Discrete 0)) C
 
 module _ o′ ℓ′ e′ where
 
-  ⊥⇒limit-F : Functor (liftC o′ ℓ′ e′ (Discrete 0)) C
-  ⊥⇒limit-F = record
+  ⊤⇒limit-F : Functor (liftC o′ ℓ′ e′ (Discrete 0)) C
+  ⊤⇒limit-F = record
     { F₀           = λ ()
     ; F₁           = λ { {()} }
     ; identity     = λ { {()} }
@@ -46,8 +46,8 @@ module _ o′ ℓ′ e′ where
     ; F-resp-≈     = λ { {()} }
     }
 
-  ⊥⇒limit : Terminal → Limit ⊥⇒limit-F
-  ⊥⇒limit t = record
+  ⊤⇒limit : Terminal → Limit ⊤⇒limit-F
+  ⊤⇒limit t = record
     { terminal = record
       { ⊤        = record
         { N    = ⊤
@@ -58,13 +58,13 @@ module _ o′ ℓ′ e′ where
         }
       ; ⊤-is-terminal = record
         { !        = λ {K} →
-          let open Co.Cone ⊥⇒limit-F K
+          let open Co.Cone ⊤⇒limit-F K
           in record
           { arr     = !
           ; commute = λ { {()} }
           }
         ; !-unique = λ f →
-          let module f = Co.Cone⇒ ⊥⇒limit-F f
+          let module f = Co.Cone⇒ ⊤⇒limit-F f
           in !-unique f.arr
         }
       }


### PR DESCRIPTION
This PR updates the name of `limit⇒⊥` to `limit⇒⊤` in `Categories.Object.Limit`. It also updates the `Makefile` to only add tracked files to `Everything.agda`, to make it easier to deal with experiments that aren't tracked.