### PR TITLE
Define Kernels and Normal Monomorphisms

### DIFF
--- a/src/Categories/Category/Cartesian/Properties.agda
+++ b/src/Categories/Category/Cartesian/Properties.agda
@@ -46,19 +46,21 @@ module _ (prods : BinaryProducts) (pullbacks : ∀ {A B X} (f : A ⇒ X) (g : B 
   prods×pullbacks⇒equalizers : Equalizer f g
   prods×pullbacks⇒equalizers {f = f} {g = g} = record
     { arr       = pb′.p₁
-    ; equality  = begin
-      f ∘ pb′.p₁           ≈⟨ refl⟩∘⟨ helper₁ ⟩
-      f ∘ pb.p₁ ∘ pb′.p₂   ≈⟨ pullˡ pb.commute ⟩
-      (g ∘ pb.p₂) ∘ pb′.p₂ ≈˘⟨ pushʳ helper₂ ⟩
-      g ∘ pb′.p₁           ∎
-    ; equalize  = λ {_ i} eq → pb′.universal $ begin
-      ⟨ id , id ⟩ ∘ i                                       ≈⟨ ⟨⟩∘ ⟩
-      ⟨ id ∘ i , id ∘ i ⟩                                   ≈⟨ ⟨⟩-cong₂ identityˡ identityˡ ⟩
-      ⟨ i ,  i ⟩                                            ≈˘⟨ ⟨⟩-cong₂ pb.p₁∘universal≈h₁ pb.p₂∘universal≈h₂ ⟩
-      ⟨ pb.p₁ ∘ pb.universal eq , pb.p₂ ∘ pb.universal eq ⟩ ≈˘⟨ ⟨⟩∘ ⟩
-      h ∘ pb.universal eq                                   ∎
-    ; universal = ⟺ pb′.p₁∘universal≈h₁
-    ; unique    = λ eq → pb′.unique (⟺ eq) (pb.unique (pullˡ (⟺ helper₁) ○ ⟺ eq) (pullˡ (⟺ helper₂) ○ ⟺ eq))
+    ; isEqualizer = record
+      { equality  = begin
+        f ∘ pb′.p₁           ≈⟨ refl⟩∘⟨ helper₁ ⟩
+        f ∘ pb.p₁ ∘ pb′.p₂   ≈⟨ pullˡ pb.commute ⟩
+        (g ∘ pb.p₂) ∘ pb′.p₂ ≈˘⟨ pushʳ helper₂ ⟩
+        g ∘ pb′.p₁           ∎
+      ; equalize  = λ {_ i} eq → pb′.universal $ begin
+        ⟨ id , id ⟩ ∘ i                                       ≈⟨ ⟨⟩∘ ⟩
+        ⟨ id ∘ i , id ∘ i ⟩                                   ≈⟨ ⟨⟩-cong₂ identityˡ identityˡ ⟩
+        ⟨ i ,  i ⟩                                            ≈˘⟨ ⟨⟩-cong₂ pb.p₁∘universal≈h₁ pb.p₂∘universal≈h₂ ⟩
+        ⟨ pb.p₁ ∘ pb.universal eq , pb.p₂ ∘ pb.universal eq ⟩ ≈˘⟨ ⟨⟩∘ ⟩
+        h ∘ pb.universal eq                                   ∎
+      ; universal = ⟺ pb′.p₁∘universal≈h₁
+      ; unique    = λ eq → pb′.unique (⟺ eq) (pb.unique (pullˡ (⟺ helper₁) ○ ⟺ eq) (pullˡ (⟺ helper₂) ○ ⟺ eq))
+      }
     }
     where pb : Pullback f g
           pb         = pullbacks _ _

--- a/src/Categories/Diagram/Duality.agda
+++ b/src/Categories/Diagram/Duality.agda
@@ -39,10 +39,12 @@ private
 Coequalizer⇒coEqualizer : Coequalizer f g → Equalizer f g
 Coequalizer⇒coEqualizer coe = record
   { arr       = arr
-  ; equality  = equality
-  ; equalize  = coequalize
-  ; universal = universal
-  ; unique    = unique
+  ; isEqualizer = record
+    { equality  = equality
+    ; equalize  = coequalize
+    ; universal = universal
+    ; unique    = unique
+    }
   }
   where open Coequalizer coe
 

--- a/src/Categories/Diagram/Equalizer.agda
+++ b/src/Categories/Diagram/Equalizer.agda
@@ -19,13 +19,10 @@ private
     A B X : Obj
     h i j k : A ⇒ B
 
-record Equalizer (f g : A ⇒ B) : Set (o ⊔ ℓ ⊔ e) where
+record IsEqualizer {E} (arr : E ⇒ A) (f g : A ⇒ B) : Set (o ⊔ ℓ ⊔ e) where
   field
-    {obj} : Obj
-    arr   : obj ⇒ A
-
-    equality  : f ∘ arr ≈ g ∘ arr
-    equalize  : ∀ {h : X ⇒ A} → f ∘ h ≈ g ∘ h → X ⇒ obj
+    equality : f ∘ arr ≈ g ∘ arr
+    equalize : ∀ {h : X ⇒ A} → f ∘ h ≈ g ∘ h → X ⇒ E
     universal : ∀ {eq : f ∘ h ≈ g ∘ h} → h ≈ arr ∘ equalize eq
     unique    : ∀ {eq : f ∘ h ≈ g ∘ h} → h ≈ arr ∘ i → i ≈ equalize eq
 
@@ -61,6 +58,14 @@ record Equalizer (f g : A ⇒ B) : Set (o ⊔ ℓ ⊔ e) where
     h                           ≈⟨ unique (sym eq) ⟩
     equalize (extendʳ equality) ≈˘⟨ unique refl ⟩
     i                           ∎
+
+record Equalizer (f g : A ⇒ B) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    {obj} : Obj
+    arr   : obj ⇒ A
+    isEqualizer : IsEqualizer arr f g
+
+  open IsEqualizer isEqualizer public
 
 Equalizer⇒Mono : (e : Equalizer h i) → Mono (Equalizer.arr e)
 Equalizer⇒Mono e f g eq =

--- a/src/Categories/Diagram/Equalizer/Limit.agda
+++ b/src/Categories/Diagram/Equalizer/Limit.agda
@@ -36,26 +36,28 @@ module _ {o′ ℓ′ e′} {F : Functor (liftC o′ ℓ′ e′ Parallel) C} wh
   limit⇒equalizer L = record
     { obj       = apex
     ; arr       = proj (lift 0F)
-    ; equality  = limit-commute (lift 0F) ○ ⟺ (limit-commute (lift 1F))
-    ; equalize  = λ {_} {h} eq → rep record
-      { apex = record
-        { ψ       = λ { (lift 0F) → h
-                      ; (lift 1F) → F₁ (lift 1F) ∘ h }
-        ; commute = λ { {lift 0F} {lift 0F} (lift 0F) → elimˡ identity
-                      ; {lift 0F} {lift 1F} (lift 0F) → eq
-                      ; {lift 0F} {lift 1F} (lift 1F) → refl
-                      ; {lift 1F} {lift 1F} (lift 0F) → elimˡ identity }
+    ; isEqualizer = record
+      { equality  = limit-commute (lift 0F) ○ ⟺ (limit-commute (lift 1F))
+      ; equalize  = λ {_} {h} eq → rep record
+        { apex = record
+          { ψ       = λ { (lift 0F) → h
+                        ; (lift 1F) → F₁ (lift 1F) ∘ h }
+          ; commute = λ { {lift 0F} {lift 0F} (lift 0F) → elimˡ identity
+                        ; {lift 0F} {lift 1F} (lift 0F) → eq
+                        ; {lift 0F} {lift 1F} (lift 1F) → refl
+                        ; {lift 1F} {lift 1F} (lift 0F) → elimˡ identity }
+          }
         }
-      }
-    ; universal = ⟺ commute
-    ; unique    = λ {_} {h i} eq → ⟺ (terminal.!-unique record
-      { arr = i
-      ; commute = λ { {lift 0F} → ⟺ eq
-                    ; {lift 1F} → begin
-                      proj (lift 1F) ∘ i                ≈˘⟨ pullˡ (limit-commute (lift 1F)) ⟩
-                      F₁ (lift 1F) ∘ proj (lift 0F) ∘ i ≈˘⟨ refl⟩∘⟨ eq ⟩
-                      F₁ (lift 1F) ∘ h                  ∎ }
-      })
+      ; universal = ⟺ commute
+      ; unique    = λ {_} {h i} eq → ⟺ (terminal.!-unique record
+        { arr = i
+        ; commute = λ { {lift 0F} → ⟺ eq
+                      ; {lift 1F} → begin
+                        proj (lift 1F) ∘ i                ≈˘⟨ pullˡ (limit-commute (lift 1F)) ⟩
+                        F₁ (lift 1F) ∘ proj (lift 0F) ∘ i ≈˘⟨ refl⟩∘⟨ eq ⟩
+                        F₁ (lift 1F) ∘ h                  ∎ }
+        })
+    }
     }
     where open Limit L
 

--- a/src/Categories/Diagram/Pullback.agda
+++ b/src/Categories/Diagram/Pullback.agda
@@ -175,18 +175,20 @@ Product×Pullback⇒Equalizer : (p : Product A B) → Pullback f g →
   Equalizer (f ∘ Product.π₁ p) (g ∘ Product.π₂ p)
 Product×Pullback⇒Equalizer {f = f} {g = g} p pu = record
   { arr       = ⟨ p₁ , p₂ ⟩
-  ; equality  = begin
-    (f ∘ π₁) ∘ ⟨ p₁ , p₂ ⟩ ≈⟨ pullʳ project₁ ⟩
-    f ∘ p₁                 ≈⟨ commute ⟩
-    g ∘ p₂                 ≈˘⟨ pullʳ project₂ ⟩
-    (g ∘ π₂) ∘ ⟨ p₁ , p₂ ⟩ ∎
-  ; equalize  = λ eq → pu.universal (sym-assoc ○ eq ○ assoc)
-  ; universal = λ {_ h} → begin
-    h                      ≈˘⟨ p.unique (⟺ p₁∘universal≈h₁) (⟺ p₂∘universal≈h₂) ⟩
-    ⟨ p₁ ∘ _ , p₂ ∘ _ ⟩    ≈⟨ p.unique (pullˡ project₁) (pullˡ project₂) ⟩
-    ⟨ p₁ , p₂ ⟩ ∘ _        ∎
-  ; unique    = λ eq → pu.unique (pushˡ (⟺ project₁) ○ ⟺ (∘-resp-≈ʳ eq))
-                                 (pushˡ (⟺ project₂) ○ ⟺ (∘-resp-≈ʳ eq))
+  ; isEqualizer = record
+    { equality  = begin
+      (f ∘ π₁) ∘ ⟨ p₁ , p₂ ⟩ ≈⟨ pullʳ project₁ ⟩
+      f ∘ p₁                 ≈⟨ commute ⟩
+      g ∘ p₂                 ≈˘⟨ pullʳ project₂ ⟩
+      (g ∘ π₂) ∘ ⟨ p₁ , p₂ ⟩ ∎
+    ; equalize  = λ eq → pu.universal (sym-assoc ○ eq ○ assoc)
+    ; universal = λ {_ h} → begin
+      h                      ≈˘⟨ p.unique (⟺ p₁∘universal≈h₁) (⟺ p₂∘universal≈h₂) ⟩
+      ⟨ p₁ ∘ _ , p₂ ∘ _ ⟩    ≈⟨ p.unique (pullˡ project₁) (pullˡ project₂) ⟩
+      ⟨ p₁ , p₂ ⟩ ∘ _        ∎
+    ; unique    = λ eq → pu.unique (pushˡ (⟺ project₁) ○ ⟺ (∘-resp-≈ʳ eq))
+                                   (pushˡ (⟺ project₂) ○ ⟺ (∘-resp-≈ʳ eq))
+  }
   }
   where module p = Product p
         module pu = Pullback pu

--- a/src/Categories/Diagram/Pullback/Properties.agda
+++ b/src/Categories/Diagram/Pullback/Properties.agda
@@ -93,15 +93,17 @@ module _ (pullbacks : ∀ {X Y Z} (f : X ⇒ Z) (g : Y ⇒ Z) → Pullback f g)
   pullback×cartesian⇒equalizer : Equalizer f g
   pullback×cartesian⇒equalizer {f = f} {g = g} = record
     { arr       = p.p₁
-    ; equality  = equality
-    ; equalize  = λ {_ h} eq → p.universal $ begin
-      ⟨ f , g ⟩ ∘ h               ≈⟨ ⟨⟩∘ ⟩
-      ⟨ f ∘ h , g ∘ h ⟩           ≈˘⟨ ⟨⟩-cong₂ identityˡ (identityˡ ○ eq) ⟩
-      ⟨ id ∘ f ∘ h , id ∘ f ∘ h ⟩ ≈˘⟨ ⟨⟩∘ ⟩
-      ⟨ id , id ⟩ ∘ f ∘ h         ∎
-    ; universal = ⟺ p.p₁∘universal≈h₁
-    ; unique    = λ eq → p.unique (⟺ eq)
-                                  (⟺ (pullˡ eq′) ○ ⟺ (∘-resp-≈ʳ eq))
+    ; isEqualizer = record
+      { equality  = equality
+      ; equalize  = λ {_ h} eq → p.universal $ begin
+        ⟨ f , g ⟩ ∘ h               ≈⟨ ⟨⟩∘ ⟩
+        ⟨ f ∘ h , g ∘ h ⟩           ≈˘⟨ ⟨⟩-cong₂ identityˡ (identityˡ ○ eq) ⟩
+        ⟨ id ∘ f ∘ h , id ∘ f ∘ h ⟩ ≈˘⟨ ⟨⟩∘ ⟩
+        ⟨ id , id ⟩ ∘ f ∘ h         ∎
+      ; universal = ⟺ p.p₁∘universal≈h₁
+      ; unique    = λ eq → p.unique (⟺ eq)
+                                    (⟺ (pullˡ eq′) ○ ⟺ (∘-resp-≈ʳ eq))
+      }
     }
     where p : Pullback ⟨ f , g ⟩ ⟨ id , id ⟩
           p = pullbacks _ _

--- a/src/Categories/Diagram/Pullback/Properties.agda
+++ b/src/Categories/Diagram/Pullback/Properties.agda
@@ -11,6 +11,7 @@ open import Categories.Diagram.Pullback C
 open import Categories.Diagram.Equalizer C
 open import Categories.Object.Product C
 open import Categories.Object.Terminal C
+open import Categories.Morphism C
 open import Categories.Morphism.Reasoning C
 
 private
@@ -19,6 +20,17 @@ private
     X Y Z : Obj
     f g h i : X ⇒ Y
 open HomReasoning
+open Equiv
+
+-- pullbacks of a monomorphism along itself give us the identity arrow.
+pullback-self-mono : Mono f → IsPullback id id f f
+pullback-self-mono mono = record
+  { commute = refl
+  ; universal = λ {X} {h₁} {h₂} eq → h₁
+  ; unique = λ id∘i≈h₁ _ → ⟺ identityˡ ○ id∘i≈h₁
+  ; p₁∘universal≈h₁ = identityˡ
+  ; p₂∘universal≈h₂ = λ {X} {h₁} {h₂} {eq} → identityˡ ○ mono h₁ h₂ eq
+  }
 
 -- pullback from a terminal object is the same as a product
 module _ (t : Terminal) where

--- a/src/Categories/Morphism/Normal.agda
+++ b/src/Categories/Morphism/Normal.agda
@@ -1,0 +1,34 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core
+open import Categories.Object.Zero
+
+-- Normal Mono and Epimorphisms
+-- https://ncatlab.org/nlab/show/normal+monomorphism
+module Categories.Morphism.Normal {o ℓ e} (𝒞 : Category o ℓ e) (𝒞-Zero : Zero 𝒞) where
+
+open import Level
+
+open import Categories.Object.Kernel 𝒞-Zero
+open import Categories.Object.Kernel.Properties 𝒞-Zero
+open import Categories.Morphism 𝒞
+
+open Category 𝒞
+
+record IsNormalMonomorphism {A K : Obj} (k : K ⇒ A) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    {B} : Obj
+    arr : A ⇒ B
+    isKernel : IsKernel k arr
+
+  open IsKernel isKernel public
+
+  mono : Mono k
+  mono = Kernel-Mono (IsKernel⇒Kernel isKernel)
+
+record NormalMonomorphism (K A : Obj) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    mor : K ⇒ A
+    isNormalMonomorphism : IsNormalMonomorphism mor
+
+  open IsNormalMonomorphism isNormalMonomorphism public

--- a/src/Categories/Object/Kernel.agda
+++ b/src/Categories/Object/Kernel.agda
@@ -1,0 +1,54 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category
+open import Categories.Object.Zero
+
+-- Kernels of morphisms.
+-- https://ncatlab.org/nlab/show/kernel
+module Categories.Object.Kernel {o ℓ e} {𝒞 : Category o ℓ e} (zero : Zero 𝒞) where
+
+open import Level using (_⊔_)
+
+open import Categories.Morphism 𝒞
+open import Categories.Morphism.Reasoning 𝒞
+  hiding (glue)
+
+open Category 𝒞
+open Zero zero
+
+open HomReasoning
+
+private
+  variable
+    A B X : Obj
+    f h i j k : A ⇒ B
+
+-- Note: We could define Kernels directly as equalizers or as pullbacks, but it seems somewhat
+-- cleaner to just define them "as is" to avoid mucking about with extra morphisms that can
+-- get in the way. For example, if we defined them as 'Pullback f !' then our 'p₂' projection
+-- would _always_ be trivially equal to '¡ : K ⇒ zero'.
+
+record IsKernel {A B K} (k : K ⇒ A) (f : A ⇒ B) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    commute : f ∘ k ≈ zero⇒
+    universal : ∀ {X} {h : X ⇒ A} → f ∘ h ≈ zero⇒ → X ⇒ K 
+    factors : ∀ {eq : f ∘ h ≈ zero⇒} → h ≈ k ∘ universal eq
+    unique : ∀ {eq : f ∘ h ≈ zero⇒} → h ≈ k ∘ i → i ≈ universal eq
+
+  universal-resp-≈ : ∀ {eq : f ∘ h ≈ zero⇒} {eq′ : f ∘ i ≈ zero⇒} →
+    h ≈ i → universal eq ≈ universal eq′
+  universal-resp-≈ h≈i = unique (⟺ h≈i ○ factors)
+
+  universal-∘ : f ∘ k ∘ h ≈ zero⇒ 
+  universal-∘ {h = h} = begin
+    f ∘ k ∘ h ≈⟨ pullˡ commute ⟩
+    zero⇒ ∘ h ≈⟨ pullʳ (⟺ (¡-unique (¡ ∘ h))) ⟩
+    zero⇒ ∎
+
+record Kernel {A B} (f : A ⇒ B) : Set (o ⊔ ℓ ⊔ e) where
+  field
+     {kernel} : Obj
+     kernel⇒ : kernel ⇒ A
+     isKernel : IsKernel kernel⇒ f
+
+  open IsKernel isKernel public

--- a/src/Categories/Object/Kernel.agda
+++ b/src/Categories/Object/Kernel.agda
@@ -52,3 +52,9 @@ record Kernel {A B} (f : A ⇒ B) : Set (o ⊔ ℓ ⊔ e) where
      isKernel : IsKernel kernel⇒ f
 
   open IsKernel isKernel public
+
+IsKernel⇒Kernel : IsKernel k f → Kernel f
+IsKernel⇒Kernel {k = k} isKernel = record
+  { kernel⇒ = k
+  ; isKernel = isKernel
+  }

--- a/src/Categories/Object/Kernel/Properties.agda
+++ b/src/Categories/Object/Kernel/Properties.agda
@@ -1,0 +1,133 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category
+open import Categories.Object.Zero
+
+module Categories.Object.Kernel.Properties {o ℓ e} {𝒞 : Category o ℓ e} (𝒞-Zero : Zero 𝒞) where
+
+open import Function using (_$_)
+
+open import Categories.Diagram.Equalizer 𝒞
+open import Categories.Diagram.Pullback 𝒞 renaming (glue to glue-pullback; up-to-iso to pullback-up-to-iso)
+open import Categories.Diagram.Pullback.Properties 𝒞
+open import Categories.Object.Kernel 𝒞-Zero
+open import Categories.Object.Terminal 𝒞
+
+open import Categories.Morphism 𝒞
+open import Categories.Morphism.Reasoning 𝒞
+
+open Category 𝒞
+open HomReasoning
+open Equiv
+
+open Zero 𝒞-Zero
+
+private
+  variable
+    A B : Obj
+    f : A ⇒ B
+
+-- We can express kernels as pullbacks along the morphism '! : ⊥ ⇒ A'.
+Kernel⇒Pullback : Kernel f → Pullback f !
+Kernel⇒Pullback {f = f} kernel = record
+  { p₁ = kernel⇒
+  ; p₂ = ¡
+  ; isPullback = record
+    { commute = commute
+    ; universal = λ {C} {h₁} {h₂} eq → universal {h = h₁} $ begin
+      f ∘ h₁ ≈⟨ eq ⟩
+      ! ∘ h₂ ≈˘⟨ refl⟩∘⟨ ¡-unique h₂ ⟩
+      zero⇒ ∎
+    ; unique = λ {C} {h₁} {h₂} {i} k-eq h-eq → unique $ begin
+      h₁ ≈˘⟨ k-eq ⟩
+      kernel⇒ ∘ i ∎
+    ; p₁∘universal≈h₁ = ⟺ factors
+    ; p₂∘universal≈h₂ = ¡-unique₂ _ _
+    }
+  }
+  where
+    open Kernel kernel
+
+-- All pullbacks along the morphism '! : ⊥ ⇒ A' are also kernels.
+Pullback⇒Kernel : Pullback f ! → Kernel f
+Pullback⇒Kernel {f = f} pullback = record
+  { kernel⇒ = p₁
+  ; isKernel = record
+    { commute = begin
+      f ∘ p₁ ≈⟨ commute ⟩
+      ! ∘ p₂ ≈˘⟨ refl⟩∘⟨ ¡-unique p₂ ⟩
+      zero⇒ ∎
+    ; universal = λ eq → universal eq
+    ; factors = ⟺ p₁∘universal≈h₁
+    ; unique = λ eq → unique (⟺ eq) (⟺ (¡-unique _))
+    }
+  }
+  where
+    open Pullback pullback
+
+-- We can also express kernels as the equalizer of 'f' and the zero morphism.
+Kernel⇒Equalizer : Kernel f → Equalizer f zero⇒
+Kernel⇒Equalizer {f = f} kernel = record
+  { arr = kernel⇒
+  ; isEqualizer = record
+    { equality = begin
+      f ∘ kernel⇒ ≈⟨ commute ⟩
+      zero⇒       ≈⟨ pushʳ (¡-unique (¡ ∘ kernel⇒)) ⟩
+      zero⇒ ∘ kernel⇒ ∎
+    ; equalize = λ {_} {h} eq → universal (eq ○ pullʳ (⟺ (¡-unique (¡ ∘ h))))
+    ; universal = factors
+    ; unique = unique
+    }
+  }
+  where
+    open Kernel kernel
+
+-- Furthermore, all equalizers of 'f' and the zero morphism are equalizers
+Equalizer⇒Kernel : Equalizer f zero⇒ → Kernel f
+Equalizer⇒Kernel {f = f} equalizer = record
+  { kernel⇒ = arr
+  ; isKernel = record
+    { commute = begin
+      f ∘ arr      ≈⟨ equality ⟩
+      zero⇒ ∘ arr ≈⟨ pullʳ (⟺ (¡-unique (¡ ∘ arr))) ⟩
+      zero⇒ ∎
+    ; universal = λ {_} {h} eq → equalize (eq ○ pushʳ (¡-unique (¡ ∘ h)))
+    ; factors = universal
+    ; unique = unique
+    }
+  }
+  where
+    open Equalizer equalizer
+
+module _ (K : Kernel f) where
+  open Kernel K
+
+  Kernel-Mono : Mono kernel⇒
+  Kernel-Mono g₁ g₂ eq = begin
+    g₁ ≈⟨ unique refl ⟩
+    universal universal-∘ ≈˘⟨ unique eq ⟩
+    g₂ ∎
+
+module _ (has-kernels : ∀ {A B} → (f : A ⇒ B) → Kernel f) where
+
+  -- The kernel of a kernel is isomorphic to the zero object.
+  kernel²-zero : ∀ {A B} {f : A ⇒ B} → Kernel.kernel (has-kernels (Kernel.kernel⇒ (has-kernels f))) ≅ zero
+  kernel²-zero {B = B} {f = f} = pullback-up-to-iso kernel-pullback (pullback-mono-mono !-Mono)
+    where
+      K : Kernel f
+      K = has-kernels f
+
+      module K = Kernel K
+
+      K′ : Kernel K.kernel⇒
+      K′ = has-kernels K.kernel⇒
+
+      kernel-pullback : Pullback ! !
+      kernel-pullback = Pullback-resp-≈ (glue-pullback (Kernel⇒Pullback K) (swap (Kernel⇒Pullback K′))) (!-unique (f ∘ !)) refl
+
+      pullback-mono-mono : ∀ {A B} {f : A ⇒ B} → Mono f → Pullback f f
+      pullback-mono-mono mono = record
+        { p₁ = id
+        ; p₂ = id
+        ; isPullback = pullback-self-mono mono
+        }

--- a/src/Categories/Object/Zero.agda
+++ b/src/Categories/Object/Zero.agda
@@ -10,7 +10,10 @@ open import Level using (_⊔_)
 open import Categories.Object.Terminal C
 open import Categories.Object.Initial C
 
+open import Categories.Morphism C
+
 open Category C
+open HomReasoning
 
 record Zero : Set (o ⊔ ℓ ⊔ e) where
  field
@@ -18,9 +21,19 @@ record Zero : Set (o ⊔ ℓ ⊔ e) where
    !    : ∀ {A} → zero ⇒ A
    ¡    : ∀ {A} → A ⇒ zero
 
+ zero⇒ : ∀ {A B : Obj} → A ⇒ B
+ zero⇒ {A} = ! ∘ ¡
+
  field
    !-unique : ∀ {A} (f : zero ⇒ A) → ! ≈ f
    ¡-unique : ∀ {A} (f : A ⇒ zero) → ¡ ≈ f
+
+ ¡-unique₂ : ∀ {A} (f g : A ⇒ zero) → f ≈ g
+ ¡-unique₂ f g = ⟺ (¡-unique f) ○ ¡-unique g
+
+ !-unique₂ : ∀ {A} (f g : zero ⇒ A) → f ≈ g
+ !-unique₂ f g = ⟺ (!-unique f) ○ !-unique g
+
 
  initial : Initial
  initial = record
@@ -42,3 +55,9 @@ record Zero : Set (o ⊔ ℓ ⊔ e) where
 
  module initial  = Initial initial
  module terminal = Terminal terminal
+
+ !-Mono : ∀ {A} → Mono (! {A})
+ !-Mono = from-⊤-is-Mono {t = terminal} !
+
+ ¡-Epi : ∀ {A} → Epi (¡ {A})
+ ¡-Epi = to-⊥-is-Epi {i = initial} ¡


### PR DESCRIPTION
## Patch Description
This PR implements Kernels and Normal Monomorphisms, which moves us closer to being able to use `agda-categories` to do some group theory!

## Notes
I took this opportunity to split up equalizers into a bundled and predicate form, as this is going to be useful when we start working with regular morphisms (of which normal morphisms are a subset).

## References:
https://ncatlab.org/nlab/show/kernel
https://ncatlab.org/nlab/show/normal+monomorphism