### PR TITLE
Move monoidal properties of cartesian categories into separate modules

### DIFF
--- a/src/Categories/Category/Cartesian.agda
+++ b/src/Categories/Category/Cartesian.agda
@@ -262,6 +262,11 @@ record Cartesian : Set (levelOfTerm 𝒞) where
   power A 1 = A
   power A (suc (suc n)) = A × power A (suc n)
 
+-- The cartesian structure induces a monoidal one: 𝒞 is cartesian monoidal.
+
+module CartesianMonoidal (cartesian : Cartesian) where
+  open Cartesian cartesian
+
   ⊤×A≅A : ⊤ × A ≅ A
   ⊤×A≅A = record
     { from = π₂
@@ -372,9 +377,11 @@ record Cartesian : Set (levelOfTerm 𝒞) where
         ∎
     }
 
-  module monoidal = Monoidal monoidal
-  open monoidal using (_⊗₁_)
+  open Monoidal monoidal public
 
+module CartesianSymmetricMonoidal (cartesian : Cartesian) where
+  open Cartesian cartesian
+  open CartesianMonoidal cartesian
   open Sym monoidal
 
   symmetric : Symmetric
@@ -405,5 +412,4 @@ record Cartesian : Set (levelOfTerm 𝒞) where
         assocˡ ∘ swap ∘ assocˡ                                    ∎
     }
 
-  module symmetric = Symmetric symmetric
-  open symmetric public
+  open Symmetric symmetric public

--- a/src/Categories/Category/Cartesian/Structure.agda
+++ b/src/Categories/Category/Cartesian/Structure.agda
@@ -23,5 +23,5 @@ record CartesianCategory o ℓ e : Set (suc (o ⊔ ℓ ⊔ e)) where
   monoidalCategory : MonoidalCategory o ℓ e
   monoidalCategory = record
     { U        = U
-    ; monoidal = monoidal
+    ; monoidal = CartesianMonoidal.monoidal U cartesian
     }

--- a/src/Categories/Category/CartesianClosed.agda
+++ b/src/Categories/Category/CartesianClosed.agda
@@ -50,6 +50,7 @@ record CartesianClosed : Set (levelOfTerm 𝒞) where
   module cartesian = Cartesian cartesian
 
   open cartesian public
+  open CartesianMonoidal cartesian using (A×⊤≅A)
 
   B^A×A : ∀ B A → Product (B ^ A) A
   B^A×A B A = exp.product {A} {B}
@@ -201,69 +202,75 @@ record CartesianClosed : Set (levelOfTerm 𝒞) where
   -⇨_ : Obj → Functor 𝒞.op 𝒞
   -⇨_ = appʳ -⇨-
 
-  module _ where
-    private
-      A⇨[-×A] : Obj → Endofunctor 𝒞
-      A⇨[-×A] A = A ⇨- ∘F -× A
+-- The cartesian closed structure induces a monoidal closed one:
+-- 𝒞 is cartesian monoidal closed.
 
-      module A⇨[-×A] {A} = Functor (A⇨[-×A] A)
+module CartesianMonoidalClosed (cartesianClosed : CartesianClosed) where
+  open CartesianClosed cartesianClosed
+  open CartesianMonoidal cartesian using (monoidal)
 
-      [A⇨-]×A : Obj → Endofunctor 𝒞
-      [A⇨-]×A A = -× A ∘F A ⇨-
+  private
+    A⇨[-×A] : Obj → Endofunctor 𝒞
+    A⇨[-×A] A = A ⇨- ∘F -× A
 
-      module [A⇨-]×A {A} = Functor ([A⇨-]×A A)
+    module A⇨[-×A] {A} = Functor (A⇨[-×A] A)
 
-    closedMonoidal : Closed monoidal
-    closedMonoidal = record
-      { [-,-]   = -⇨-
-      ; adjoint = λ {A} → record
-        { unit   = ntHelper record
-          { η       = λ _ → λg id
-          ; commute = λ f → λ-unique₂′ $ begin
-            eval′ ∘ first (λg id ∘ f)                     ≈˘⟨ refl⟩∘⟨ first∘first ⟩
-            eval′ ∘ first (λg id) ∘ first f               ≈⟨ cancelˡ β′ ⟩
-            first f                                       ≈˘⟨ cancelʳ β′ ⟩
-            (first f ∘ eval′)  ∘ first (λg id)            ≈˘⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
-            (first f ∘ eval′ ∘ first id)  ∘ first (λg id) ≈˘⟨ pullˡ β′ ⟩
-            eval′ ∘ first (A⇨[-×A].F₁ f) ∘ first (λg id)  ≈⟨ refl⟩∘⟨ first∘first ⟩
-            eval′ ∘ first (A⇨[-×A].F₁ f ∘ λg id)          ∎
-          }
-        ; counit = ntHelper record
-          { η       = λ _ → eval′
-          ; commute = λ f → begin
-            eval′ ∘ [A⇨-]×A.F₁ f ≈⟨ β′ ⟩
-            f ∘ eval′ ∘ first id ≈⟨ refl⟩∘⟨ elimʳ (id×id product) ⟩
-            f ∘ eval′            ∎
-          }
-        ; zig    = β′
-        ; zag    = λ-unique₂′ $ begin
-          eval′ ∘ first (λg (eval′ ∘ eval′ ∘ second id) ∘ λg id)
-                                          ≈˘⟨ refl⟩∘⟨ first∘first ⟩
-          eval′ ∘ first (λg (eval′ ∘ eval′ ∘ second id)) ∘ first (λg id)
-                                          ≈⟨ pullˡ β′ ⟩
-          (eval′ ∘ eval′ ∘ second id) ∘ first (λg id)
-                                          ≈⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
-          (eval′ ∘ eval′) ∘ first (λg id) ≈⟨ cancelʳ β′ ⟩
-          eval′                           ≈˘⟨ elimʳ (id×id product) ⟩
-          eval′ ∘ first id                ∎
+    [A⇨-]×A : Obj → Endofunctor 𝒞
+    [A⇨-]×A A = -× A ∘F A ⇨-
+
+    module [A⇨-]×A {A} = Functor ([A⇨-]×A A)
+
+  closedMonoidal : Closed monoidal
+  closedMonoidal = record
+    { [-,-]   = -⇨-
+    ; adjoint = λ {A} → record
+      { unit   = ntHelper record
+        { η       = λ _ → λg id
+        ; commute = λ f → λ-unique₂′ $ begin
+          eval′ ∘ first (λg id ∘ f)                     ≈˘⟨ refl⟩∘⟨ first∘first ⟩
+          eval′ ∘ first (λg id) ∘ first f               ≈⟨ cancelˡ β′ ⟩
+          first f                                       ≈˘⟨ cancelʳ β′ ⟩
+          (first f ∘ eval′)  ∘ first (λg id)            ≈˘⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
+          (first f ∘ eval′ ∘ first id)  ∘ first (λg id) ≈˘⟨ pullˡ β′ ⟩
+          eval′ ∘ first (A⇨[-×A].F₁ f) ∘ first (λg id)  ≈⟨ refl⟩∘⟨ first∘first ⟩
+          eval′ ∘ first (A⇨[-×A].F₁ f ∘ λg id)          ∎
         }
-      ; mate    = λ {X Y} f → record
-        { commute₁ = λ-unique₂′ $ begin
-          eval′ ∘ first (λg (second f ∘ eval′ ∘ second id) ∘ λg id)         ≈˘⟨ refl⟩∘⟨ first∘first ⟩
-          eval′ ∘ first (λg (second f ∘ eval′ ∘ second id)) ∘ first (λg id) ≈⟨ pullˡ β′ ⟩
-          (second f ∘ eval′ ∘ second id) ∘ first (λg id)                    ≈⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
-          (second f ∘ eval′) ∘ first (λg id)                                ≈⟨ cancelʳ β′ ⟩
-          second f                                                          ≈˘⟨ cancelˡ β′ ⟩
-          eval′ ∘ first (λg id) ∘ second f                                  ≈⟨ pushʳ first↔second ⟩
-          (eval′ ∘ second f) ∘ first (λg id)                                ≈˘⟨ identityˡ ⟩∘⟨refl ⟩
-          (id ∘ eval′ ∘ second f) ∘ first (λg id)                           ≈˘⟨ pullˡ β′ ⟩
-          eval′ ∘ first (λg (id ∘ eval′ ∘ second f)) ∘ first (λg id)        ≈⟨ refl⟩∘⟨ first∘first ⟩
-          eval′ ∘ first (λg (id ∘ eval′ ∘ second f) ∘ λg id)                ∎
-        ; commute₂ = begin
-          eval′ ∘ first (λg (id ∘ eval′ ∘ second f)) ≈⟨ β′ ⟩
-          id ∘ eval′ ∘ second f                      ≈⟨ identityˡ ⟩
-          eval′ ∘ second f                           ∎
+      ; counit = ntHelper record
+        { η       = λ _ → eval′
+        ; commute = λ f → begin
+          eval′ ∘ [A⇨-]×A.F₁ f ≈⟨ β′ ⟩
+          f ∘ eval′ ∘ first id ≈⟨ refl⟩∘⟨ elimʳ (id×id product) ⟩
+          f ∘ eval′            ∎
         }
+      ; zig    = β′
+      ; zag    = λ-unique₂′ $ begin
+        eval′ ∘ first (λg (eval′ ∘ eval′ ∘ second id) ∘ λg id)
+                                        ≈˘⟨ refl⟩∘⟨ first∘first ⟩
+        eval′ ∘ first (λg (eval′ ∘ eval′ ∘ second id)) ∘ first (λg id)
+                                        ≈⟨ pullˡ β′ ⟩
+        (eval′ ∘ eval′ ∘ second id) ∘ first (λg id)
+                                        ≈⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
+        (eval′ ∘ eval′) ∘ first (λg id) ≈⟨ cancelʳ β′ ⟩
+        eval′                           ≈˘⟨ elimʳ (id×id product) ⟩
+        eval′ ∘ first id                ∎
       }
+    ; mate    = λ {X Y} f → record
+      { commute₁ = λ-unique₂′ $ begin
+        eval′ ∘ first (λg (second f ∘ eval′ ∘ second id) ∘ λg id)         ≈˘⟨ refl⟩∘⟨ first∘first ⟩
+        eval′ ∘ first (λg (second f ∘ eval′ ∘ second id)) ∘ first (λg id) ≈⟨ pullˡ β′ ⟩
+        (second f ∘ eval′ ∘ second id) ∘ first (λg id)                    ≈⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
+        (second f ∘ eval′) ∘ first (λg id)                                ≈⟨ cancelʳ β′ ⟩
+        second f                                                          ≈˘⟨ cancelˡ β′ ⟩
+        eval′ ∘ first (λg id) ∘ second f                                  ≈⟨ pushʳ first↔second ⟩
+        (eval′ ∘ second f) ∘ first (λg id)                                ≈˘⟨ identityˡ ⟩∘⟨refl ⟩
+        (id ∘ eval′ ∘ second f) ∘ first (λg id)                           ≈˘⟨ pullˡ β′ ⟩
+        eval′ ∘ first (λg (id ∘ eval′ ∘ second f)) ∘ first (λg id)        ≈⟨ refl⟩∘⟨ first∘first ⟩
+        eval′ ∘ first (λg (id ∘ eval′ ∘ second f) ∘ λg id)                ∎
+      ; commute₂ = begin
+        eval′ ∘ first (λg (id ∘ eval′ ∘ second f)) ≈⟨ β′ ⟩
+        id ∘ eval′ ∘ second f                      ≈⟨ identityˡ ⟩
+        eval′ ∘ second f                           ∎
+      }
+    }
 
-  module closedMonoidal = Closed closedMonoidal
+  open Closed closedMonoidal public

--- a/src/Categories/Category/Cocartesian.agda
+++ b/src/Categories/Category/Cocartesian.agda
@@ -134,15 +134,19 @@ record Cocartesian : Set (levelOfTerm 𝒞) where
 
     module op-cartesian = Cartesian op-cartesian
 
-  open Dual
+-- The op-cartesian structure induces a monoidal one.
+
+module CocartesianMonoidal (cocartesian : Cocartesian) where
+  open Cocartesian cocartesian
+  private module op-cartesianMonoidal = CartesianMonoidal Dual.op-cartesian
 
   ⊥+A≅A : ⊥ + A ≅ A
-  ⊥+A≅A = op-≅⇒≅ (op-cartesian.⊤×A≅A)
+  ⊥+A≅A = op-≅⇒≅ (op-cartesianMonoidal.⊤×A≅A)
 
   A+⊥≅A : A + ⊥ ≅ A
-  A+⊥≅A = op-≅⇒≅ (op-cartesian.A×⊤≅A)
+  A+⊥≅A = op-≅⇒≅ (op-cartesianMonoidal.A×⊤≅A)
 
-  open op-cartesian
+  open op-cartesianMonoidal
     using ()
     -- both are natural isomorphism
     renaming (⊤×--id to ⊥+--id; -×⊤-id to -+⊥-id)
@@ -175,11 +179,17 @@ record Cocartesian : Set (levelOfTerm 𝒞) where
                                             ([ -+ W ]-resp-Iso (iso +-assoc))))
                                      (Iso-∘ (iso +-assoc) (iso +-assoc))
     }
-    where op-monoidal = op-cartesian.monoidal
-          open Monoidal op-monoidal
+    where open op-cartesianMonoidal
           open _≅_
 
-  module +-monoidal = Monoidal +-monoidal
+  open Monoidal +-monoidal public
+
+module CocartesianSymmetricMonoidal (cocartesian : Cocartesian) where
+  open Cocartesian cocartesian
+  open CocartesianMonoidal cocartesian
+  private
+    module op-cartesianSymmetricMonoidal =
+      CartesianSymmetricMonoidal Dual.op-cartesian
 
   +-symmetric : Symmetric +-monoidal
   +-symmetric = record
@@ -202,10 +212,7 @@ record Cocartesian : Set (levelOfTerm 𝒞) where
       }
     ; commutative = commutative
     }
-    where op-symmetric = op-cartesian.symmetric
-          open Symmetric op-symmetric
+    where open op-cartesianSymmetricMonoidal
           open _≅_
 
-  -- we don't open this module publicly in order to prevent introducing conflicts
-  -- with Cartesian category
-  module +-symmetric = Symmetric +-symmetric
+  open Symmetric +-symmetric public

--- a/src/Categories/Category/Monoidal/Instance/Cats.agda
+++ b/src/Categories/Category/Monoidal/Instance/Cats.agda
@@ -38,8 +38,5 @@ module Product {o ℓ e : Level} where
   Cats-is : Cartesian
   Cats-is = record { terminal = One-⊤ ; products = Cats-has-all }
 
-  private
-    module Cart = Cartesian.Cartesian Cats-is
-
   Cats-Monoidal : Monoidal C
-  Cats-Monoidal = Cart.monoidal
+  Cats-Monoidal = Cartesian.CartesianMonoidal.monoidal C Cats-is

--- a/src/Categories/Category/Monoidal/Instance/Setoids.agda
+++ b/src/Categories/Category/Monoidal/Instance/Setoids.agda
@@ -49,7 +49,9 @@ module _ {o ℓ} where
     }
 
   module Setoids-Cartesian = Cartesian Setoids-Cartesian
-  open Setoids-Cartesian renaming (monoidal to Setoids-Monoidal) public
+  open Setoids-Cartesian public
+  module Setoids-CartesianMonoidal = CartesianMonoidal _ Setoids-Cartesian
+  open Setoids-CartesianMonoidal renaming (monoidal to Setoids-Monoidal) public
 
   Setoids-Cocartesian : Cocartesian (Setoids o (o ⊔ ℓ))
   Setoids-Cocartesian = record

--- a/src/Categories/Category/Monoidal/Instance/Sets.agda
+++ b/src/Categories/Category/Monoidal/Instance/Sets.agda
@@ -45,11 +45,8 @@ module Product {o : Level} where
   Sets-is : Cartesian
   Sets-is = record { terminal = SingletonSet-⊤ ; products = Sets-has-all }
 
-  private
-    module Cart = Cartesian.Cartesian Sets-is
-
   Sets-Monoidal : Monoidal S
-  Sets-Monoidal = Cart.monoidal
+  Sets-Monoidal = Cartesian.CartesianMonoidal.monoidal S Sets-is
 
 module Coproduct {o : Level} where
   private
@@ -70,8 +67,5 @@ module Coproduct {o : Level} where
   Sets-is : Cocartesian
   Sets-is = record { initial = EmptySet-⊥ ; coproducts = Sets-has-all }
 
-  private
-    module Cocart = Cocartesian.Cocartesian Sets-is
-
   Sets-Monoidal : Monoidal S
-  Sets-Monoidal =  Cocart.+-monoidal
+  Sets-Monoidal = Cocartesian.CocartesianMonoidal.+-monoidal S Sets-is

--- a/src/Categories/Category/Monoidal/Instance/StrictCats.agda
+++ b/src/Categories/Category/Monoidal/Instance/StrictCats.agda
@@ -88,8 +88,5 @@ module Product {o ℓ e : Level} where
   Cats-is : Cartesian
   Cats-is = record { terminal = One-⊤ ; products = Cats-has-all }
 
-  private
-    module Cart = Cartesian.Cartesian Cats-is
-
   Cats-Monoidal : Monoidal C
-  Cats-Monoidal = Cart.monoidal
+  Cats-Monoidal = Cartesian.CartesianMonoidal.monoidal C Cats-is

--- a/src/Categories/Functor/Cartesian/Properties.agda
+++ b/src/Categories/Functor/Cartesian/Properties.agda
@@ -8,6 +8,7 @@ open import Data.Product using (Σ ; _,_)
 
 open import Categories.Category
 open import Categories.Category.Cartesian.Structure
+open import Categories.Category.Monoidal.Structure using (MonoidalCategory)
 open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
 open import Categories.Functor.Properties
 open import Categories.Functor.Cartesian
@@ -88,8 +89,10 @@ module _ (A : CartesianCategory o ℓ e) (B : CartesianCategory o′ ℓ′ e′
 
 module _ {C : CartesianCategory o ℓ e} {D : CartesianCategory o′ ℓ′ e′} where
   private
-    module C = CartesianCategory C
-    module D = CartesianCategory D
+    module C  = CartesianCategory C
+    module CM = MonoidalCategory C.monoidalCategory
+    module D  = CartesianCategory D
+    module DM = MonoidalCategory D.monoidalCategory using (associator)
     open D.HomReasoning
     open MR D.U
     open M D.U
@@ -118,7 +121,7 @@ module _ {C : CartesianCategory o ℓ e} {D : CartesianCategory o′ ℓ′ e′
           }
         }
       ; associativity = λ {X Y Z} → let open P D.U in begin
-        F.₁ C.associator.from D.∘ F.×-iso.to (X C.× Y) Z D.∘ (F.×-iso.to X Y D.⁂ D.id)
+        F.₁ CM.associator.from D.∘ F.×-iso.to (X C.× Y) Z D.∘ (F.×-iso.to X Y D.⁂ D.id)
           ≈⟨ F.F-resp-⟨⟩′ _ _ ⟩∘⟨ [ D.product ⇒ D.product ⇒ F.F-prod _ _ ]repack∘× ⟩
         F.F-resp-×.⟨ F.₁ (C.π₁ C.∘ C.π₁) , F.₁ C.⟨ C.π₂ C.∘ C.π₁ , C.π₂ ⟩ ⟩ D.∘ F.F-resp-×.⟨ F.×-iso.to X Y D.∘ D.π₁ , D.id D.∘ D.π₂ ⟩
           ≈⟨ F.F-prod.⟨⟩-cong₂ _ _ F.homomorphism (F.F-resp-⟨⟩′ _ _ ○ F.F-prod.⟨⟩-cong₂ _ _ F.homomorphism D.Equiv.refl) ⟩∘⟨refl ⟩
@@ -135,9 +138,9 @@ module _ {C : CartesianCategory o ℓ e} {D : CartesianCategory o′ ℓ′ e′
           ≈˘⟨ F.F-prod.⟨⟩-cong₂ _ _ D.identityˡ ([ F.F-prod _ _ ]⟨⟩∘ ○ (F.F-prod.⟨⟩-cong₂ _ _ D.project₁ D.project₂)) ⟩
         F.F-resp-×.⟨ D.id D.∘ D.π₁ D.∘ D.π₁ , F.×-iso.to Y Z D.∘ D.⟨ D.π₂ D.∘ D.π₁ , D.π₂ ⟩ ⟩
           ≈˘⟨ [ D.product ⇒ (F.F-prod _ _) ]×∘⟨⟩ ⟩
-        F.F-resp-×.⟨ D.id D.∘ D.π₁ , F.×-iso.to Y Z D.∘ D.π₂ ⟩ D.∘ D.associator.from
+        F.F-resp-×.⟨ D.id D.∘ D.π₁ , F.×-iso.to Y Z D.∘ D.π₂ ⟩ D.∘ DM.associator.from
           ≈˘⟨ pullˡ [ D.product ⇒ D.product ⇒ F.F-prod _ _ ]repack∘× ⟩
-        F.×-iso.to X (Y C.× Z) D.∘ (D.id D.⁂ F.×-iso.to Y Z) D.∘ D.associator.from
+        F.×-iso.to X (Y C.× Z) D.∘ (D.id D.⁂ F.×-iso.to Y Z) D.∘ DM.associator.from
           ∎
       ; unitaryˡ      = begin
         F.₁ C.π₂ D.∘ F.F-resp-×.⟨ D.π₁ , D.π₂ ⟩ D.∘ (F.F-resp-⊤.! D.⁂ D.id) ≈⟨ pullˡ F.F-resp-×.project₂ ⟩


### PR DESCRIPTION
This makes some progress towards addressing #215. By separating the monoidal properties of (co-)cartesian categories into separate modules, the overall size of the generated Haskell code seems to be reduced. In particular, there are fewer "copies" of the large proof term of the pentagon identity for cartesian categories that get included in other modules.

Questions that remain open:
 - Why is the Haskell code generated for the proof term of the pentagon identity so big in the first place?
 - Why did it get duplicated (and not just referenced) when the `monoidal` field in the `Cartesian` record was re-exported?
