### PR TITLE
Define Cokernels

### DIFF
--- a/src/Categories/Object/Cokernel.agda
+++ b/src/Categories/Object/Cokernel.agda
@@ -1,0 +1,55 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category
+open import Categories.Object.Zero
+
+-- Cokernels of morphisms.
+-- https://ncatlab.org/nlab/show/cokernel
+module Categories.Object.Cokernel {o ℓ e} {𝒞 : Category o ℓ e} (𝟎 : Zero 𝒞) where
+
+open import Level
+
+open import Categories.Morphism 𝒞
+open import Categories.Morphism.Reasoning 𝒞
+  hiding (glue)
+
+open Category 𝒞
+open Zero 𝟎
+
+open HomReasoning
+
+private
+  variable
+    A B X : Obj
+    f h i j k : A ⇒ B
+
+record IsCokernel {A B K} (f : A ⇒ B) (k : B ⇒ K) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    commute   : k ∘ f ≈ zero⇒
+    universal : ∀ {X} {h : B ⇒ X} → h ∘ f ≈ zero⇒ → K ⇒ X
+    factors   : ∀ {eq : h ∘ f ≈ zero⇒} → h ≈ universal eq ∘ k
+    unique    : ∀ {eq : h ∘ f ≈ zero⇒} → h ≈ i ∘ k → i ≈ universal eq
+
+  universal-resp-≈ : ∀ {eq : h ∘ f ≈ zero⇒} {eq′ : i ∘ f ≈ zero⇒} →
+    h ≈ i → universal eq ≈ universal eq′
+  universal-resp-≈ h≈i = unique (⟺ h≈i ○ factors)
+
+  universal-∘ : h ∘ k ∘ f ≈ zero⇒
+  universal-∘ {h = h} = begin
+    h ∘ k ∘ f ≈⟨ refl⟩∘⟨ commute ⟩
+    h ∘ zero⇒ ≈⟨ zero-∘ˡ h ⟩
+    zero⇒     ∎
+
+record Cokernel {A B} (f : A ⇒ B) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    {cokernel} : Obj
+    cokernel⇒  : B ⇒ cokernel
+    isCokernel : IsCokernel f cokernel⇒
+
+  open IsCokernel isCokernel public
+
+IsCokernel⇒Cokernel : IsCokernel f k → Cokernel f
+IsCokernel⇒Cokernel {k = k} isCokernel = record
+  { cokernel⇒ = k
+  ; isCokernel = isCokernel
+  }

--- a/src/Categories/Object/Duality.agda
+++ b/src/Categories/Object/Duality.agda
@@ -2,8 +2,7 @@
 open import Categories.Category
 
 -- Properties relating Initial and Terminal Objects,
--- and Product / Coproduct via op
-
+-- Product / Coproduct, Zero objects, and Kernel / Cokernel via op
 module Categories.Object.Duality {o ℓ e} (C : Category o ℓ e) where
 
 open Category C
@@ -19,7 +18,15 @@ open import Categories.Object.Coproduct C
 
 open import Categories.Object.Zero
 
-IsInitial⇒coIsTerminal : ∀ {X} → IsInitial X → IsTerminal X
+import Categories.Object.Kernel as Kernels
+import Categories.Object.Cokernel as Cokernels
+
+private
+  variable
+    A B X Z : Obj
+    f g k : A ⇒ B
+
+IsInitial⇒coIsTerminal : IsInitial X → IsTerminal X
 IsInitial⇒coIsTerminal is⊥ = record
   { !        = !
   ; !-unique = !-unique
@@ -33,7 +40,7 @@ IsInitial⇒coIsTerminal is⊥ = record
   }
   where open Initial i
 
-coIsTerminal⇒IsInitial : ∀ {X} → IsTerminal X → IsInitial X
+coIsTerminal⇒IsInitial : IsTerminal X → IsInitial X
 coIsTerminal⇒IsInitial is⊤ = record
   { !        = !
   ; !-unique = !-unique
@@ -47,7 +54,7 @@ op⊤⇒⊥ t = record
   }
   where open Terminal t
 
-Coproduct⇒coProduct : ∀ {A B} → Coproduct A B → Product A B
+Coproduct⇒coProduct : Coproduct A B → Product A B
 Coproduct⇒coProduct A+B = record
   { A×B      = A+B.A+B
   ; π₁       = A+B.i₁
@@ -74,7 +81,7 @@ coProduct⇒Coproduct A×B = record
   module A×B = Product A×B
 
 -- Zero objects are autodual
-IsZero⇒coIsZero : ∀ {Z} → IsZero C Z → IsZero op Z
+IsZero⇒coIsZero : IsZero C Z → IsZero op Z
 IsZero⇒coIsZero is-zero = record
   { isInitial = record { ! = ! ; !-unique = !-unique }
   ; isTerminal = record { ! = ¡ ; !-unique = ¡-unique }
@@ -82,7 +89,7 @@ IsZero⇒coIsZero is-zero = record
   where
     open IsZero is-zero
 
-coIsZero⇒IsZero : ∀ {Z} → IsZero op Z → IsZero C Z
+coIsZero⇒IsZero : IsZero op Z → IsZero C Z
 coIsZero⇒IsZero co-is-zero = record
   { isInitial = record { ! = ! ; !-unique = !-unique }
   ; isTerminal = record { ! = ¡ ; !-unique = ¡-unique }
@@ -108,12 +115,10 @@ Zero⇒coZero zero = record
 
 -- Tests to ensure that dualities are involutive up to definitional equality.
 private
-  coIsTerminal⟺IsInitial : ∀ {X} (⊥ : IsInitial X) →
-    coIsTerminal⇒IsInitial (IsInitial⇒coIsTerminal ⊥) ≡ ⊥
+  coIsTerminal⟺IsInitial : (⊥ : IsInitial X) → coIsTerminal⇒IsInitial (IsInitial⇒coIsTerminal ⊥) ≡ ⊥
   coIsTerminal⟺IsInitial _ = ≡.refl
 
-  IsInitial⟺coIsTerminal : ∀ {X} (⊤ : IsTerminal X) →
-    IsInitial⇒coIsTerminal (coIsTerminal⇒IsInitial ⊤) ≡ ⊤
+  IsInitial⟺coIsTerminal : (⊤ : IsTerminal X) → IsInitial⇒coIsTerminal (coIsTerminal⇒IsInitial ⊤) ≡ ⊤
   IsInitial⟺coIsTerminal _ = ≡.refl
 
   ⊥⟺op⊤ : (⊤ : Terminal) → ⊥⇒op⊤ (op⊤⇒⊥ ⊤) ≡ ⊤
@@ -122,24 +127,73 @@ private
   op⊤⟺⊥ : (⊥ : Initial) → op⊤⇒⊥ (⊥⇒op⊤ ⊥) ≡ ⊥
   op⊤⟺⊥ _ = ≡.refl
 
-  Coproduct⟺coProduct : ∀ {A B} (p : Product A B) → Coproduct⇒coProduct (coProduct⇒Coproduct p) ≡ p
+  Coproduct⟺coProduct : (p : Product A B) → Coproduct⇒coProduct (coProduct⇒Coproduct p) ≡ p
   Coproduct⟺coProduct _ = ≡.refl
 
-  coProduct⟺Coproduct : ∀ {A B} (p : Coproduct A B) → coProduct⇒Coproduct (Coproduct⇒coProduct p) ≡ p
+  coProduct⟺Coproduct : (p : Coproduct A B) → coProduct⇒Coproduct (Coproduct⇒coProduct p) ≡ p
   coProduct⟺Coproduct _ = ≡.refl
 
-  coIsZero⟺IsZero : ∀ {Z} {zero : IsZero op Z} →
-    IsZero⇒coIsZero (coIsZero⇒IsZero zero) ≡ zero
+  coIsZero⟺IsZero : {zero : IsZero op Z} → IsZero⇒coIsZero (coIsZero⇒IsZero zero) ≡ zero
   coIsZero⟺IsZero = ≡.refl
 
-  IsZero⟺coIsZero : ∀ {Z} {zero : IsZero C Z} →
-    coIsZero⇒IsZero (IsZero⇒coIsZero zero) ≡ zero
+  IsZero⟺coIsZero : ∀ {Z} {zero : IsZero C Z} → coIsZero⇒IsZero (IsZero⇒coIsZero zero) ≡ zero
   IsZero⟺coIsZero = ≡.refl
 
-  coZero⟺Zero : ∀ {zero : Zero op} →
-    Zero⇒coZero (coZero⇒Zero zero) ≡ zero
+  coZero⟺Zero : ∀ {zero : Zero op} → Zero⇒coZero (coZero⇒Zero zero) ≡ zero
   coZero⟺Zero = ≡.refl
 
-  Zero⟺coZero : ∀ {zero : Zero C} →
-    coZero⇒Zero (Zero⇒coZero zero) ≡ zero
+  Zero⟺coZero : ∀ {zero : Zero C} → coZero⇒Zero (Zero⇒coZero zero) ≡ zero
   Zero⟺coZero = ≡.refl
+
+module _ (𝟎 : Zero C) where
+  open Kernels (Zero⇒coZero 𝟎)
+  open Cokernels 𝟎
+
+  coIsKernel⇒IsCokernel : IsKernel k f → IsCokernel f k
+  coIsKernel⇒IsCokernel isKernel = record
+    { commute = commute
+    ; universal = universal
+    ; factors = factors
+    ; unique = unique
+    }
+    where
+      open IsKernel isKernel
+
+  IsCokernel⇒coIsKernel : IsCokernel f k → IsKernel k f
+  IsCokernel⇒coIsKernel isCokernel = record
+    { commute = commute
+    ; universal = universal
+    ; factors = factors
+    ; unique = unique
+    }
+    where
+      open IsCokernel isCokernel
+
+  coKernel⇒Cokernel : Kernel f → Cokernel f
+  coKernel⇒Cokernel k = record
+    { cokernel⇒ = kernel⇒
+    ; isCokernel = coIsKernel⇒IsCokernel isKernel
+    }
+    where
+      open Kernel k
+
+  Cokernel⇒coKernel : Cokernel f → Kernel f
+  Cokernel⇒coKernel k = record
+    { kernel⇒ = cokernel⇒
+    ; isKernel = IsCokernel⇒coIsKernel isCokernel
+    }
+    where
+      open Cokernel k
+
+  private
+    coIsKernel⟺IsCokernel : ∀ {isKernel : IsKernel k f} → IsCokernel⇒coIsKernel (coIsKernel⇒IsCokernel isKernel) ≡ isKernel
+    coIsKernel⟺IsCokernel = ≡.refl
+
+    IsCokernel⟺coIsKernel : ∀ {isCokernel : IsCokernel f k} → coIsKernel⇒IsCokernel (IsCokernel⇒coIsKernel isCokernel) ≡ isCokernel
+    IsCokernel⟺coIsKernel = ≡.refl
+
+    coKernel⟺Cokernel : ∀ {kernel : Kernel f} → Cokernel⇒coKernel (coKernel⇒Cokernel kernel) ≡ kernel
+    coKernel⟺Cokernel = ≡.refl
+
+    Cokernel⟺coKernel : ∀ {cokernel : Cokernel f} → coKernel⇒Cokernel (Cokernel⇒coKernel cokernel) ≡ cokernel
+    Cokernel⟺coKernel = ≡.refl


### PR DESCRIPTION
This patch defines Cokernels, and also proves some facts about duality with kernels. I did a minor refactoring in the `Categories.Object.Duality` module, by pulling some implicits into variables.