### PR TITLE
Show that we can build Equivalences of Categories from Pointwise Isomorphisms

### DIFF
--- a/src/Categories/Category/Equivalence/Properties.agda
+++ b/src/Categories/Category/Equivalence/Properties.agda
@@ -6,10 +6,14 @@ module Categories.Category.Equivalence.Properties where
 
 open import Level
 
+open import Data.Product using (Σ-syntax; _,_; proj₁)
+
 open import Categories.Adjoint.Equivalence using (⊣Equivalence)
+open import Categories.Adjoint
 open import Categories.Adjoint.TwoSided using (_⊣⊢_; withZig)
-open import Categories.Category.Core
+open import Categories.Category
 open import Categories.Category.Equivalence using (WeakInverse; StrongEquivalence)
+open import Categories.Morphism
 import Categories.Morphism.Reasoning as MR
 import Categories.Morphism.Properties as MP
 open import Categories.Functor renaming (id to idF)
@@ -115,3 +119,68 @@ module _ {o ℓ e o′ ℓ′ e′} {C : Category o ℓ e} {D : Category o′ �
     }
 
   module C≅D = ⊣Equivalence C≅D
+
+module _ {F : Functor C D} {G : Functor D C} (F⊣G : F ⊣ G) where
+  private
+    module C = Category C
+    module D = Category D
+    module F = Functor F
+    module G = Functor G
+
+  open Adjoint F⊣G
+
+  -- If the unit and the counit of an adjuction are pointwise isomorphisms, then they form an equivalence of categories.
+  pointwise-iso-equivalence : (∀ X → Σ[ f ∈ C [  G.F₀ (F.F₀ X) , X ] ] Iso C (unit.η X) f) → (∀ X → Σ[ f ∈ D [ X , F.F₀ (G.F₀ X) ] ] Iso D (counit.η X) f) → WeakInverse F G
+  pointwise-iso-equivalence unit-iso counit-iso = record
+    { F∘G≈id = record
+      { F⇒G = counit
+      ; F⇐G = ntHelper record
+        { η = λ X → proj₁ (counit-iso X)
+        ; commute = λ {X} {Y} f →
+          let open D
+              open HomReasoning
+              open Equiv
+              open MR D
+              (toˣ , isoˣ) = counit-iso X
+              (toʸ , isoʸ) = counit-iso Y
+          in begin
+            toʸ ∘ f                                    ≈⟨ introʳ (isoʳ isoˣ) ⟩
+            (toʸ ∘ f) ∘ (counit.η X ∘ toˣ)             ≈⟨ extend² (counit.sym-commute f) ⟩
+            (toʸ ∘ counit.η Y) ∘ (F.F₁ (G.F₁ f) ∘ toˣ) ≈⟨ elimˡ (isoˡ isoʸ) ⟩
+            F.F₁ (G.F₁ f) ∘ toˣ                        ∎
+        }
+      ; iso = λ X →
+        let (_ , isoˣ) = counit-iso X
+        in record
+          { isoˡ = isoˡ isoˣ
+          ; isoʳ = isoʳ isoˣ
+          }
+      }
+    ; G∘F≈id = record
+      { F⇒G = ntHelper record
+        { η = λ X → proj₁ (unit-iso X)
+        ; commute = λ {X} {Y} f →
+          let open C
+              open HomReasoning
+              open Equiv
+              open MR C
+              (toˣ , isoˣ) = unit-iso X
+              (toʸ , isoʸ) = unit-iso Y
+          in begin
+            toʸ ∘ G.F₁ (F.F₁ f)                   ≈⟨ introʳ (isoʳ isoˣ) ⟩
+            (toʸ ∘ G.F₁ (F.₁ f)) ∘ unit.η X ∘ toˣ ≈⟨ extend² (unit.sym-commute f)  ⟩
+            (toʸ ∘ unit.η Y) ∘ f ∘ toˣ            ≈⟨ elimˡ (isoˡ isoʸ) ⟩
+            f ∘ toˣ                               ∎
+        }
+      ; F⇐G = unit
+      ; iso = λ X →
+        let (_ , isoˣ) = unit-iso X
+        in record
+          { isoˡ = isoʳ isoˣ
+          ; isoʳ = isoˡ isoˣ
+          }
+      }
+    }
+    where
+      open Iso
+

--- a/src/Categories/Category/Equivalence/Properties.agda
+++ b/src/Categories/Category/Equivalence/Properties.agda
@@ -21,6 +21,7 @@ open import Categories.Functor.Properties using ([_]-resp-Iso)
 open import Categories.NaturalTransformation using (ntHelper; _∘ᵥ_; _∘ˡ_; _∘ʳ_)
 open import Categories.NaturalTransformation.NaturalIsomorphism as ≃
   using (NaturalIsomorphism ; unitorˡ; unitorʳ; associator; _ⓘᵥ_; _ⓘˡ_; _ⓘʳ_)
+open import Categories.NaturalTransformation.NaturalIsomorphism.Properties using (pointwise-iso)
 
 private
   variable
@@ -130,57 +131,16 @@ module _ {F : Functor C D} {G : Functor D C} (F⊣G : F ⊣ G) where
   open Adjoint F⊣G
 
   -- If the unit and the counit of an adjuction are pointwise isomorphisms, then they form an equivalence of categories.
-  pointwise-iso-equivalence : (∀ X → Σ[ f ∈ C [  G.F₀ (F.F₀ X) , X ] ] Iso C (unit.η X) f) → (∀ X → Σ[ f ∈ D [ X , F.F₀ (G.F₀ X) ] ] Iso D (counit.η X) f) → WeakInverse F G
-  pointwise-iso-equivalence unit-iso counit-iso = record
-    { F∘G≈id = record
-      { F⇒G = counit
-      ; F⇐G = ntHelper record
-        { η = λ X → proj₁ (counit-iso X)
-        ; commute = λ {X} {Y} f →
-          let open D
-              open HomReasoning
-              open Equiv
-              open MR D
-              (toˣ , isoˣ) = counit-iso X
-              (toʸ , isoʸ) = counit-iso Y
-          in begin
-            toʸ ∘ f                                    ≈⟨ introʳ (isoʳ isoˣ) ⟩
-            (toʸ ∘ f) ∘ (counit.η X ∘ toˣ)             ≈⟨ extend² (counit.sym-commute f) ⟩
-            (toʸ ∘ counit.η Y) ∘ (F.F₁ (G.F₁ f) ∘ toˣ) ≈⟨ elimˡ (isoˡ isoʸ) ⟩
-            F.F₁ (G.F₁ f) ∘ toˣ                        ∎
-        }
-      ; iso = λ X →
-        let (_ , isoˣ) = counit-iso X
-        in record
-          { isoˡ = isoˡ isoˣ
-          ; isoʳ = isoʳ isoˣ
-          }
-      }
-    ; G∘F≈id = record
-      { F⇒G = ntHelper record
-        { η = λ X → proj₁ (unit-iso X)
-        ; commute = λ {X} {Y} f →
-          let open C
-              open HomReasoning
-              open Equiv
-              open MR C
-              (toˣ , isoˣ) = unit-iso X
-              (toʸ , isoʸ) = unit-iso Y
-          in begin
-            toʸ ∘ G.F₁ (F.F₁ f)                   ≈⟨ introʳ (isoʳ isoˣ) ⟩
-            (toʸ ∘ G.F₁ (F.₁ f)) ∘ unit.η X ∘ toˣ ≈⟨ extend² (unit.sym-commute f)  ⟩
-            (toʸ ∘ unit.η Y) ∘ f ∘ toˣ            ≈⟨ elimˡ (isoˡ isoʸ) ⟩
-            f ∘ toˣ                               ∎
-        }
-      ; F⇐G = unit
-      ; iso = λ X →
-        let (_ , isoˣ) = unit-iso X
-        in record
-          { isoˡ = isoʳ isoˣ
-          ; isoʳ = isoˡ isoˣ
-          }
-      }
+  pointwise-iso-equivalence : (∀ X → Σ[ f ∈ D [ X , F.F₀ (G.F₀ X) ] ] Iso D (counit.η X) f) → (∀ X → Σ[ f ∈ C [  G.F₀ (F.F₀ X) , X ] ] Iso C (unit.η X) f) → WeakInverse F G
+  pointwise-iso-equivalence counit-iso unit-iso = record
+    { F∘G≈id =
+      let iso X =
+            let (to , is-iso) = counit-iso X
+            in record { from = counit.η X ; to = to ; iso = is-iso }
+      in pointwise-iso iso counit.commute
+    ; G∘F≈id =
+      let iso X =
+            let (to , is-iso) = unit-iso X
+            in record { from = unit.η X ; to = to ; iso = is-iso }
+      in ≃.sym (pointwise-iso iso unit.commute)
     }
-    where
-      open Iso
-

--- a/src/Categories/NaturalTransformation/NaturalIsomorphism/Properties.agda
+++ b/src/Categories/NaturalTransformation/NaturalIsomorphism/Properties.agda
@@ -21,6 +21,27 @@ private
     C D : Category o ℓ e
 
 
+module _ {F G : Functor C D} where
+  private
+    module C = Category C
+    module F = Functor F
+    module G = Functor G
+
+  open Category D
+  open Mor D
+  open _≅_
+
+  -- We can construct a natural isomorphism from a pointwise isomorphism, provided that we can show naturality in one direction.
+  pointwise-iso : (iso : ∀ X → F.F₀ X ≅ G.F₀ X) → (∀ {X Y} → (f : C [ X , Y ]) → from (iso Y) ∘ F.F₁ f ≈ G.F₁ f ∘ from (iso X)) → NaturalIsomorphism F G
+  pointwise-iso iso commute = niHelper record
+    { η = λ X → from (iso X)
+    ; η⁻¹ = λ X → to (iso X)
+    ; commute = commute
+    ; iso = λ X → record
+      { isoˡ = isoˡ (iso X)
+      ; isoʳ = isoʳ (iso X)
+      }
+    }
 
 module _ {F G : Functor C D} (α : NaturalIsomorphism F G) where
   private module C = Category C


### PR DESCRIPTION
# Patch Description

This PR adds 2 helper functions for building various incarnations of natural isomorphisms from pointwise equivalences.
This is sorely needed for my proofs of the various monadicity theorems, as otherwise we get bogged down in the details incredibly quickly.

# Notes
I'm not super happy with the sigma types present in the definition of `pointwise-iso-equivalence`. Perhaps we ought to add something to `Categories.Morphism` that captures the notion of a morphism being one half of some isomorphism. It seems like this situation is often referred to as "f is an isomorphim" which suggests this type ought to be called `IsIso`, but that conflicts with our naming scheme for predicates.