### PR TITLE
Add a variant of Kelly's monoidal coherence lemmas for bicategories…

### DIFF
--- a/src/Categories/Bicategory/Bigroupoid.agda
+++ b/src/Categories/Bicategory/Bigroupoid.agda
@@ -28,6 +28,7 @@ import Categories.Morphism.Reasoning as MR
 -- https://link.springer.com/article/10.1023/A:1011270417127
 record IsBigroupoid {o ℓ e t} (C : Bicategory o ℓ e t) : Set (o ⊔ ℓ ⊔ e ⊔ t) where
   open BicategoryExtras C
+  open Shorthands
 
   field
     hom-isGroupoid : ∀ A B → IsGroupoid (hom A B)
@@ -51,20 +52,20 @@ record IsBigroupoid {o ℓ e t} (C : Bicategory o ℓ e t) : Set (o ⊔ ℓ ⊔ 
     pentagon₁ : ∀ {A B} {f : A ⇒₁ B} →
                   let open Commutation (hom A B) in
                   [ (f ∘ₕ f ⁻¹) ∘ₕ f ⇒ f ]⟨
-                    associator.from      ⇒⟨ f ∘ₕ f ⁻¹ ∘ₕ f ⟩
-                    f ▷ cancel.⇒.η f     ⇒⟨ f ∘ₕ id₁ ⟩
-                    unitorʳ.from
-                  ≈ cancel′.⇒.η f ◁ f    ⇒⟨ id₁ ∘ₕ f ⟩
-                    unitorˡ.from
+                    α⇒                  ⇒⟨ f ∘ₕ f ⁻¹ ∘ₕ f ⟩
+                    f ▷ cancel.⇒.η f    ⇒⟨ f ∘ₕ id₁ ⟩
+                    ρ⇒
+                  ≈ cancel′.⇒.η f ◁ f   ⇒⟨ id₁ ∘ₕ f ⟩
+                    λ⇒
                   ⟩
     pentagon₂ : ∀ {A B} {f : A ⇒₁ B} →
                   let open Commutation (hom B A) in
                   [ (f ⁻¹ ∘ₕ f) ∘ₕ f ⁻¹ ⇒ f ⁻¹ ]⟨
-                    associator.from            ⇒⟨ f ⁻¹ ∘ₕ f ∘ₕ f ⁻¹ ⟩
-                    f ⁻¹ ▷ cancel′.⇒.η f       ⇒⟨ f ⁻¹ ∘ₕ id₁ ⟩
-                    unitorʳ.from
-                  ≈ cancel.⇒.η f ◁ f ⁻¹        ⇒⟨ id₁ ∘ₕ f ⁻¹ ⟩
-                    unitorˡ.from
+                    α⇒                     ⇒⟨ f ⁻¹ ∘ₕ f ∘ₕ f ⁻¹ ⟩
+                    f ⁻¹ ▷ cancel′.⇒.η f   ⇒⟨ f ⁻¹ ∘ₕ id₁ ⟩
+                    ρ⇒
+                  ≈ cancel.⇒.η f ◁ f ⁻¹    ⇒⟨ id₁ ∘ₕ f ⁻¹ ⟩
+                    λ⇒
                   ⟩
 
   private
@@ -82,68 +83,68 @@ record IsBigroupoid {o ℓ e t} (C : Bicategory o ℓ e t) : Set (o ⊔ ℓ ⊔ 
     open MR′
     module ℱ = Functor
 
-  cancel-comm : ∀ {α : f ⇒₂ g} → cancel.⇒.η g ∘ᵥ (α ⁻¹′ ⊚₁ α) ≈ cancel.⇒.η f
-  cancel-comm {α = α} = cancel.⇒.commute α ○ identity₂ˡ
+  cancel-comm : ∀ {β : f ⇒₂ g} → cancel.⇒.η g ∘ᵥ (β ⁻¹′ ⊚₁ β) ≈ cancel.⇒.η f
+  cancel-comm {β = β} = cancel.⇒.commute β ○ identity₂ˡ
 
-  cancel⁻¹-comm : ∀ {α : f ⇒₂ g} → (α ⁻¹′ ⊚₁ α) ∘ᵥ cancel.⇐.η f ≈ cancel.⇐.η g
-  cancel⁻¹-comm {α = α} = ⟺ (cancel.⇐.commute α) ○ identity₂ʳ
+  cancel⁻¹-comm : ∀ {β : f ⇒₂ g} → (β ⁻¹′ ⊚₁ β) ∘ᵥ cancel.⇐.η f ≈ cancel.⇐.η g
+  cancel⁻¹-comm {β = β} = ⟺ (cancel.⇐.commute β) ○ identity₂ʳ
 
-  cancel′-comm : ∀ {α : f ⇒₂ g} → cancel′.⇒.η g ∘ᵥ (α ⊚₁ α ⁻¹′) ≈ cancel′.⇒.η f
-  cancel′-comm {α = α} = cancel′.⇒.commute α ○ identity₂ˡ
+  cancel′-comm : ∀ {β : f ⇒₂ g} → cancel′.⇒.η g ∘ᵥ (β ⊚₁ β ⁻¹′) ≈ cancel′.⇒.η f
+  cancel′-comm {β = β} = cancel′.⇒.commute β ○ identity₂ˡ
 
-  cancel′⁻¹-comm : ∀ {α : f ⇒₂ g} → (α ⊚₁ α ⁻¹′) ∘ᵥ cancel′.⇐.η f ≈ cancel′.⇐.η g
-  cancel′⁻¹-comm {α = α} = ⟺ (cancel′.⇐.commute α) ○ identity₂ʳ
+  cancel′⁻¹-comm : ∀ {β : f ⇒₂ g} → (β ⊚₁ β ⁻¹′) ∘ᵥ cancel′.⇐.η f ≈ cancel′.⇐.η g
+  cancel′⁻¹-comm {β = β} = ⟺ (cancel′.⇐.commute β) ○ identity₂ʳ
 
   hom⁻¹⁻¹≃id : ∀ {A B} → hom[ B , A ]⁻¹ ∘F hom[ A , B ]⁻¹ ≃ idF
   hom⁻¹⁻¹≃id {A} {B} = record
     { F⇒G = ntHelper record
-      { η       = λ f → (((unitorˡ.from ∘ᵥ cancel.⇒.η (f ⁻¹) ◁ f) ∘ᵥ associator.to) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ unitorʳ.to
-      ; commute = λ {f g} α → begin
-        ((((unitorˡ.from ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ associator.to) ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇐.η g) ∘ᵥ unitorʳ.to) ∘ᵥ α ⁻¹′ ⁻¹′
-          ≈˘⟨ pushʳ ◁-∘ᵥ-λ⁻¹ ⟩
-        (((unitorˡ.from ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ associator.to) ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇐.η g) ∘ᵥ ((α ⁻¹′ ⁻¹′ ◁ id₁) ∘ᵥ unitorʳ.to)
+      { η       = λ f → (((λ⇒ ∘ᵥ cancel.⇒.η (f ⁻¹) ◁ f) ∘ᵥ α⇐) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ ρ⇐
+      ; commute = λ {f g} β → begin
+        ((((λ⇒ ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ α⇐) ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇐.η g) ∘ᵥ ρ⇐) ∘ᵥ β ⁻¹′ ⁻¹′
+          ≈˘⟨ pushʳ ◁-∘ᵥ-ρ⇐ ⟩
+        (((λ⇒ ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ α⇐) ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇐.η g) ∘ᵥ ((β ⁻¹′ ⁻¹′ ◁ id₁) ∘ᵥ ρ⇐)
           ≈⟨ center ◁-▷-exchg ⟩
-        ((unitorˡ.from ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ associator.to) ∘ᵥ (α ⁻¹′ ⁻¹′ ◁ (g ⁻¹ ∘ₕ g) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η g) ∘ᵥ unitorʳ.to
-          ≈⟨ center (⟺ assoc₂ ○ hom.∘-resp-≈ assoc⁻¹-◁-∘ₕ (ℱ.F-resp-≈ ((f ⁻¹ ⁻¹) ⊚-) (⟺ cancel⁻¹-comm))) ⟩
-        (unitorˡ.from ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ ((α ⁻¹′ ⁻¹′ ◁ g ⁻¹ ◁ g ∘ᵥ associator.to) ∘ᵥ f ⁻¹ ⁻¹ ▷ ((α ⁻¹′ ⊚₁ α) ∘ᵥ cancel.⇐.η f)) ∘ᵥ unitorʳ.to
+        ((λ⇒ ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ α⇐) ∘ᵥ (β ⁻¹′ ⁻¹′ ◁ (g ⁻¹ ∘ₕ g) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η g) ∘ᵥ ρ⇐
+          ≈⟨ center (⟺ assoc₂ ○ hom.∘-resp-≈ α⇐-◁-∘ₕ (ℱ.F-resp-≈ ((f ⁻¹ ⁻¹) ⊚-) (⟺ cancel⁻¹-comm))) ⟩
+        (λ⇒ ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ ((β ⁻¹′ ⁻¹′ ◁ g ⁻¹ ◁ g ∘ᵥ α⇐) ∘ᵥ f ⁻¹ ⁻¹ ▷ ((β ⁻¹′ ⊚₁ β) ∘ᵥ cancel.⇐.η f)) ∘ᵥ ρ⇐
           ≈⟨ refl⟩∘⟨ (hom.∘-resp-≈ʳ (ℱ.homomorphism ((f ⁻¹ ⁻¹) ⊚-)) ○ center (⊚-assoc.⇐.commute _) ○ center⁻¹ ([ ⊚ ]-merge (⟺ [ ⊚ ]-decompose₁) identity₂ˡ) refl) ⟩∘⟨refl ⟩
-        (unitorˡ.from ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ (((α ⁻¹′ ⁻¹′ ⊚₁ α ⁻¹′) ⊚₁ α) ∘ᵥ associator.to ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ unitorʳ.to
+        (λ⇒ ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ (((β ⁻¹′ ⁻¹′ ⊚₁ β ⁻¹′) ⊚₁ β) ∘ᵥ α⇐ ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ ρ⇐
           ≈˘⟨ assoc₂ ⟩
-        ((unitorˡ.from ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ (((α ⁻¹′ ⁻¹′ ⊚₁ α ⁻¹′) ⊚₁ α) ∘ᵥ associator.to ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f)) ∘ᵥ unitorʳ.to
+        ((λ⇒ ∘ᵥ cancel.⇒.η (g ⁻¹) ◁ g) ∘ᵥ (((β ⁻¹′ ⁻¹′ ⊚₁ β ⁻¹′) ⊚₁ β) ∘ᵥ α⇐ ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f)) ∘ᵥ ρ⇐
           ≈⟨ center ([ ⊚ ]-merge cancel-comm identity₂ˡ) ⟩∘⟨refl ⟩
-        (unitorˡ.from ∘ᵥ cancel.⇒.η (f ⁻¹) ⊚₁ α ∘ᵥ associator.to ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ unitorʳ.to
+        (λ⇒ ∘ᵥ cancel.⇒.η (f ⁻¹) ⊚₁ β ∘ᵥ α⇐ ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ ρ⇐
           ≈˘⟨ (assoc₂ ○ assoc₂) ⟩∘⟨refl ⟩
-        (((unitorˡ.from ∘ᵥ cancel.⇒.η (f ⁻¹) ⊚₁ α) ∘ᵥ associator.to) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ unitorʳ.to
+        (((λ⇒ ∘ᵥ cancel.⇒.η (f ⁻¹) ⊚₁ β) ∘ᵥ α⇐) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ ρ⇐
           ≈⟨ (hom.∘-resp-≈ʳ [ ⊚ ]-decompose₂) ⟩∘⟨refl ⟩∘⟨refl ⟩∘⟨refl ⟩
-        (((unitorˡ.from ∘ᵥ id₁ ▷ α ∘ᵥ cancel.⇒.η (f ⁻¹) ◁ f) ∘ᵥ associator.to) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ unitorʳ.to
-          ≈⟨ pullˡ ρ-∘ᵥ-▷ ⟩∘⟨refl ⟩∘⟨refl ⟩∘⟨refl ⟩
-        ((((α ∘ᵥ unitorˡ.from) ∘ᵥ cancel.⇒.η (f ⁻¹) ◁ f) ∘ᵥ associator.to) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ unitorʳ.to
+        (((λ⇒ ∘ᵥ id₁ ▷ β ∘ᵥ cancel.⇒.η (f ⁻¹) ◁ f) ∘ᵥ α⇐) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ ρ⇐
+          ≈⟨ pullˡ λ⇒-∘ᵥ-▷ ⟩∘⟨refl ⟩∘⟨refl ⟩∘⟨refl ⟩
+        ((((β ∘ᵥ λ⇒) ∘ᵥ cancel.⇒.η (f ⁻¹) ◁ f) ∘ᵥ α⇐) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ ρ⇐
           ≈⟨ (assoc₂ ○ assoc₂ ○ assoc₂ ○ assoc₂) ⟩
-        α ∘ᵥ unitorˡ.from ∘ᵥ cancel.⇒.η (f ⁻¹) ◁ f ∘ᵥ associator.to ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f ∘ᵥ unitorʳ.to
+        β ∘ᵥ λ⇒ ∘ᵥ cancel.⇒.η (f ⁻¹) ◁ f ∘ᵥ α⇐ ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f ∘ᵥ ρ⇐
           ≈˘⟨ refl⟩∘⟨ (assoc₂ ○ assoc₂ ○ assoc₂) ⟩
-        α ∘ᵥ (((unitorˡ.from ∘ᵥ cancel.⇒.η (f ⁻¹) ◁ f) ∘ᵥ associator.to) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ unitorʳ.to
+        β ∘ᵥ (((λ⇒ ∘ᵥ cancel.⇒.η (f ⁻¹) ◁ f) ∘ᵥ α⇐) ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇐.η f) ∘ᵥ ρ⇐
           ∎
       }
     ; F⇐G = ntHelper record
-      { η       = λ f → unitorʳ.from ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇒.η f ∘ᵥ associator.from ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f ∘ᵥ unitorˡ.to
-      ; commute = λ {f g} α → begin
-        (unitorʳ.from ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ associator.from ∘ᵥ cancel.⇐.η (g ⁻¹) ◁ g ∘ᵥ unitorˡ.to) ∘ᵥ α
+      { η       = λ f → ρ⇒ ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇒.η f ∘ᵥ α⇒ ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f ∘ᵥ λ⇐
+      ; commute = λ {f g} β → begin
+        (ρ⇒ ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ α⇒ ∘ᵥ cancel.⇐.η (g ⁻¹) ◁ g ∘ᵥ λ⇐) ∘ᵥ β
           ≈⟨ assoc₂ ○ hom.∘-resp-≈ʳ (assoc₂ ○ hom.∘-resp-≈ʳ (assoc₂ ○ hom.∘-resp-≈ʳ assoc₂)) ⟩
-        unitorʳ.from ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ associator.from ∘ᵥ cancel.⇐.η (g ⁻¹) ◁ g ∘ᵥ unitorˡ.to ∘ᵥ α
-          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ ▷-∘ᵥ-ρ⁻¹ ⟩
-        unitorʳ.from ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ associator.from ∘ᵥ cancel.⇐.η (g ⁻¹) ◁ g ∘ᵥ id₁ ▷ α ∘ᵥ unitorˡ.to
-          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ pullˡ (⟺ [ ⊚ ]-decompose₁ ○ ⊚.F-resp-≈ (⟺ cancel⁻¹-comm , refl)) ⟩
-        unitorʳ.from ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ associator.from ∘ᵥ (α ⁻¹′ ⁻¹′ ⊚₁ α ⁻¹′ ∘ᵥ cancel.⇐.η (f ⁻¹)) ⊚₁ α ∘ᵥ unitorˡ.to
-          ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ hom.∘-resp-≈ˡ ([ ⊚ ]-merge refl identity₂ʳ) ⟩
-        unitorʳ.from ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ associator.from ∘ᵥ ((α ⁻¹′ ⁻¹′ ⊚₁ α ⁻¹′) ⊚₁ α ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f) ∘ᵥ unitorˡ.to
+        ρ⇒ ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ α⇒ ∘ᵥ cancel.⇐.η (g ⁻¹) ◁ g ∘ᵥ λ⇐ ∘ᵥ β
+          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ ▷-∘ᵥ-λ⇐ ⟩
+        ρ⇒ ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ α⇒ ∘ᵥ cancel.⇐.η (g ⁻¹) ◁ g ∘ᵥ id₁ ▷ β ∘ᵥ λ⇐
+          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ pullˡ (⟺ [ ⊚ ]-decompose₁ ○ ⊚-resp-≈ˡ (⟺ cancel⁻¹-comm)) ⟩
+        ρ⇒ ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ α⇒ ∘ᵥ (β ⁻¹′ ⁻¹′ ⊚₁ β ⁻¹′ ∘ᵥ cancel.⇐.η (f ⁻¹)) ⊚₁ β ∘ᵥ λ⇐
+          ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ [ ⊚ ]-merge refl identity₂ʳ ⟩∘⟨refl ⟩
+        ρ⇒ ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ α⇒ ∘ᵥ ((β ⁻¹′ ⁻¹′ ⊚₁ β ⁻¹′) ⊚₁ β ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f) ∘ᵥ λ⇐
           ≈⟨ refl⟩∘⟨ refl⟩∘⟨ center⁻¹ (⊚-assoc.⇒.commute _) refl ⟩
-        unitorʳ.from ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ (α ⁻¹′ ⁻¹′ ⊚₁ α ⁻¹′ ⊚₁ α ∘ᵥ associator.from) ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f ∘ᵥ unitorˡ.to
+        ρ⇒ ∘ᵥ g ⁻¹ ⁻¹ ▷ cancel.⇒.η g ∘ᵥ (β ⁻¹′ ⁻¹′ ⊚₁ β ⁻¹′ ⊚₁ β ∘ᵥ α⇒) ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f ∘ᵥ λ⇐
           ≈⟨ refl⟩∘⟨ (hom.∘-resp-≈ʳ assoc₂ ○ pullˡ ([ ⊚ ]-merge identity₂ˡ cancel-comm)) ⟩
-        unitorʳ.from ∘ᵥ (α ⁻¹′ ⁻¹′) ⊚₁ (cancel.⇒.η f) ∘ᵥ associator.from ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f ∘ᵥ unitorˡ.to
+        ρ⇒ ∘ᵥ (β ⁻¹′ ⁻¹′) ⊚₁ (cancel.⇒.η f) ∘ᵥ α⇒ ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f ∘ᵥ λ⇐
           ≈⟨ refl⟩∘⟨ (hom.∘-resp-≈ˡ [ ⊚ ]-decompose₁ ○ assoc₂) ⟩
-        unitorʳ.from ∘ᵥ (α ⁻¹′ ⁻¹′) ◁ id₁ ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇒.η f ∘ᵥ associator.from ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f ∘ᵥ unitorˡ.to
-          ≈⟨ (pullˡ λ-∘ᵥ-◁) ○ assoc₂ ⟩
-        α ⁻¹′ ⁻¹′ ∘ᵥ unitorʳ.from ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇒.η f ∘ᵥ associator.from ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f ∘ᵥ unitorˡ.to
+        ρ⇒ ∘ᵥ (β ⁻¹′ ⁻¹′) ◁ id₁ ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇒.η f ∘ᵥ α⇒ ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f ∘ᵥ λ⇐
+          ≈⟨ (pullˡ ρ⇒-∘ᵥ-◁) ○ assoc₂ ⟩
+        β ⁻¹′ ⁻¹′ ∘ᵥ ρ⇒ ∘ᵥ f ⁻¹ ⁻¹ ▷ cancel.⇒.η f ∘ᵥ α⇒ ∘ᵥ cancel.⇐.η (f ⁻¹) ◁ f ∘ᵥ λ⇐
           ∎
       }
     ; iso = λ f → Iso-∘ (Iso-swap (unitʳ.iso _)) $

--- a/src/Categories/Bicategory/Extras.agda
+++ b/src/Categories/Bicategory/Extras.agda
@@ -6,25 +6,32 @@ module Categories.Bicategory.Extras {o ℓ e t} (Bicat : Bicategory o ℓ e t) w
 
 open import Data.Product using (_,_)
 
+open import Categories.Category.Construction.Functors using (Functors; module curry)
 open import Categories.Functor using (Functor)
-open import Categories.Functor.Bifunctor using (appʳ; appˡ)
-open import Categories.Functor.Bifunctor.Properties using ([_]-commute; [_]-merge)
+open import Categories.Functor.Bifunctor using (flip-bifunctor)
+open import Categories.Functor.Bifunctor.Properties
+open import Categories.NaturalTransformation
+  using (NaturalTransformation; ntHelper)
 open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism)
 
 import Categories.Morphism as Mor
 import Categories.Morphism.Reasoning as MR
 import Categories.Morphism.IsoEquiv as IsoEquiv
+open import Categories.NaturalTransformation.NaturalIsomorphism.Properties
+  using (push-eq)
 
 open Bicategory Bicat public
 private
   variable
     A B C D : Obj
     f g h i : A ⇒₁ B
-    α β γ : f ⇒₂ g
+    α β γ δ : f ⇒₂ g
 
 infixr 7 _∘ᵢ_
 infixr 9 _▷ᵢ_
 infixl 9 _◁ᵢ_
+infixr 6 _⟩⊚⟨_ refl⟩⊚⟨_
+infixl 7 _⟩⊚⟨refl
 
 module ⊚ {A B C}          = Functor (⊚ {A} {B} {C})
 module ⊚-assoc {A B C D}  = NaturalIsomorphism (⊚-assoc {A} {B} {C} {D})
@@ -70,12 +77,25 @@ module Shorthands where
   α⇐ = associator.to
 open Shorthands
 
+-- Two curried versions of ⊚.
 
--⊚_ : C ⇒₁ A → Functor (hom A B) (hom C B)
--⊚_ = appʳ ⊚
+-⊚[-] : Functor (hom A B) (Functors (hom B C) (hom A C))
+-⊚[-] = curry.F₀ (flip-bifunctor ⊚)
+
+[-]⊚- : Functor (hom B C) (Functors (hom A B) (hom A C))
+[-]⊚- = curry.F₀ ⊚
+
+-⊚_ : A ⇒₁ B → Functor (hom B C) (hom A C)
+-⊚_ = Functor.F₀ -⊚[-]
 
 _⊚- : B ⇒₁ C → Functor (hom A B) (hom A C)
-_⊚- = appˡ ⊚
+_⊚- = Functor.F₀ [-]⊚-
+
+-▷_ : ∀ {C} → f ⇒₂ g → NaturalTransformation (-⊚_ {C = C} f) (-⊚ g)
+-▷_ = Functor.F₁ -⊚[-]
+
+_◁- : ∀ {A} → f ⇒₂ g → NaturalTransformation (_⊚- {A = A} f) (g ⊚-)
+_◁- = Functor.F₁ [-]⊚-
 
 identity₂ˡ : id₂ ∘ᵥ α ≈ α
 identity₂ˡ = hom.identityˡ
@@ -96,7 +116,7 @@ open hom.HomReasoning
 open hom.Equiv
 private
   module MR′ {A} {B} where
-    open MR (hom A B) using (conjugate-to) public
+    open MR (hom A B) public hiding (push-eq)
     open Mor (hom A B) using (_≅_; module ≅) public
     open IsoEquiv (hom A B) using (⌞_⌟; _≃_) public
   open MR′
@@ -119,44 +139,68 @@ _◁ᵢ_ : {g h : B ⇒₁ C} (α : g ≅ h) (f : A ⇒₁ B) → g ∘ₕ f ≅
 _▷ᵢ_ : {f g : A ⇒₁ B} (h : B ⇒₁ C) (α : f ≅ g) → h ∘ₕ f ≅ h ∘ₕ g
 _ ▷ᵢ α = idᵢ ⊚ᵢ α
 
+⊚-resp-≈ : α ≈ β → γ ≈ δ → α ⊚₁ γ ≈ β ⊚₁ δ
+⊚-resp-≈ p q = ⊚.F-resp-≈ (p , q)
+
+⊚-resp-≈ˡ : α ≈ β → α ⊚₁ γ ≈ β ⊚₁ γ
+⊚-resp-≈ˡ p = ⊚.F-resp-≈ (p , hom.Equiv.refl)
+
+⊚-resp-≈ʳ : γ ≈ δ → α ⊚₁ γ ≈ α ⊚₁ δ
+⊚-resp-≈ʳ q = ⊚.F-resp-≈ (hom.Equiv.refl , q)
+
+_⟩⊚⟨_ : α ≈ β → γ ≈ δ → α ⊚₁ γ ≈ β ⊚₁ δ
+_⟩⊚⟨_ = ⊚-resp-≈
+
+refl⟩⊚⟨_ : γ ≈ δ → α ⊚₁ γ ≈ α ⊚₁ δ
+refl⟩⊚⟨_ = ⊚-resp-≈ʳ
+
+_⟩⊚⟨refl : α ≈ β → α ⊚₁ γ ≈ β ⊚₁ γ
+_⟩⊚⟨refl = ⊚-resp-≈ˡ
+
 ∘ᵥ-distr-◁ : (α ◁ f) ∘ᵥ (β ◁ f) ≈ (α ∘ᵥ β) ◁ f
 ∘ᵥ-distr-◁ {f = f} = ⟺ (Functor.homomorphism (-⊚ f))
 
 ∘ᵥ-distr-▷ : (f ▷ α) ∘ᵥ (f ▷ β) ≈ f ▷ (α ∘ᵥ β)
 ∘ᵥ-distr-▷ {f = f} = ⟺ (Functor.homomorphism (f ⊚-))
 
-ρ-∘ᵥ-▷ : λ⇒ ∘ᵥ (id₁ ▷ α) ≈ α ∘ᵥ λ⇒
-ρ-∘ᵥ-▷ {α = α} = begin
-  λ⇒ ∘ᵥ (id₁ ▷ α)    ≈˘⟨ hom.∘-resp-≈ʳ (⊚.F-resp-≈ (id.identity , refl)) ⟩
+λ⇒-∘ᵥ-▷ : λ⇒ ∘ᵥ (id₁ ▷ α) ≈ α ∘ᵥ λ⇒
+λ⇒-∘ᵥ-▷ {α = α} = begin
+  λ⇒ ∘ᵥ (id₁ ▷ α)    ≈˘⟨ refl⟩∘⟨ id.identity ⟩⊚⟨refl ⟩
   λ⇒ ∘ᵥ id.F₁ _ ⊚₁ α ≈⟨ unitˡ.⇒.commute (_ , α) ⟩
   α ∘ᵥ λ⇒            ∎
 
-▷-∘ᵥ-ρ⁻¹ : (id₁ ▷ α) ∘ᵥ λ⇐ ≈ λ⇐ ∘ᵥ α
-▷-∘ᵥ-ρ⁻¹ = conjugate-to (≅.sym unitorˡ) (≅.sym unitorˡ) ρ-∘ᵥ-▷
+▷-∘ᵥ-λ⇐ : (id₁ ▷ α) ∘ᵥ λ⇐ ≈ λ⇐ ∘ᵥ α
+▷-∘ᵥ-λ⇐ = conjugate-to (≅.sym unitorˡ) (≅.sym unitorˡ) λ⇒-∘ᵥ-▷
 
-λ-∘ᵥ-◁ : ρ⇒ ∘ᵥ (α ◁ id₁) ≈ α ∘ᵥ ρ⇒
-λ-∘ᵥ-◁ {α = α} = begin
-  ρ⇒ ∘ᵥ (α ◁ id₁)      ≈˘⟨ hom.∘-resp-≈ʳ (⊚.F-resp-≈ (refl , id.identity)) ⟩
+ρ⇒-∘ᵥ-◁ : ρ⇒ ∘ᵥ (α ◁ id₁) ≈ α ∘ᵥ ρ⇒
+ρ⇒-∘ᵥ-◁ {α = α} = begin
+  ρ⇒ ∘ᵥ (α ◁ id₁)      ≈˘⟨ refl⟩∘⟨ refl⟩⊚⟨ id.identity ⟩
   ρ⇒ ∘ᵥ (α ⊚₁ id.F₁ _) ≈⟨ unitʳ.⇒.commute (α , _) ⟩
   α ∘ᵥ ρ⇒              ∎
 
-◁-∘ᵥ-λ⁻¹ : (α ◁ id₁) ∘ᵥ ρ⇐ ≈ ρ⇐ ∘ᵥ α
-◁-∘ᵥ-λ⁻¹ = conjugate-to (≅.sym unitorʳ) (≅.sym unitorʳ) λ-∘ᵥ-◁
+◁-∘ᵥ-ρ⇐ : (α ◁ id₁) ∘ᵥ ρ⇐ ≈ ρ⇐ ∘ᵥ α
+◁-∘ᵥ-ρ⇐ = conjugate-to (≅.sym unitorʳ) (≅.sym unitorʳ) ρ⇒-∘ᵥ-◁
 
-assoc⁻¹-◁-∘ₕ : associator.to ∘ᵥ (α ◁ (g ∘ₕ f)) ≈ ((α ◁ g) ◁ f) ∘ᵥ associator.to
-assoc⁻¹-◁-∘ₕ {α = α} {g = g} {f = f} = begin
-  associator.to ∘ᵥ (α ◁ (g ∘ₕ f))    ≈˘⟨ hom.∘-resp-≈ʳ (⊚.F-resp-≈ (refl , ⊚.identity)) ⟩
-  associator.to ∘ᵥ (α ⊚₁ id₂ ⊚₁ id₂) ≈⟨ ⊚-assoc.⇐.commute ((α , id₂) , id₂) ⟩
-  ((α ◁ g) ◁ f) ∘ᵥ associator.to     ∎
+α⇐-◁-∘ₕ : α⇐ ∘ᵥ (γ ◁ (g ∘ₕ f)) ≈ ((γ ◁ g) ◁ f) ∘ᵥ α⇐
+α⇐-◁-∘ₕ {γ = γ} {g = g} {f = f} = begin
+  α⇐ ∘ᵥ (γ ◁ (g ∘ₕ f))    ≈˘⟨ refl⟩∘⟨ refl⟩⊚⟨ ⊚.identity ⟩
+  α⇐ ∘ᵥ (γ ⊚₁ id₂ ⊚₁ id₂)  ≈⟨ ⊚-assoc.⇐.commute ((γ , id₂) , id₂) ⟩
+  ((γ ◁ g) ◁ f) ∘ᵥ α⇐      ∎
 
-assoc⁻¹-▷-◁ : associator.to ∘ᵥ (f ▷ (α ◁ g)) ≈ ((f ▷ α) ◁ g) ∘ᵥ associator.to
-assoc⁻¹-▷-◁ {f = f} {α = α} {g = g} = ⊚-assoc.⇐.commute ((id₂ , α) , id₂)
+α⇒-◁-∘ₕ : α⇒ ∘ᵥ γ ◁ g ◁ f ≈ γ ◁ (g ∘ₕ f) ∘ᵥ α⇒
+α⇒-◁-∘ₕ = ⟺ (conjugate-to associator associator α⇐-◁-∘ₕ)
 
-assoc⁻¹-▷-∘ₕ : associator.to ∘ᵥ (g ▷ (f ▷ α)) ≈ ((g ∘ₕ f) ▷ α) ∘ᵥ associator.to
-assoc⁻¹-▷-∘ₕ {g = g} {f = f} {α = α} = begin
-  associator.to ∘ᵥ (g ▷ (f ▷ α))       ≈⟨ ⊚-assoc.⇐.commute ((id₂ , id₂) , α) ⟩
-  ((id₂ ⊚₁ id₂) ⊚₁ α) ∘ᵥ associator.to ≈⟨ hom.∘-resp-≈ˡ (⊚.F-resp-≈ (⊚.identity , refl)) ⟩
-  ((g ∘ₕ f) ▷ α) ∘ᵥ associator.to      ∎
+α⇐-▷-◁ : α⇐ ∘ᵥ (f ▷ (γ ◁ g)) ≈ ((f ▷ γ) ◁ g) ∘ᵥ α⇐
+α⇐-▷-◁ {f = f} {γ = γ} {g = g} = ⊚-assoc.⇐.commute ((id₂ , γ) , id₂)
+
+α⇒-▷-∘ₕ : α⇒ ∘ᵥ (f ∘ₕ g) ▷ γ ≈ f ▷ g ▷ γ ∘ᵥ α⇒
+α⇒-▷-∘ₕ{f = f} {g = g} {γ = γ} = begin
+  α⇒ ∘ᵥ (f ⊚₀ g) ▷ γ     ≈˘⟨ refl⟩∘⟨ ⊚.identity ⟩⊚⟨refl ⟩
+  α⇒ ∘ᵥ (f ▷ id₂) ⊚₁ γ   ≈⟨ ⊚-assoc.⇒.commute ((id₂ , id₂) , γ) ⟩
+  f ▷ g ▷ γ ∘ᵥ α⇒        ∎
+
+α⇐-▷-∘ₕ : α⇐ ∘ᵥ (g ▷ (f ▷ γ)) ≈ ((g ∘ₕ f) ▷ γ) ∘ᵥ α⇐
+α⇐-▷-∘ₕ = conjugate-from associator associator (⟺ α⇒-▷-∘ₕ)
 
 ◁-▷-exchg : ∀ {α : f ⇒₂ g} {β : h ⇒₂ i} → (i ▷ α) ∘ᵥ (β ◁ f) ≈ (β ◁ g) ∘ᵥ (h ▷ α)
 ◁-▷-exchg = [ ⊚ ]-commute
@@ -176,3 +220,116 @@ pentagon-iso = ⌞ pentagon ⌟
 pentagon-inv : ∀ {E} {f : A ⇒₁ B} {g : B ⇒₁ C} {h : C ⇒₁ D} {i : D ⇒₁ E} →
                (α⇐ ◁ f ∘ᵥ α⇐) ∘ᵥ i ▷ α⇐ ≈ α⇐ ∘ᵥ α⇐ {f = i} {h} {g ∘ₕ f}
 pentagon-inv = _≃_.to-≈ pentagon-iso
+
+module UnitorCoherence where
+
+  -- Extra coherence laws for the unitors.
+  --
+  -- These are similar to the extra coherence laws for monoidal
+  -- categories that Kelly proved admissible in 1964.  The proofs are
+  -- largely the same.  See Categories.Category.Monoidal.Properties
+  -- for the monoidal versions and
+  --
+  --   https://ncatlab.org/nlab/show/monoidal+category
+  --
+  -- for an explanation of the proof and references to Kelly's paper.
+
+  open ComHom
+
+  -- As described on nLab, we start by proving that the 'perimeters'
+  -- of two large diagrams commute...
+
+  id▷λ-perimeter : [ ((id₁ ⊚₀ id₁) ⊚₀ f) ⊚₀ g ⇒ id₁ ⊚₀ (f ⊚₀ g) ]⟨
+                     α⇒ ◁ g       ⇒⟨ (id₁ ⊚₀ (id₁ ⊚₀ f)) ⊚₀ g ⟩
+                     α⇒           ⇒⟨ id₁ ⊚₀ ((id₁ ⊚₀ f) ⊚₀ g) ⟩
+                     id₁ ▷ α⇒     ⇒⟨ id₁ ⊚₀ (id₁ ⊚₀ (f ⊚₀ g)) ⟩
+                     id₁ ▷ λ⇒
+                   ≈ ρ⇒ ◁ f ◁ g   ⇒⟨ (id₁ ⊚₀ f) ⊚₀ g ⟩
+                     α⇒
+                   ⟩
+  id▷λ-perimeter {f = f} {g = g} = begin
+    id₁ ▷ λ⇒ ∘ᵥ id₁ ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ g   ≈⟨ refl⟩∘⟨ pentagon ⟩
+    id₁ ▷ λ⇒ ∘ᵥ α⇒ ∘ᵥ α⇒                   ≈⟨ pullˡ triangle ⟩
+    ρ⇒ ◁ (f ⊚₀ g) ∘ᵥ α⇒                    ≈˘⟨ refl⟩⊚⟨ ⊚.identity ⟩∘⟨refl ⟩
+    ρ⇒ ⊚₁ (id₂ ◁ g) ∘ᵥ α⇒                  ≈˘⟨ ⊚-assoc.⇒.commute _ ⟩
+    α⇒ ∘ᵥ ρ⇒ ◁ f ◁ g                       ∎
+
+  ρ◁id-perimeter : [ ((f ⊚₀ g) ⊚₀ id₁) ⊚₀ id₁ ⇒ f ⊚₀ (g ⊚₀ id₁) ]⟨
+                     α⇒ ◁ id₁     ⇒⟨ (f ⊚₀ (g ⊚₀ id₁)) ⊚₀ id₁ ⟩
+                     α⇒           ⇒⟨ f ⊚₀ ((g ⊚₀ id₁) ⊚₀ id₁) ⟩
+                     f ▷ α⇒       ⇒⟨ f ⊚₀ (g ⊚₀ (id₁ ⊚₀ id₁)) ⟩
+                     f ▷ g ▷ λ⇒
+                   ≈ ρ⇒ ◁ id₁     ⇒⟨ (f ⊚₀ g) ⊚₀ id₁ ⟩
+                     α⇒
+                   ⟩
+  ρ◁id-perimeter {f = f} {g = g} = begin
+    f ▷ g ▷ λ⇒ ∘ᵥ f ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ id₁   ≈⟨ refl⟩∘⟨ pentagon ⟩
+    f ▷ g ▷ λ⇒ ∘ᵥ α⇒ ∘ᵥ α⇒                   ≈˘⟨ pushˡ (⊚-assoc.⇒.commute _) ⟩
+    (α⇒ ∘ᵥ (f ▷ id₂) ⊚₁ λ⇒) ∘ᵥ α⇒       ≈⟨ pullʳ (⊚.identity ⟩⊚⟨refl ⟩∘⟨refl) ⟩
+    α⇒ ∘ᵥ (f ⊚₀ g) ▷ λ⇒ ∘ᵥ α⇒           ≈⟨ refl⟩∘⟨ triangle ⟩
+    α⇒ ∘ᵥ ρ⇒ ◁ id₁                      ∎
+
+  -- ... which allow us to prove that the following triangles commute...
+
+  id▷λ-coherence : [ id₁ ⊚₀ ((id₁ ⊚₀ f) ⊚₀ g) ⇒ id₁ ⊚₀ (f ⊚₀ g) ]⟨
+                     id₁ ▷ (λ⇒ ◁ g)
+                   ≈ id₁ ▷ α⇒         ⇒⟨ id₁ ⊚₀ (id₁ ⊚₀ (f ⊚₀ g)) ⟩
+                     id₁ ▷ λ⇒
+                   ⟩
+  id▷λ-coherence {f = f} {g = g} = begin
+      id₁ ▷ (λ⇒ ◁ g)
+    ≈⟨ switch-fromtoʳ associator (⟺ (⊚-assoc.⇒.commute _)) ⟩
+      (α⇒ ∘ᵥ (id₁ ▷ λ⇒) ◁ g) ∘ᵥ α⇐
+    ≈⟨ (refl⟩∘⟨ switch-fromtoʳ associator triangle ⟩⊚⟨refl) ⟩∘⟨refl ⟩
+      (α⇒ ∘ᵥ ((ρ⇒ ◁ f ∘ᵥ α⇐) ◁ g)) ∘ᵥ α⇐
+    ≈⟨ pushˡ (pushʳ (Functor.homomorphism (-⊚ g))) ⟩
+      (α⇒ ∘ᵥ ρ⇒ ◁ f ◁ g) ∘ᵥ (α⇐ ◁ g ∘ᵥ α⇐)
+    ≈˘⟨ switch-fromtoʳ (associator ∘ᵢ (associator ⊚ᵢ idᵢ))
+                       (hom.assoc ○ id▷λ-perimeter) ⟩
+      id₁ ▷ λ⇒ ∘ᵥ id₁ ▷ α⇒
+    ∎
+
+  ρ◁id-coherence : [ ((f ⊚₀ g) ⊚₀ id₁) ⊚₀ id₁ ⇒ (f ⊚₀ g) ⊚₀ id₁ ]⟨
+                     ρ⇒ ◁ id₁
+                   ≈ α⇒ ◁ id₁          ⇒⟨ (f ⊚₀ (g ⊚₀ id₁)) ⊚₀ id₁ ⟩
+                     (f ▷ ρ⇒) ◁ id₁
+                   ⟩
+  ρ◁id-coherence {f = f} {g = g} = begin
+      ρ⇒ ◁ id₁
+    ≈⟨ switch-fromtoˡ associator (⟺ ρ◁id-perimeter) ⟩
+      α⇐ ∘ᵥ f ▷ g ▷ λ⇒ ∘ᵥ f ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ id₁
+    ≈˘⟨ pullʳ (pushˡ (Functor.homomorphism (f ⊚-))) ⟩
+      (α⇐ ∘ᵥ f ▷ (g ▷ λ⇒ ∘ᵥ α⇒)) ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ id₁
+    ≈⟨ pullˡ (pushˡ (refl⟩∘⟨ refl⟩⊚⟨ triangle)) ⟩
+      (α⇐ ∘ᵥ f ▷ (ρ⇒ ◁ id₁) ∘ᵥ α⇒) ∘ᵥ α⇒ ◁ id₁
+    ≈˘⟨ switch-fromtoˡ associator (⊚-assoc.⇒.commute _) ⟩∘⟨refl ⟩
+      (f ▷ ρ⇒) ◁ id₁ ∘ᵥ α⇒ ◁ id₁
+    ∎
+
+  -- ... which are the results modulo (id₁ ⊚-) and (-⊚ id₁).
+
+  unitorˡ-coherence : [ (id₁ ⊚₀ f) ⊚₀ g ⇒ f ⊚₀ g ]⟨
+                        λ⇒ ◁ g
+                      ≈ α⇒         ⇒⟨ id₁ ⊚₀ (f ⊚₀ g) ⟩
+                        λ⇒
+                      ⟩
+  unitorˡ-coherence {f = f} {g = g} = push-eq unitˡ (begin
+    id.F₁ _ ⊚₁ (λ⇒ ◁ g)     ≈⟨ id.identity ⟩⊚⟨refl ⟩
+    id₁ ▷ (λ⇒ ◁ g)          ≈⟨ id▷λ-coherence ⟩
+    id₁ ▷ λ⇒ ∘ᵥ id₁ ▷ α⇒    ≈˘⟨ Functor.homomorphism (id₁ ⊚-) ⟩
+    id₁ ▷ (λ⇒ ∘ᵥ α⇒)        ≈˘⟨ id.identity ⟩⊚⟨refl ⟩
+    id.F₁ _ ⊚₁ (λ⇒ ∘ᵥ α⇒)   ∎)
+
+  unitorʳ-coherence : [ (f ⊚₀ g) ⊚₀ id₁ ⇒ f ⊚₀ g ]⟨
+                        ρ⇒
+                      ≈ α⇒         ⇒⟨ f ⊚₀ (g ⊚₀ id₁) ⟩
+                        f ▷ ρ⇒
+                      ⟩
+  unitorʳ-coherence {f = f} {g = g} = push-eq unitʳ (begin
+    ρ⇒ ⊚₁ id.F₁ _                ≈⟨ refl⟩⊚⟨ id.identity ⟩
+    ρ⇒ ◁ id₁                     ≈⟨ ρ◁id-coherence ⟩
+    (f ▷ ρ⇒) ◁ id₁ ∘ᵥ α⇒ ◁ id₁   ≈˘⟨ Functor.homomorphism (-⊚ id₁) ⟩
+    (f ▷ ρ⇒ ∘ᵥ α⇒) ◁ id₁         ≈˘⟨ refl⟩⊚⟨ id.identity ⟩
+    (f ▷ ρ⇒ ∘ᵥ α⇒) ⊚₁ id.F₁ _    ∎)
+
+open UnitorCoherence public using (unitorˡ-coherence; unitorʳ-coherence)


### PR DESCRIPTION
… and some other lemmas and support for working with bicategories that was missing (shorthands, reasoning combinators, etc.)

The PR also fixes some inconsistently named lemmas (e.g. `λ-∘ᵥ-◁` was about the right unitor, while `ρ-∘ᵥ-▷` was about the left unitor) and updates dependencies.