### PR TITLE
Split Pullback into predicate and bundled forms, and correct the definition of Subobject Classifiers

### DIFF
--- a/src/Categories/Category/CartesianClosed/Locally.agda
+++ b/src/Categories/Category/CartesianClosed/Locally.agda
@@ -38,11 +38,13 @@ record Locally : Set (levelOfTerm C) where
     { P               = sliceobj (X.arr ∘ p.p₁)
     ; p₁              = slicearr refl
     ; p₂              = slicearr comm
-    ; commute         = p.commute
-    ; universal       = λ {Z} {h i} eq → slicearr {h = p.universal eq} (pullʳ p.p₁∘universal≈h₁ ○ Slice⇒.△ h)
-    ; unique          = λ eq₁ eq₂ → p.unique eq₁ eq₂
-    ; p₁∘universal≈h₁ = p.p₁∘universal≈h₁
-    ; p₂∘universal≈h₂ = p.p₂∘universal≈h₂
+    ; isPullback = record
+      { commute         = p.commute
+      ; universal       = λ {Z} {h i} eq → slicearr {h = p.universal eq} (pullʳ p.p₁∘universal≈h₁ ○ Slice⇒.△ h)
+      ; unique          = λ eq₁ eq₂ → p.unique eq₁ eq₂
+      ; p₁∘universal≈h₁ = p.p₁∘universal≈h₁
+      ; p₂∘universal≈h₂ = p.p₂∘universal≈h₂
+      }
     }
     where open HomReasoning
           open Equiv

--- a/src/Categories/Category/Slice/Properties.agda
+++ b/src/Categories/Category/Slice/Properties.agda
@@ -27,11 +27,13 @@ module _ {A : C.Obj} where
   product⇒pullback p = record
     { p₁              = h π₁
     ; p₂              = h π₂
-    ; commute         = △ π₁ ○ ⟺ (△ π₂)
-    ; universal       = λ eq → h ⟨ slicearr eq , slicearr refl ⟩
-    ; unique          = λ {_ _ _ _ eq} eq′ eq″ → ⟺ (unique {h = slicearr (pushˡ (⟺ (△ π₁)) ○ C.∘-resp-≈ʳ eq′ ○ eq)} eq′ eq″)
-    ; p₁∘universal≈h₁ = project₁
-    ; p₂∘universal≈h₂ = project₂
+    ; isPullback = record
+      { commute         = △ π₁ ○ ⟺ (△ π₂)
+      ; universal       = λ eq → h ⟨ slicearr eq , slicearr refl ⟩
+      ; unique          = λ {_ _ _ _ eq} eq′ eq″ → ⟺ (unique {h = slicearr (pushˡ (⟺ (△ π₁)) ○ C.∘-resp-≈ʳ eq′ ○ eq)} eq′ eq″)
+      ; p₁∘universal≈h₁ = project₁
+      ; p₂∘universal≈h₂ = project₂
+      }
     }
     where open Product (Slice A) p
 

--- a/src/Categories/Diagram/Duality.agda
+++ b/src/Categories/Diagram/Duality.agda
@@ -72,11 +72,13 @@ Pushout⇒coPullback : Pushout f g → Pullback f g
 Pushout⇒coPullback p = record
   { p₁              = i₁
   ; p₂              = i₂
-  ; commute         = commute
-  ; universal       = universal
-  ; unique          = unique
-  ; p₁∘universal≈h₁ = universal∘i₁≈h₁
-  ; p₂∘universal≈h₂ = universal∘i₂≈h₂
+  ; isPullback = record
+    { commute         = commute
+    ; universal       = universal
+    ; unique          = unique
+    ; p₁∘universal≈h₁ = universal∘i₁≈h₁
+    ; p₂∘universal≈h₂ = universal∘i₂≈h₂
+    }
   }
   where open Pushout p
 

--- a/src/Categories/Diagram/Pullback.agda
+++ b/src/Categories/Diagram/Pullback.agda
@@ -21,13 +21,8 @@ private
     A B X Y Z : Obj
     f g h h₁ h₂ i i₁ i₂ j k : A ⇒ B
 
--- Pullback of two arrows with a common codomain
-record Pullback (f : X ⇒ Z) (g : Y ⇒ Z) : Set (o ⊔ ℓ ⊔ e) where
-  field
-    {P} : Obj
-    p₁  : P ⇒ X
-    p₂  : P ⇒ Y
-
+-- Proof that a given square is a pullback
+record IsPullback {P : Obj} (p₁ : P ⇒ X) (p₂ : P ⇒ Y) (f : X ⇒ Z) (g : Y ⇒ Z) : Set (o ⊔ ℓ ⊔ e) where
   field
     commute   : f ∘ p₁ ≈ g ∘ p₂
     universal : ∀ {h₁ : A ⇒ X} {h₂ : A ⇒ Y} → f ∘ h₁ ≈ g ∘ h₂ → A ⇒ P
@@ -57,6 +52,17 @@ record Pullback (f : X ⇒ Z) (g : Y ⇒ Z) : Set (o ⊔ ℓ ⊔ e) where
     universal eq ≈˘⟨ unique refl refl ⟩
     i            ∎
     where eq = extendʳ commute
+  
+
+-- Pullback of two arrows with a common codomain
+record Pullback (f : X ⇒ Z) (g : Y ⇒ Z) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    {P} : Obj
+    p₁  : P ⇒ X
+    p₂  : P ⇒ Y
+    isPullback : IsPullback p₁ p₂ f g
+
+  open IsPullback isPullback public
 
 up-to-iso : (pullback pullback′ : Pullback f g) → Pullback.P pullback ≅ Pullback.P pullback′
 up-to-iso pullback pullback′ = record
@@ -88,11 +94,13 @@ swap : Pullback f g → Pullback g f
 swap p = record
   { p₁              = p₂
   ; p₂              = p₁
-  ; commute        = ⟺ commute
-  ; universal       = universal ● ⟺
-  ; unique          = flip unique
-  ; p₁∘universal≈h₁ = p₂∘universal≈h₂
-  ; p₂∘universal≈h₂ = p₁∘universal≈h₁
+  ; isPullback = record
+    { commute          = ⟺ commute
+    ; universal       = universal ● ⟺
+    ; unique          = flip unique
+    ; p₁∘universal≈h₁ = p₂∘universal≈h₂
+    ; p₂∘universal≈h₂ = p₁∘universal≈h₁
+    }
   }
   where open Pullback p
 
@@ -100,16 +108,18 @@ glue : (p : Pullback f g) → Pullback h (Pullback.p₁ p) → Pullback (f ∘ h
 glue {h = h} p q = record
   { p₁              = q.p₁
   ; p₂              = p.p₂ ∘ q.p₂
-  ; commute        = glue-square p.commute q.commute
-  ; universal       = λ eq → q.universal (⟺ (p.p₁∘universal≈h₁ {eq = sym-assoc ○ eq}))
-  ; unique          = λ {_ h₁ h₂ i} eq eq′ →
-    q.unique eq (p.unique (begin
-      p.p₁ ∘ q.p₂ ∘ i ≈˘⟨ extendʳ q.commute ⟩
-      h ∘ q.p₁ ∘ i    ≈⟨ refl⟩∘⟨ eq ⟩
-      h ∘ h₁          ∎)
-                          (sym-assoc ○ eq′))
-  ; p₁∘universal≈h₁ = q.p₁∘universal≈h₁
-  ; p₂∘universal≈h₂ = assoc ○ ∘-resp-≈ʳ q.p₂∘universal≈h₂ ○ p.p₂∘universal≈h₂
+  ; isPullback = record
+    { commute        = glue-square p.commute q.commute
+    ; universal       = λ eq → q.universal (⟺ (p.p₁∘universal≈h₁ {eq = sym-assoc ○ eq}))
+    ; unique          = λ {_ h₁ h₂ i} eq eq′ →
+      q.unique eq (p.unique (begin
+        p.p₁ ∘ q.p₂ ∘ i ≈˘⟨ extendʳ q.commute ⟩
+        h ∘ q.p₁ ∘ i    ≈⟨ refl⟩∘⟨ eq ⟩
+        h ∘ h₁          ∎)
+                            (sym-assoc ○ eq′))
+    ; p₁∘universal≈h₁ = q.p₁∘universal≈h₁
+    ; p₂∘universal≈h₂ = assoc ○ ∘-resp-≈ʳ q.p₂∘universal≈h₂ ○ p.p₂∘universal≈h₂
+    }
   }
   where module p = Pullback p
         module q = Pullback q
@@ -118,19 +128,21 @@ unglue : (p : Pullback f g) → Pullback (f ∘ h) g → Pullback h (Pullback.p�
 unglue {f = f} {g = g} {h = h} p q = record
   { p₁              = q.p₁
   ; p₂              = p₂′
-  ; commute        = ⟺ p.p₁∘universal≈h₁
-  ; universal       = λ {_ h₁ h₂} eq → q.universal $ begin
-    (f ∘ h) ∘ h₁      ≈⟨ pullʳ eq ⟩
-    f ∘ p.p₁ ∘ h₂     ≈⟨ extendʳ p.commute ⟩
-    g ∘ p.p₂ ∘ h₂     ∎
-  ; unique          = λ {_ h₁ h₂ i} eq eq′ → q.unique eq $ begin
-  q.p₂ ∘ i            ≈⟨ pushˡ (⟺ p.p₂∘universal≈h₂) ⟩
-  p.p₂ ∘ p₂′ ∘ i      ≈⟨ refl⟩∘⟨ eq′ ⟩
-  p.p₂ ∘ h₂           ∎
-  ; p₁∘universal≈h₁ = q.p₁∘universal≈h₁
-  ; p₂∘universal≈h₂ = λ {_ _ _ eq} →
-    p.unique-diagram ((pullˡ p.p₁∘universal≈h₁) ○ pullʳ q.p₁∘universal≈h₁ ○ eq)
-                     (pullˡ p.p₂∘universal≈h₂ ○ q.p₂∘universal≈h₂)
+  ; isPullback = record
+    { commute        = ⟺ p.p₁∘universal≈h₁
+    ; universal       = λ {_ h₁ h₂} eq → q.universal $ begin
+      (f ∘ h) ∘ h₁      ≈⟨ pullʳ eq ⟩
+      f ∘ p.p₁ ∘ h₂     ≈⟨ extendʳ p.commute ⟩
+      g ∘ p.p₂ ∘ h₂     ∎
+    ; unique          = λ {_ h₁ h₂ i} eq eq′ → q.unique eq $ begin
+    q.p₂ ∘ i            ≈⟨ pushˡ (⟺ p.p₂∘universal≈h₂) ⟩
+    p.p₂ ∘ p₂′ ∘ i      ≈⟨ refl⟩∘⟨ eq′ ⟩
+    p.p₂ ∘ h₂           ∎
+    ; p₁∘universal≈h₁ = q.p₁∘universal≈h₁
+    ; p₂∘universal≈h₂ = λ {_ _ _ eq} →
+      p.unique-diagram ((pullˡ p.p₁∘universal≈h₁) ○ pullʳ q.p₁∘universal≈h₁ ○ eq)
+                       (pullˡ p.p₂∘universal≈h₂ ○ q.p₂∘universal≈h₂)
+    }
   }
   where module p = Pullback p
         module q = Pullback q
@@ -142,15 +154,17 @@ Product×Equalizer⇒Pullback :
 Product×Equalizer⇒Pullback {f = f} {g = g} p e = record
   { p₁              = π₁ ∘ arr
   ; p₂              = π₂ ∘ arr
-  ; commute         = sym-assoc ○ equality ○ assoc
-  ; universal       = λ {_ h₁ h₂} eq → equalize $ begin
-    (f ∘ π₁) ∘ ⟨ h₁ , h₂ ⟩ ≈⟨ pullʳ project₁ ⟩
-    f ∘ h₁                ≈⟨ eq ⟩
-    g ∘ h₂                ≈˘⟨ pullʳ project₂ ⟩
-    (g ∘ π₂) ∘ ⟨ h₁ , h₂ ⟩ ∎
-  ; unique          = λ eq eq′ → e.unique (p.unique (sym-assoc ○ eq) (sym-assoc ○ eq′))
-  ; p₁∘universal≈h₁ = pullʳ (⟺ e.universal) ○ project₁
-  ; p₂∘universal≈h₂ = pullʳ (⟺ e.universal) ○ project₂
+  ; isPullback = record
+    { commute         = sym-assoc ○ equality ○ assoc
+    ; universal       = λ {_ h₁ h₂} eq → equalize $ begin
+      (f ∘ π₁) ∘ ⟨ h₁ , h₂ ⟩ ≈⟨ pullʳ project₁ ⟩
+      f ∘ h₁                ≈⟨ eq ⟩
+      g ∘ h₂                ≈˘⟨ pullʳ project₂ ⟩
+      (g ∘ π₂) ∘ ⟨ h₁ , h₂ ⟩ ∎
+    ; unique          = λ eq eq′ → e.unique (p.unique (sym-assoc ○ eq) (sym-assoc ○ eq′))
+    ; p₁∘universal≈h₁ = pullʳ (⟺ e.universal) ○ project₁
+    ; p₂∘universal≈h₂ = pullʳ (⟺ e.universal) ○ project₂
+    }
   }
   where module p = Product p
         module e = Equalizer e
@@ -186,11 +200,13 @@ module _ (p : Pullback f g) where
   Pullback-resp-≈ eq eq′ = record
     { p₁              = p₁
     ; p₂              = p₂
-    ; commute         = ∘-resp-≈ˡ eq ○ commute ○ ⟺ (∘-resp-≈ˡ eq′)
-    ; universal       = λ eq″ → universal (∘-resp-≈ˡ (⟺ eq) ○ eq″ ○ ∘-resp-≈ˡ eq′)
-    ; unique          = unique
-    ; p₁∘universal≈h₁ = p₁∘universal≈h₁
-    ; p₂∘universal≈h₂ = p₂∘universal≈h₂
+    ; isPullback = record
+      { commute         = ∘-resp-≈ˡ eq ○ commute ○ ⟺ (∘-resp-≈ˡ eq′)
+      ; universal       = λ eq″ → universal (∘-resp-≈ˡ (⟺ eq) ○ eq″ ○ ∘-resp-≈ˡ eq′)
+      ; unique          = unique
+      ; p₁∘universal≈h₁ = p₁∘universal≈h₁
+      ; p₂∘universal≈h₂ = p₂∘universal≈h₂
+      }
     }
 
   Pullback-resp-Mono : Mono g → Mono p₁

--- a/src/Categories/Diagram/Pullback/Limit.agda
+++ b/src/Categories/Diagram/Pullback/Limit.agda
@@ -48,11 +48,13 @@ module _ {F : Functor Span.op C} where
   limit⇒pullback lim = record
     { p₁              = proj left
     ; p₂              = proj right
-    ; commute         = trans (limit-commute span-arrˡ) (sym (limit-commute span-arrʳ))
-    ; universal       = universal
-    ; unique          = commute′
-    ; p₁∘universal≈h₁ = commute
-    ; p₂∘universal≈h₂ = commute
+    ; isPullback = record
+      { commute         = trans (limit-commute span-arrˡ) (sym (limit-commute span-arrʳ))
+      ; universal       = universal
+      ; unique          = commute′
+      ; p₁∘universal≈h₁ = commute
+      ; p₂∘universal≈h₂ = commute
+      }
     }
     where open Limit lim
           open Equiv

--- a/src/Categories/Diagram/Pullback/Properties.agda
+++ b/src/Categories/Diagram/Pullback/Properties.agda
@@ -40,11 +40,13 @@ module _ (t : Terminal) where
   product⇒pullback-⊤ p = record
     { p₁              = π₁
     ; p₂              = π₂
-    ; commute         = !-unique₂
-    ; universal       = λ {_ f g} _ → ⟨ f , g ⟩
-    ; unique          = λ eq eq′ → ⟺ (unique eq eq′)
-    ; p₁∘universal≈h₁ = project₁
-    ; p₂∘universal≈h₂ = project₂
+    ; isPullback = record
+      { commute         = !-unique₂
+      ; universal       = λ {_ f g} _ → ⟨ f , g ⟩
+      ; unique          = λ eq eq′ → ⟺ (unique eq eq′)
+      ; p₁∘universal≈h₁ = project₁
+      ; p₂∘universal≈h₂ = project₂
+      }
     }
     where open Product p
 
@@ -56,11 +58,13 @@ module _ (p : Pullback f g) where
   pullback-resp-≈ eq eq′ = record
     { p₁              = p₁
     ; p₂              = p₂
-    ; commute         = ∘-resp-≈ˡ (⟺ eq) ○ commute ○ ∘-resp-≈ˡ eq′
-    ; universal       = λ eq″ → universal (∘-resp-≈ˡ eq ○ eq″ ○ ∘-resp-≈ˡ (⟺ eq′))
-    ; unique          = unique
-    ; p₁∘universal≈h₁ = p₁∘universal≈h₁
-    ; p₂∘universal≈h₂ = p₂∘universal≈h₂
+    ; isPullback = record
+      { commute         = ∘-resp-≈ˡ (⟺ eq) ○ commute ○ ∘-resp-≈ˡ eq′
+      ; universal       = λ eq″ → universal (∘-resp-≈ˡ eq ○ eq″ ○ ∘-resp-≈ˡ (⟺ eq′))
+      ; unique          = unique
+      ; p₁∘universal≈h₁ = p₁∘universal≈h₁
+      ; p₂∘universal≈h₂ = p₂∘universal≈h₂
+      }
     }
 
 -- Some facts about pulling back along identity

--- a/src/Categories/Diagram/SubobjectClassifier.agda
+++ b/src/Categories/Diagram/SubobjectClassifier.agda
@@ -26,5 +26,5 @@ record SubobjectClassifier : Set (o ⊔ ℓ ⊔ e) where
   field
     true      : ⊤ ⇒ Ω
     universal : ∀ {X Y} {f : X ⇒ Y} → Mono f → Y ⇒ Ω
-    pullback  : ∀ {X Y} {f : X ⇒ Y} {mono : Mono f} → Pullback (universal mono) true
-    unique    : ∀ {X Y} {f : X ⇒ Y} {g} {mono : Mono f} → Pullback g true → universal mono ≈ g
+    pullback  : ∀ {X Y} {f : X ⇒ Y} {mono : Mono f} → IsPullback f ! (universal mono) true
+    unique    : ∀ {X Y} {f : X ⇒ Y} {g} {mono : Mono f} → IsPullback f ! g true → universal mono ≈ g


### PR DESCRIPTION
As discussed in the [Zulip](https://agda.zulipchat.com/#narrow/stream/263194-Categories/topic/Incorrect.20Definition.20of.20Subobject.20Classifiers), the current definition of Subobject Classifiers is just slightly off. As Andrea pointed out, it is equivalent to saying that there is only one subobject for every object! Luckily the fix is very easy. We just need to split `Pullback` into a predicate and bundled form, and then re-phrase the definition of Subobject Classifiers in terms of the predicate form.