### PR TITLE
Streamline Pseudofunctor and Bicategory.Extras modules

### DIFF
--- a/Everything.agda
+++ b/Everything.agda
@@ -28,6 +28,7 @@ import Categories.Bicategory.Construction.1-Category
 import Categories.Bicategory.Extras
 import Categories.Bicategory.Instance.Cats
 import Categories.Bicategory.Instance.EnrichedCats
+import Categories.Bicategory.Opposite
 import Categories.Category
 import Categories.Category.BicartesianClosed
 import Categories.Category.CMonoidEnriched

--- a/src/Categories/Bicategory/Bigroupoid.agda
+++ b/src/Categories/Bicategory/Bigroupoid.agda
@@ -13,7 +13,7 @@ import Categories.Category.Equivalence.Properties as EP
 open import Categories.Category.Product
 open import Categories.Category.Groupoid using (IsGroupoid)
 open import Categories.Bicategory
-open import Categories.Bicategory.Extras
+import Categories.Bicategory.Extras as BicategoryExtras
 open import Categories.Functor renaming (id to idF)
 open import Categories.Functor.Properties
 open import Categories.Functor.Bifunctor.Properties
@@ -27,8 +27,7 @@ import Categories.Morphism.Reasoning as MR
 
 -- https://link.springer.com/article/10.1023/A:1011270417127
 record IsBigroupoid {o ℓ e t} (C : Bicategory o ℓ e t) : Set (o ⊔ ℓ ⊔ e ⊔ t) where
-  open Bicategory C public
-  open Extras C
+  open BicategoryExtras C
 
   field
     hom-isGroupoid : ∀ A B → IsGroupoid (hom A B)
@@ -159,6 +158,8 @@ record IsBigroupoid {o ℓ e t} (C : Bicategory o ℓ e t) : Set (o ⊔ ℓ ⊔ 
 
   hom⁻¹-⊣Equivalence : ∀ {A} {B} → hom[ A , B ]⁻¹ ⊣⊢ hom[ B , A ]⁻¹
   hom⁻¹-⊣Equivalence {A} {B} = EP.F⊣⊢G (hom⁻¹-weakInverse {A} {B})
+
+  open Bicategory C public
 
 -- A bigroupoid is a bicategory that has a bigroupoid structure
 

--- a/src/Categories/Bicategory/Extras.agda
+++ b/src/Categories/Bicategory/Extras.agda
@@ -1,10 +1,11 @@
 {-# OPTIONS --without-K --safe #-}
 
-module Categories.Bicategory.Extras where
+open import Categories.Bicategory using (Bicategory)
+
+module Categories.Bicategory.Extras {o ℓ e t} (Bicat : Bicategory o ℓ e t) where
 
 open import Data.Product using (_,_)
 
-open import Categories.Bicategory using (Bicategory)
 open import Categories.Functor using (Functor)
 open import Categories.Functor.Bifunctor using (appʳ; appˡ)
 open import Categories.Functor.Bifunctor.Properties using ([_]-commute; [_]-merge)
@@ -14,165 +15,164 @@ import Categories.Morphism as Mor
 import Categories.Morphism.Reasoning as MR
 import Categories.Morphism.IsoEquiv as IsoEquiv
 
-module Extras {o ℓ e t} (Bicat : Bicategory o ℓ e t) where
-  open Bicategory Bicat
-  private
-    variable
-      A B C D : Obj
-      f g h i : A ⇒₁ B
-      α β γ : f ⇒₂ g
+open Bicategory Bicat public
+private
+  variable
+    A B C D : Obj
+    f g h i : A ⇒₁ B
+    α β γ : f ⇒₂ g
 
-  infixr 7 _∘ᵢ_
-  infixr 9 _▷ᵢ_
-  infixl 9 _◁ᵢ_
+infixr 7 _∘ᵢ_
+infixr 9 _▷ᵢ_
+infixl 9 _◁ᵢ_
 
-  module ⊚ {A B C}          = Functor (⊚ {A} {B} {C})
-  module ⊚-assoc {A B C D}  = NaturalIsomorphism (⊚-assoc {A} {B} {C} {D})
-  module unitˡ {A B}        = NaturalIsomorphism (unitˡ {A} {B})
-  module unitʳ {A B}        = NaturalIsomorphism (unitʳ {A} {B})
-  module id {A}             = Functor (id {A})
+module ⊚ {A B C}          = Functor (⊚ {A} {B} {C})
+module ⊚-assoc {A B C D}  = NaturalIsomorphism (⊚-assoc {A} {B} {C} {D})
+module unitˡ {A B}        = NaturalIsomorphism (unitˡ {A} {B})
+module unitʳ {A B}        = NaturalIsomorphism (unitʳ {A} {B})
+module id {A}             = Functor (id {A})
 
-  unitorˡ : {A B : Obj} {f : A ⇒₁ B} → Mor._≅_ (hom A B) (id₁ ∘ₕ f) f
-  unitorˡ {_} {_} {f} = record
-    { from = unitˡ.⇒.η (_ , f)
-    ; to   = unitˡ.⇐.η (_ , f)
-    ; iso  = unitˡ.iso (_ , f)
-    }
+unitorˡ : {A B : Obj} {f : A ⇒₁ B} → Mor._≅_ (hom A B) (id₁ ∘ₕ f) f
+unitorˡ {_} {_} {f} = record
+  { from = unitˡ.⇒.η (_ , f)
+  ; to   = unitˡ.⇐.η (_ , f)
+  ; iso  = unitˡ.iso (_ , f)
+  }
 
-  module unitorˡ {A B f} = Mor._≅_ (unitorˡ {A} {B} {f})
+module unitorˡ {A B f} = Mor._≅_ (unitorˡ {A} {B} {f})
 
-  unitorʳ : {A B : Obj} {f : A ⇒₁ B} → Mor._≅_ (hom A B) (f ∘ₕ id₁) f
-  unitorʳ {_} {_} {f} = record
-    { from = unitʳ.⇒.η (f , _)
-    ; to   = unitʳ.⇐.η (f , _)
-    ; iso  = unitʳ.iso (f , _)
-    }
+unitorʳ : {A B : Obj} {f : A ⇒₁ B} → Mor._≅_ (hom A B) (f ∘ₕ id₁) f
+unitorʳ {_} {_} {f} = record
+  { from = unitʳ.⇒.η (f , _)
+  ; to   = unitʳ.⇐.η (f , _)
+  ; iso  = unitʳ.iso (f , _)
+  }
 
-  module unitorʳ {A B f} = Mor._≅_ (unitorʳ {A} {B} {f})
+module unitorʳ {A B f} = Mor._≅_ (unitorʳ {A} {B} {f})
 
-  associator : {A B C D : Obj} {f : D ⇒₁ B} {g : C ⇒₁ D} {h : A ⇒₁ C} →  Mor._≅_ (hom A B) ((f ∘ₕ g) ∘ₕ h) (f ∘ₕ g ∘ₕ h)
-  associator {_} {_} {_} {_} {f} {g} {h} = record
-    { from = ⊚-assoc.⇒.η ((f , g) , h)
-    ; to   = ⊚-assoc.⇐.η ((f , g) , h)
-    ; iso  = ⊚-assoc.iso ((f , g) , h)
-    }
+associator : {A B C D : Obj} {f : D ⇒₁ B} {g : C ⇒₁ D} {h : A ⇒₁ C} →  Mor._≅_ (hom A B) ((f ∘ₕ g) ∘ₕ h) (f ∘ₕ g ∘ₕ h)
+associator {_} {_} {_} {_} {f} {g} {h} = record
+  { from = ⊚-assoc.⇒.η ((f , g) , h)
+  ; to   = ⊚-assoc.⇐.η ((f , g) , h)
+  ; iso  = ⊚-assoc.iso ((f , g) , h)
+  }
 
-  module associator {A B C D} {f : C ⇒₁ B} {g : D ⇒₁ C} {h} = Mor._≅_ (associator {A = A} {B = B} {f = f} {g = g} {h = h})
+module associator {A B C D} {f : C ⇒₁ B} {g : D ⇒₁ C} {h} = Mor._≅_ (associator {A = A} {B = B} {f = f} {g = g} {h = h})
 
-  module Shorthands where
-    λ⇒ = unitorˡ.from
-    λ⇐ = unitorˡ.to
+module Shorthands where
+  λ⇒ = unitorˡ.from
+  λ⇐ = unitorˡ.to
 
-    ρ⇒ = unitorʳ.from
-    ρ⇐ = unitorʳ.to
+  ρ⇒ = unitorʳ.from
+  ρ⇐ = unitorʳ.to
 
-    α⇒ = associator.from
-    α⇐ = associator.to
-  open Shorthands
+  α⇒ = associator.from
+  α⇐ = associator.to
+open Shorthands
 
 
-  -⊚_ : C ⇒₁ A → Functor (hom A B) (hom C B)
-  -⊚_ = appʳ ⊚
+-⊚_ : C ⇒₁ A → Functor (hom A B) (hom C B)
+-⊚_ = appʳ ⊚
 
-  _⊚- : B ⇒₁ C → Functor (hom A B) (hom A C)
-  _⊚- = appˡ ⊚
+_⊚- : B ⇒₁ C → Functor (hom A B) (hom A C)
+_⊚- = appˡ ⊚
 
-  identity₂ˡ : id₂ ∘ᵥ α ≈ α
-  identity₂ˡ = hom.identityˡ
+identity₂ˡ : id₂ ∘ᵥ α ≈ α
+identity₂ˡ = hom.identityˡ
 
-  identity₂ʳ : α ∘ᵥ id₂ ≈ α
-  identity₂ʳ = hom.identityʳ
+identity₂ʳ : α ∘ᵥ id₂ ≈ α
+identity₂ʳ = hom.identityʳ
 
-  assoc₂ : (α ∘ᵥ β) ∘ᵥ γ ≈ α ∘ᵥ β ∘ᵥ γ
-  assoc₂ = hom.assoc
+assoc₂ : (α ∘ᵥ β) ∘ᵥ γ ≈ α ∘ᵥ β ∘ᵥ γ
+assoc₂ = hom.assoc
 
-  id₂◁ : id₂ {f = g} ◁ f ≈ id₂
-  id₂◁ = ⊚.identity
+id₂◁ : id₂ {f = g} ◁ f ≈ id₂
+id₂◁ = ⊚.identity
 
-  ▷id₂ : f ▷ id₂ {f = g} ≈ id₂
-  ▷id₂ = ⊚.identity
+▷id₂ : f ▷ id₂ {f = g} ≈ id₂
+▷id₂ = ⊚.identity
 
-  open hom.HomReasoning
-  open hom.Equiv
-  private
-    module MR′ {A} {B} where
-      open MR (hom A B) using (conjugate-to) public
-      open Mor (hom A B) using (_≅_; module ≅) public
-      open IsoEquiv (hom A B) using (⌞_⌟; _≃_) public
-    open MR′
-  idᵢ  = λ {A B f} → ≅.refl {A} {B} {f}
-  _∘ᵢ_ = λ {A B f g h} α β → ≅.trans {A} {B} {f} {g} {h} β α
+open hom.HomReasoning
+open hom.Equiv
+private
+  module MR′ {A} {B} where
+    open MR (hom A B) using (conjugate-to) public
+    open Mor (hom A B) using (_≅_; module ≅) public
+    open IsoEquiv (hom A B) using (⌞_⌟; _≃_) public
+  open MR′
+idᵢ  = λ {A B f} → ≅.refl {A} {B} {f}
+_∘ᵢ_ = λ {A B f g h} α β → ≅.trans {A} {B} {f} {g} {h} β α
 
-  _⊚ᵢ_ : f ≅ h → g ≅ i → f ⊚₀ g ≅ h ⊚₀ i
-  α ⊚ᵢ β = record
-    { from = from α ⊚₁ from β
-    ; to   = to α ⊚₁ to β
-    ; iso  = record
-      { isoˡ = [ ⊚ ]-merge (isoˡ α) (isoˡ β) ○ ⊚.identity
-      ; isoʳ = [ ⊚ ]-merge (isoʳ α) (isoʳ β) ○ ⊚.identity }
-    }
-    where open _≅_
+_⊚ᵢ_ : f ≅ h → g ≅ i → f ⊚₀ g ≅ h ⊚₀ i
+α ⊚ᵢ β = record
+  { from = from α ⊚₁ from β
+  ; to   = to α ⊚₁ to β
+  ; iso  = record
+    { isoˡ = [ ⊚ ]-merge (isoˡ α) (isoˡ β) ○ ⊚.identity
+    ; isoʳ = [ ⊚ ]-merge (isoʳ α) (isoʳ β) ○ ⊚.identity }
+  }
+  where open _≅_
 
-  _◁ᵢ_ : {g h : B ⇒₁ C} (α : g ≅ h) (f : A ⇒₁ B) → g ∘ₕ f ≅ h ∘ₕ f
-  α ◁ᵢ _ = α ⊚ᵢ idᵢ
+_◁ᵢ_ : {g h : B ⇒₁ C} (α : g ≅ h) (f : A ⇒₁ B) → g ∘ₕ f ≅ h ∘ₕ f
+α ◁ᵢ _ = α ⊚ᵢ idᵢ
 
-  _▷ᵢ_ : {f g : A ⇒₁ B} (h : B ⇒₁ C) (α : f ≅ g) → h ∘ₕ f ≅ h ∘ₕ g
-  _ ▷ᵢ α = idᵢ ⊚ᵢ α
+_▷ᵢ_ : {f g : A ⇒₁ B} (h : B ⇒₁ C) (α : f ≅ g) → h ∘ₕ f ≅ h ∘ₕ g
+_ ▷ᵢ α = idᵢ ⊚ᵢ α
 
-  ∘ᵥ-distr-◁ : (α ◁ f) ∘ᵥ (β ◁ f) ≈ (α ∘ᵥ β) ◁ f
-  ∘ᵥ-distr-◁ {f = f} = ⟺ (Functor.homomorphism (-⊚ f))
+∘ᵥ-distr-◁ : (α ◁ f) ∘ᵥ (β ◁ f) ≈ (α ∘ᵥ β) ◁ f
+∘ᵥ-distr-◁ {f = f} = ⟺ (Functor.homomorphism (-⊚ f))
 
-  ∘ᵥ-distr-▷ : (f ▷ α) ∘ᵥ (f ▷ β) ≈ f ▷ (α ∘ᵥ β)
-  ∘ᵥ-distr-▷ {f = f} = ⟺ (Functor.homomorphism (f ⊚-))
+∘ᵥ-distr-▷ : (f ▷ α) ∘ᵥ (f ▷ β) ≈ f ▷ (α ∘ᵥ β)
+∘ᵥ-distr-▷ {f = f} = ⟺ (Functor.homomorphism (f ⊚-))
 
-  ρ-∘ᵥ-▷ : λ⇒ ∘ᵥ (id₁ ▷ α) ≈ α ∘ᵥ λ⇒
-  ρ-∘ᵥ-▷ {α = α} = begin
-    λ⇒ ∘ᵥ (id₁ ▷ α)    ≈˘⟨ hom.∘-resp-≈ʳ (⊚.F-resp-≈ (id.identity , refl)) ⟩
-    λ⇒ ∘ᵥ id.F₁ _ ⊚₁ α ≈⟨ unitˡ.⇒.commute (_ , α) ⟩
-    α ∘ᵥ λ⇒            ∎
+ρ-∘ᵥ-▷ : λ⇒ ∘ᵥ (id₁ ▷ α) ≈ α ∘ᵥ λ⇒
+ρ-∘ᵥ-▷ {α = α} = begin
+  λ⇒ ∘ᵥ (id₁ ▷ α)    ≈˘⟨ hom.∘-resp-≈ʳ (⊚.F-resp-≈ (id.identity , refl)) ⟩
+  λ⇒ ∘ᵥ id.F₁ _ ⊚₁ α ≈⟨ unitˡ.⇒.commute (_ , α) ⟩
+  α ∘ᵥ λ⇒            ∎
 
-  ▷-∘ᵥ-ρ⁻¹ : (id₁ ▷ α) ∘ᵥ λ⇐ ≈ λ⇐ ∘ᵥ α
-  ▷-∘ᵥ-ρ⁻¹ = conjugate-to (≅.sym unitorˡ) (≅.sym unitorˡ) ρ-∘ᵥ-▷
+▷-∘ᵥ-ρ⁻¹ : (id₁ ▷ α) ∘ᵥ λ⇐ ≈ λ⇐ ∘ᵥ α
+▷-∘ᵥ-ρ⁻¹ = conjugate-to (≅.sym unitorˡ) (≅.sym unitorˡ) ρ-∘ᵥ-▷
 
-  λ-∘ᵥ-◁ : ρ⇒ ∘ᵥ (α ◁ id₁) ≈ α ∘ᵥ ρ⇒
-  λ-∘ᵥ-◁ {α = α} = begin
-    ρ⇒ ∘ᵥ (α ◁ id₁)      ≈˘⟨ hom.∘-resp-≈ʳ (⊚.F-resp-≈ (refl , id.identity)) ⟩
-    ρ⇒ ∘ᵥ (α ⊚₁ id.F₁ _) ≈⟨ unitʳ.⇒.commute (α , _) ⟩
-    α ∘ᵥ ρ⇒              ∎
+λ-∘ᵥ-◁ : ρ⇒ ∘ᵥ (α ◁ id₁) ≈ α ∘ᵥ ρ⇒
+λ-∘ᵥ-◁ {α = α} = begin
+  ρ⇒ ∘ᵥ (α ◁ id₁)      ≈˘⟨ hom.∘-resp-≈ʳ (⊚.F-resp-≈ (refl , id.identity)) ⟩
+  ρ⇒ ∘ᵥ (α ⊚₁ id.F₁ _) ≈⟨ unitʳ.⇒.commute (α , _) ⟩
+  α ∘ᵥ ρ⇒              ∎
 
-  ◁-∘ᵥ-λ⁻¹ : (α ◁ id₁) ∘ᵥ ρ⇐ ≈ ρ⇐ ∘ᵥ α
-  ◁-∘ᵥ-λ⁻¹ = conjugate-to (≅.sym unitorʳ) (≅.sym unitorʳ) λ-∘ᵥ-◁
+◁-∘ᵥ-λ⁻¹ : (α ◁ id₁) ∘ᵥ ρ⇐ ≈ ρ⇐ ∘ᵥ α
+◁-∘ᵥ-λ⁻¹ = conjugate-to (≅.sym unitorʳ) (≅.sym unitorʳ) λ-∘ᵥ-◁
 
-  assoc⁻¹-◁-∘ₕ : associator.to ∘ᵥ (α ◁ (g ∘ₕ f)) ≈ ((α ◁ g) ◁ f) ∘ᵥ associator.to
-  assoc⁻¹-◁-∘ₕ {α = α} {g = g} {f = f} = begin
-    associator.to ∘ᵥ (α ◁ (g ∘ₕ f))    ≈˘⟨ hom.∘-resp-≈ʳ (⊚.F-resp-≈ (refl , ⊚.identity)) ⟩
-    associator.to ∘ᵥ (α ⊚₁ id₂ ⊚₁ id₂) ≈⟨ ⊚-assoc.⇐.commute ((α , id₂) , id₂) ⟩
-    ((α ◁ g) ◁ f) ∘ᵥ associator.to     ∎
+assoc⁻¹-◁-∘ₕ : associator.to ∘ᵥ (α ◁ (g ∘ₕ f)) ≈ ((α ◁ g) ◁ f) ∘ᵥ associator.to
+assoc⁻¹-◁-∘ₕ {α = α} {g = g} {f = f} = begin
+  associator.to ∘ᵥ (α ◁ (g ∘ₕ f))    ≈˘⟨ hom.∘-resp-≈ʳ (⊚.F-resp-≈ (refl , ⊚.identity)) ⟩
+  associator.to ∘ᵥ (α ⊚₁ id₂ ⊚₁ id₂) ≈⟨ ⊚-assoc.⇐.commute ((α , id₂) , id₂) ⟩
+  ((α ◁ g) ◁ f) ∘ᵥ associator.to     ∎
 
-  assoc⁻¹-▷-◁ : associator.to ∘ᵥ (f ▷ (α ◁ g)) ≈ ((f ▷ α) ◁ g) ∘ᵥ associator.to
-  assoc⁻¹-▷-◁ {f = f} {α = α} {g = g} = ⊚-assoc.⇐.commute ((id₂ , α) , id₂)
+assoc⁻¹-▷-◁ : associator.to ∘ᵥ (f ▷ (α ◁ g)) ≈ ((f ▷ α) ◁ g) ∘ᵥ associator.to
+assoc⁻¹-▷-◁ {f = f} {α = α} {g = g} = ⊚-assoc.⇐.commute ((id₂ , α) , id₂)
 
-  assoc⁻¹-▷-∘ₕ : associator.to ∘ᵥ (g ▷ (f ▷ α)) ≈ ((g ∘ₕ f) ▷ α) ∘ᵥ associator.to
-  assoc⁻¹-▷-∘ₕ {g = g} {f = f} {α = α} = begin
-    associator.to ∘ᵥ (g ▷ (f ▷ α))       ≈⟨ ⊚-assoc.⇐.commute ((id₂ , id₂) , α) ⟩
-    ((id₂ ⊚₁ id₂) ⊚₁ α) ∘ᵥ associator.to ≈⟨ hom.∘-resp-≈ˡ (⊚.F-resp-≈ (⊚.identity , refl)) ⟩
-    ((g ∘ₕ f) ▷ α) ∘ᵥ associator.to      ∎
+assoc⁻¹-▷-∘ₕ : associator.to ∘ᵥ (g ▷ (f ▷ α)) ≈ ((g ∘ₕ f) ▷ α) ∘ᵥ associator.to
+assoc⁻¹-▷-∘ₕ {g = g} {f = f} {α = α} = begin
+  associator.to ∘ᵥ (g ▷ (f ▷ α))       ≈⟨ ⊚-assoc.⇐.commute ((id₂ , id₂) , α) ⟩
+  ((id₂ ⊚₁ id₂) ⊚₁ α) ∘ᵥ associator.to ≈⟨ hom.∘-resp-≈ˡ (⊚.F-resp-≈ (⊚.identity , refl)) ⟩
+  ((g ∘ₕ f) ▷ α) ∘ᵥ associator.to      ∎
 
-  ◁-▷-exchg : ∀ {α : f ⇒₂ g} {β : h ⇒₂ i} → (i ▷ α) ∘ᵥ (β ◁ f) ≈ (β ◁ g) ∘ᵥ (h ▷ α)
-  ◁-▷-exchg = [ ⊚ ]-commute
+◁-▷-exchg : ∀ {α : f ⇒₂ g} {β : h ⇒₂ i} → (i ▷ α) ∘ᵥ (β ◁ f) ≈ (β ◁ g) ∘ᵥ (h ▷ α)
+◁-▷-exchg = [ ⊚ ]-commute
 
-  triangle-iso : {f : A ⇒₁ B} {g : B ⇒₁ C} →
-                 (g ▷ᵢ unitorˡ ∘ᵢ associator) ≃ (unitorʳ ◁ᵢ f)
-  triangle-iso = ⌞ triangle ⌟
+triangle-iso : {f : A ⇒₁ B} {g : B ⇒₁ C} →
+               (g ▷ᵢ unitorˡ ∘ᵢ associator) ≃ (unitorʳ ◁ᵢ f)
+triangle-iso = ⌞ triangle ⌟
 
-  triangle-inv : {f : A ⇒₁ B} {g : B ⇒₁ C} → α⇐ ∘ᵥ g ▷ λ⇐ ≈ ρ⇐ ◁ f
-  triangle-inv = _≃_.to-≈ triangle-iso
+triangle-inv : {f : A ⇒₁ B} {g : B ⇒₁ C} → α⇐ ∘ᵥ g ▷ λ⇐ ≈ ρ⇐ ◁ f
+triangle-inv = _≃_.to-≈ triangle-iso
 
-  pentagon-iso : ∀ {E} {f : A ⇒₁ B} {g : B ⇒₁ C} {h : C ⇒₁ D} {i : D ⇒₁ E} →
-                 (i ▷ᵢ associator ∘ᵢ associator ∘ᵢ associator ◁ᵢ f) ≃
-                 (associator {f = i} {h} {g ∘ₕ f} ∘ᵢ associator)
-  pentagon-iso = ⌞ pentagon ⌟
+pentagon-iso : ∀ {E} {f : A ⇒₁ B} {g : B ⇒₁ C} {h : C ⇒₁ D} {i : D ⇒₁ E} →
+               (i ▷ᵢ associator ∘ᵢ associator ∘ᵢ associator ◁ᵢ f) ≃
+               (associator {f = i} {h} {g ∘ₕ f} ∘ᵢ associator)
+pentagon-iso = ⌞ pentagon ⌟
 
-  pentagon-inv : ∀ {E} {f : A ⇒₁ B} {g : B ⇒₁ C} {h : C ⇒₁ D} {i : D ⇒₁ E} →
-                 (α⇐ ◁ f ∘ᵥ α⇐) ∘ᵥ i ▷ α⇐ ≈ α⇐ ∘ᵥ α⇐ {f = i} {h} {g ∘ₕ f}
-  pentagon-inv = _≃_.to-≈ pentagon-iso
+pentagon-inv : ∀ {E} {f : A ⇒₁ B} {g : B ⇒₁ C} {h : C ⇒₁ D} {i : D ⇒₁ E} →
+               (α⇐ ◁ f ∘ᵥ α⇐) ∘ᵥ i ▷ α⇐ ≈ α⇐ ∘ᵥ α⇐ {f = i} {h} {g ∘ₕ f}
+pentagon-inv = _≃_.to-≈ pentagon-iso

--- a/src/Categories/Bicategory/Opposite.agda
+++ b/src/Categories/Bicategory/Opposite.agda
@@ -8,7 +8,7 @@ module Categories.Bicategory.Opposite where
 
 open import Data.Product using (_,_)
 
-open import Categories.Bicategory.Extras using (module Extras)
+import Categories.Bicategory.Extras as BicategoryExtras
 open import Categories.Category using (Category)
 import Categories.Category.Cartesian as Cartesian
 import Categories.Morphism as Morphism
@@ -28,8 +28,7 @@ open import Categories.NaturalTransformation.NaturalIsomorphism
 
 module _ {o ℓ e t} (C : Bicategory o ℓ e t) where
 
-  open Bicategory C
-  open Extras C
+  open BicategoryExtras C
   open Shorthands
   private
     module MR {A} {B} where

--- a/src/Categories/Bicategory/Opposite.agda
+++ b/src/Categories/Bicategory/Opposite.agda
@@ -1,0 +1,124 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Bicategory using (Bicategory)
+
+-- The 1-cell dual (op) and 2-cell dual (co) of a given bicategory.
+
+module Categories.Bicategory.Opposite where
+
+open import Data.Product using (_,_)
+
+open import Categories.Bicategory.Extras using (module Extras)
+open import Categories.Category using (Category)
+import Categories.Category.Cartesian as Cartesian
+import Categories.Morphism as Morphism
+import Categories.Morphism.Reasoning as MorphismReasoning
+open import Categories.Category.Product using (Swap)
+open import Categories.Functor using (Functor; _∘F_)
+open import Categories.NaturalTransformation.NaturalIsomorphism
+  using (NaturalIsomorphism; niHelper)
+
+-- There several ways to dualize a bicategory:
+--
+--  * flip the 1-cells (op C), or
+--  * flip the 2-cells (co C).
+--  * flip both (coop C).
+--
+-- We implement all three.
+
+module _ {o ℓ e t} (C : Bicategory o ℓ e t) where
+
+  open Bicategory C
+  open Extras C
+  open Shorthands
+  private
+    module MR {A} {B} where
+      open Morphism          (hom A B) public using (module ≅)
+      open MorphismReasoning (hom A B) public using (switch-tofromʳ)
+  open MR
+
+  -- The 1-cell dual of C.
+  --
+  -- NOTE.  The definition here is specialized to the particular choice
+  -- of tensor product (cartesian) and braiding (swap) used in the
+  -- definition of Bicategories.  We could instead have defined the
+  -- `enriched' field using the generic `op' operation defined in
+  -- Categories.Enriched.Category.Opposite, but that would have resulted
+  -- in much more complicated proofs of the triangle and pentagon
+  -- identities.  That's because the definition of associativity and the
+  -- unit laws in the generic opposite enriched category has to work for
+  -- any choice of braiding and is therefore more involved.  When these
+  -- laws become natural isomorphism in the definition of Bicategories,
+  -- they turn into long chains consisting of mostly identity morphisms
+  -- that make the types of the triangle and pentagon identities
+  -- enormous.  We can avoid this by specializing the definitions of the
+  -- associators and unitors below.
+  --
+  -- Note also that this version of `op' is almost a (definitional)
+  -- involution.  The problematic fields are the triangle and pentagon
+  -- identities which are not involutive on the nose.  This could be
+  -- fixed by adding additional fields (in the style of `sym-assoc' in
+  -- Category).  To also support `co` and `coop` would require two more
+  -- variants of each equation, so there would be quite a lot of
+  -- redundancy in the end.
+
+  op : Bicategory o ℓ e t
+  op = record
+    { enriched = record
+      { Obj = Obj
+      ; hom = λ A B → hom B A
+      ; id  = id
+      ; ⊚   = ⊚ ∘F Swap
+      ; ⊚-assoc = niHelper (record
+        { η       = λ{ ((f , g) , h) → ⊚-assoc.⇐.η ((h , g) , f) }
+        ; η⁻¹     = λ{ ((f , g) , h) → ⊚-assoc.⇒.η ((h , g) , f) }
+        ; commute = λ{ ((α , β) , γ) → ⊚-assoc.⇐.commute ((γ , β) , α) }
+        ; iso     = λ _ → record
+          { isoˡ = ⊚-assoc.iso.isoʳ _ ; isoʳ = ⊚-assoc.iso.isoˡ _ }
+        })
+      ; unitˡ = niHelper (record
+        { η       = λ{ (_ , g) → unitʳ.⇒.η (g , _) }
+        ; η⁻¹     = λ{ (_ , g) → unitʳ.⇐.η (g , _) }
+        ; commute = λ{ (_ , β) → unitʳ.⇒.commute (β , _) }
+        ; iso     = λ{ (_ , g) → record
+          { isoˡ = unitʳ.iso.isoˡ (g , _) ; isoʳ = unitʳ.iso.isoʳ (g , _) } }
+        })
+      ; unitʳ = niHelper (record
+        { η       = λ{ (f , _) → unitˡ.⇒.η (_ , f) }
+        ; η⁻¹     = λ{ (f , _) → unitˡ.⇐.η (_ , f) }
+        ; commute = λ{ (α , _) → unitˡ.⇒.commute (_ , α) }
+        ; iso     = λ{ (f , _) → record
+          { isoˡ = unitˡ.iso.isoˡ (_ , f) ; isoʳ = unitˡ.iso.isoʳ (_ , f) } }
+        })
+      }
+    ; triangle = λ {_ _ _ f g} → begin
+        ρ⇒ ◁ g ∘ᵥ α⇐   ≈˘⟨ switch-tofromʳ (≅.sym associator) triangle ⟩
+        f ▷ λ⇒         ∎
+    ; pentagon = λ {_ _ _ _ _ f g h i} → begin
+        α⇐ ◁ i ∘ᵥ α⇐ ∘ᵥ f ▷ α⇐     ≈˘⟨ hom.assoc ⟩
+        (α⇐ ◁ i ∘ᵥ α⇐) ∘ᵥ f ▷ α⇐   ≈⟨ pentagon-inv ⟩
+        α⇐ ∘ᵥ α⇐                   ∎
+    }
+    where open hom.HomReasoning
+
+  -- The 2-cell dual of C.
+
+  co : Bicategory o ℓ e t
+  co = record
+    { enriched = record
+      { Obj     = Obj
+      ; hom     = λ A B → Category.op (hom A B)
+      ; id      = Functor.op id
+      ; ⊚       = Functor.op ⊚
+      ; ⊚-assoc = NaturalIsomorphism.op′ ⊚-assoc
+      ; unitˡ   = NaturalIsomorphism.op′ unitˡ
+      ; unitʳ   = NaturalIsomorphism.op′ unitʳ
+      }
+    ; triangle  = triangle-inv
+    ; pentagon  = pentagon-inv
+    }
+
+-- The combined 1- and 2-cell dual of C.
+
+coop : ∀ {o ℓ e t} → Bicategory o ℓ e t → Bicategory o ℓ e t
+coop C = co (op C)

--- a/src/Categories/Pseudofunctor.agda
+++ b/src/Categories/Pseudofunctor.agda
@@ -6,29 +6,33 @@ open import Categories.Bicategory using (Bicategory)
 -- Follow Bénabou's definition, which is basically that of a Functor
 
 -- Note that what is in nLab is an "exploded" version of the simpler version below
-module Categories.Pseudofunctor where
+
+module Categories.Pseudofunctor {o ℓ e t o′ ℓ′ e′ t′}
+                                (C : Bicategory o ℓ e t)
+                                (D : Bicategory o′ ℓ′ e′ t′)
+                                where
 
 open import Level
 open import Data.Product using (_,_)
 
-open import Categories.Bicategory.Extras using (module Extras)
-import Categories.Category as Category
-open Category.Category using (Obj)
-open Category using (Category; _[_,_]; module Commutation)
-open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
-open import Categories.Category.Product using (_⁂_)
-open import Categories.NaturalTransformation using (NaturalTransformation)
-open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism; _≃_)
+import Categories.Bicategory.Extras as BicategoryExtras
+open import Categories.Category using (Category; _[_,_]; module Commutation)
 open import Categories.Category.Instance.One using (shift)
+open import Categories.Category.Product using (_⁂_)
+open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
+open import Categories.NaturalTransformation using (NaturalTransformation)
+open import Categories.NaturalTransformation.NaturalIsomorphism
+  using (NaturalIsomorphism; _≃_)
+
+open BicategoryExtras using (module ComHom)
+open Category using (Obj)
 open NaturalIsomorphism using (F⇒G; F⇐G)
 
-record Pseudofunctor {o ℓ e t o′ ℓ′ e′ t′  : Level} (C : Bicategory o ℓ e t) (D : Bicategory o′ ℓ′ e′ t′)
-    : Set (o ⊔ ℓ ⊔ e ⊔ t ⊔ o′ ⊔ ℓ′ ⊔ e′ ⊔ t′) where
-  private
-    module C = Bicategory C using (Obj; hom; id; ⊚; id₁; _⊚₀_)
-    module CC = Extras C using (unitorˡ; unitorʳ; associator)
-    module D = Bicategory D using (Obj; hom; id; ⊚; id₁; id₂; _⊚₀_; _⊚₁_)
-    module DD = Extras D using (unitorˡ; unitorʳ; associator)
+private
+  module C = BicategoryExtras C
+  module D = BicategoryExtras D
+
+record Pseudofunctor : Set (o ⊔ ℓ ⊔ e ⊔ t ⊔ o′ ⊔ ℓ′ ⊔ e′ ⊔ t′) where
 
   field
     P₀ : C.Obj → D.Obj
@@ -39,42 +43,52 @@ record Pseudofunctor {o ℓ e t o′ ℓ′ e′ t′  : Level} (C : Bicategory 
     P-homomorphism : {x y z : C.Obj} → D.⊚ ∘F (P₁ ⁂ P₁) ≃ P₁ ∘F C.⊚ {x} {y} {z}
     -- P preserves ≃
 
+  module P₁ {x} {y} = Functor (P₁ {x} {y})
   module unitˡ {A} = NaturalTransformation (F⇒G (P-identity {A}))
   module unitʳ {A} = NaturalTransformation (F⇐G (P-identity {A}))
   module Hom {x} {y} {z} = NaturalTransformation (F⇒G (P-homomorphism {x} {y} {z}))
 
   -- For notational convenience, shorten some functor applications
   private
-    F₀ = λ {x y} X → Functor.F₀ (P₁ {x} {y}) X
+    F₀   = λ {x y} f → Functor.F₀ (P₁ {x} {y}) f
+    F₁   = λ {x y f g} α → Functor.F₁ (P₁ {x} {y}) {f} {g} α
+    Pid  = λ {A} → NaturalTransformation.η (F⇒G (P-identity {A})) _
+    Phom = λ {x} {y} {z} f,g →
+           NaturalTransformation.η (F⇒G (P-homomorphism {x} {y} {z})) f,g
 
   field
     unitaryˡ : {x y : C.Obj} →
-               let open Commutation (D.hom (P₀ x) (P₀ y)) in
+               let open ComHom D in
                {f : Obj (C.hom x y)} →
-               [ D.id₁ D.⊚₀ (F₀ f)            ⇒ F₀ f ]⟨
-                 unitˡ.η _ D.⊚₁ D.id₂         ⇒⟨ F₀ C.id₁ D.⊚₀ F₀ f ⟩
-                 Hom.η ( C.id₁ , f)           ⇒⟨ F₀ (C.id₁ C.⊚₀ f) ⟩
-                 Functor.F₁ P₁ CC.unitorˡ.from
-               ≈ DD.unitorˡ.from
+               [ D.id₁ D.⊚₀ F₀ f     ⇒ F₀ f ]⟨
+                 Pid D.⊚₁ D.id₂      ⇒⟨ F₀ C.id₁ D.⊚₀ F₀ f ⟩
+                 Phom (C.id₁ , f)    ⇒⟨ F₀ (C.id₁ C.⊚₀ f) ⟩
+                 F₁ C.unitorˡ.from
+               ≈ D.unitorˡ.from
                ⟩
     unitaryʳ : {x y : C.Obj} →
-               let open Commutation (D.hom (P₀ x) (P₀ y)) in
+               let open ComHom D in
                {f : Obj (C.hom x y)} →
-               [ (F₀ f) D.⊚₀ D.id₁             ⇒ F₀ f ]⟨
-                 D.id₂ D.⊚₁ unitˡ.η _          ⇒⟨ F₀ f D.⊚₀ F₀ C.id₁ ⟩
-                 Hom.η ( f , C.id₁ )            ⇒⟨ F₀ (f C.⊚₀ C.id₁) ⟩
-                 Functor.F₁ P₁ (CC.unitorʳ.from)
-               ≈ DD.unitorʳ.from
+               [ F₀ f D.⊚₀ D.id₁     ⇒ F₀ f ]⟨
+                 D.id₂ D.⊚₁ Pid      ⇒⟨ F₀ f D.⊚₀ F₀ C.id₁ ⟩
+                 Phom (f , C.id₁)    ⇒⟨ F₀ (f C.⊚₀ C.id₁) ⟩
+                 F₁ C.unitorʳ.from
+               ≈ D.unitorʳ.from
                ⟩
 
     assoc : {x y z w : C.Obj} →
-            let open Commutation (D.hom (P₀ x) (P₀ w)) in
+            let open ComHom D in
             {f : Obj (C.hom x y)} {g : Obj (C.hom y z)} {h : Obj (C.hom z w)} →
-            [ (F₀ h D.⊚₀ F₀ g) D.⊚₀ F₀ f     ⇒ F₀ (h C.⊚₀ (g C.⊚₀ f)) ]⟨
-              Hom.η (h , g) D.⊚₁ D.id₂       ⇒⟨ F₀ (h C.⊚₀ g) D.⊚₀ F₀ f ⟩
-              Hom.η (_ , f)                   ⇒⟨ F₀ ((h C.⊚₀ g) C.⊚₀ f) ⟩
-              Functor.F₁ P₁ CC.associator.from
-            ≈ DD.associator.from              ⇒⟨ F₀ h D.⊚₀ (F₀ g D.⊚₀ F₀ f) ⟩
-              D.id₂ D.⊚₁ Hom.η (g , f)       ⇒⟨ F₀ h D.⊚₀ F₀ (g C.⊚₀ f) ⟩
-              Hom.η (h , _)
+            [ (F₀ h D.⊚₀ F₀ g) D.⊚₀ F₀ f    ⇒ F₀ (h C.⊚₀ (g C.⊚₀ f)) ]⟨
+              Phom (h , g) D.⊚₁ D.id₂       ⇒⟨ F₀ (h C.⊚₀ g) D.⊚₀ F₀ f ⟩
+              Phom (_ , f)                  ⇒⟨ F₀ ((h C.⊚₀ g) C.⊚₀ f) ⟩
+              F₁ C.associator.from
+            ≈ D.associator.from             ⇒⟨ F₀ h D.⊚₀ (F₀ g D.⊚₀ F₀ f) ⟩
+              D.id₂ D.⊚₁ Phom (g , f)       ⇒⟨ F₀ h D.⊚₀ F₀ (g C.⊚₀ f) ⟩
+              Phom (h , _)
             ⟩
+
+  -- Useful shorthands
+
+  ₀        = P₀
+  module ₁ = P₁


### PR DESCRIPTION
This PR depends on #223 and is a preparation for two other PRs I'm about to submit.

The changes here are not essential, but they make working with bicategories and pseudofunctors ever so slightly easier by reducing the number of modules one has to open and adding some convenient short hands. The PR also cleans up the imports of the Pseudofunctor module.