### PR TITLE
Idempotents, Split Idempotents and Karoubi Envelopes

### DIFF
--- a/src/Categories/Category/Construction/KaroubiEnvelope.agda
+++ b/src/Categories/Category/Construction/KaroubiEnvelope.agda
@@ -2,46 +2,49 @@
 
 open import Categories.Category.Core
 
+-- Karoubi Envelopes. These are the free completions of categories under split idempotents
 module Categories.Category.Construction.KaroubiEnvelope {o ℓ e} (𝒞 : Category o ℓ e) where
 
 open import Level
 
+open import Categories.Morphism.Idempotent 𝒞
 open import Categories.Morphism.Reasoning 𝒞
 
 open Category 𝒞
 open HomReasoning
 open Equiv
 
-record Idempotent : Set (o ⊔ ℓ ⊔ e) where
+-- It's nicer to work with the bundled form of idempotents here.
+-- We could use Σ types, but that gets a bit messy.
+record BundledIdempotent : Set (o ⊔ ℓ ⊔ e) where
   field
     {obj} : Obj
-    idem  : obj ⇒ obj
-    idempotent : idem ∘ idem ≈ idem
+    isIdempotent : Idempotent obj
 
-record Idempotent⇒ (I J : Idempotent) : Set (ℓ ⊔ e) where
+  open Idempotent isIdempotent public
+
+record Idempotent⇒ (I J : BundledIdempotent) : Set (ℓ ⊔ e) where
   private
-    module I = Idempotent I
-    module J = Idempotent J
+    module I = BundledIdempotent I
+    module J = BundledIdempotent J
   field
     hom : I.obj ⇒ J.obj
     absorbˡ : J.idem ∘ hom ≈ hom
     absorbʳ : hom ∘ I.idem ≈ hom
 
-open Idempotent
+open BundledIdempotent
 open Idempotent⇒
 
 KaroubiEnvelope : Category (o ⊔ ℓ ⊔ e) (ℓ ⊔ e) e
 KaroubiEnvelope = record
-  { Obj = Idempotent
+  { Obj = BundledIdempotent
   ; _⇒_ = Idempotent⇒
   ; _≈_ = λ f g → Idempotent⇒.hom f ≈ Idempotent⇒.hom g
-  ; id = λ {I} →
-    let module I = Idempotent I
-    in record
-      { hom = I.idem
-      ; absorbˡ = I.idempotent
-      ; absorbʳ = I.idempotent
-      }
+  ; id = λ {I} → record
+    { hom = idem I
+    ; absorbˡ = idempotent I
+    ; absorbʳ = idempotent I
+    }
   ; _∘_ = λ {I} {J} {K} f g →
     let module f = Idempotent⇒ f
         module g = Idempotent⇒ g

--- a/src/Categories/Category/Construction/KaroubiEnvelope.agda
+++ b/src/Categories/Category/Construction/KaroubiEnvelope.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --without-K --safe #-}
 
-open import Categories.Category.Core
+open import Categories.Category using (Category; _[_≈_])
 
 -- Karoubi Envelopes. These are the free completions of categories under split idempotents
 module Categories.Category.Construction.KaroubiEnvelope {o ℓ e} (𝒞 : Category o ℓ e) where
@@ -10,22 +10,23 @@ open import Level
 open import Categories.Morphism.Idempotent.Bundles 𝒞
 open import Categories.Morphism.Reasoning 𝒞
 
-open Category 𝒞
-open HomReasoning
-open Equiv
-
-open BundledIdempotent
-open Idempotent⇒
+private
+  module 𝒞 = Category 𝒞
+  open 𝒞.HomReasoning
+  open 𝒞.Equiv
+  
+  open Idempotent
+  open Idempotent⇒
 
 KaroubiEnvelope : Category (o ⊔ ℓ ⊔ e) (ℓ ⊔ e) e
 KaroubiEnvelope = record
-  { Obj = BundledIdempotent
+  { Obj = Idempotent
   ; _⇒_ = Idempotent⇒
-  ; _≈_ = λ f g → Idempotent⇒.hom f ≈ Idempotent⇒.hom g
-  ; id = idempotent⇒-id
-  ; _∘_ = idempotent⇒-∘
-  ; assoc = assoc
-  ; sym-assoc = sym-assoc
+  ; _≈_ = λ f g → 𝒞 [ Idempotent⇒.hom f ≈ Idempotent⇒.hom g ]
+  ; id = id
+  ; _∘_ = _∘_
+  ; assoc = 𝒞.assoc
+  ; sym-assoc = 𝒞.sym-assoc
   ; identityˡ = λ {I} {J} {f} → absorbˡ f
   ; identityʳ = λ {I} {J} {f} → absorbʳ f
   ; identity² = λ {I} → idempotent I
@@ -34,5 +35,5 @@ KaroubiEnvelope = record
     ; sym = sym
     ; trans = trans
     }
-  ; ∘-resp-≈ = ∘-resp-≈
+  ; ∘-resp-≈ = 𝒞.∘-resp-≈
   }

--- a/src/Categories/Category/Construction/KaroubiEnvelope.agda
+++ b/src/Categories/Category/Construction/KaroubiEnvelope.agda
@@ -7,30 +7,12 @@ module Categories.Category.Construction.KaroubiEnvelope {o ℓ e} (𝒞 : Catego
 
 open import Level
 
-open import Categories.Morphism.Idempotent 𝒞
+open import Categories.Morphism.Idempotent.Bundles 𝒞
 open import Categories.Morphism.Reasoning 𝒞
 
 open Category 𝒞
 open HomReasoning
 open Equiv
-
--- It's nicer to work with the bundled form of idempotents here.
--- We could use Σ types, but that gets a bit messy.
-record BundledIdempotent : Set (o ⊔ ℓ ⊔ e) where
-  field
-    {obj} : Obj
-    isIdempotent : Idempotent obj
-
-  open Idempotent isIdempotent public
-
-record Idempotent⇒ (I J : BundledIdempotent) : Set (ℓ ⊔ e) where
-  private
-    module I = BundledIdempotent I
-    module J = BundledIdempotent J
-  field
-    hom : I.obj ⇒ J.obj
-    absorbˡ : J.idem ∘ hom ≈ hom
-    absorbʳ : hom ∘ I.idem ≈ hom
 
 open BundledIdempotent
 open Idempotent⇒
@@ -40,23 +22,8 @@ KaroubiEnvelope = record
   { Obj = BundledIdempotent
   ; _⇒_ = Idempotent⇒
   ; _≈_ = λ f g → Idempotent⇒.hom f ≈ Idempotent⇒.hom g
-  ; id = λ {I} → record
-    { hom = idem I
-    ; absorbˡ = idempotent I
-    ; absorbʳ = idempotent I
-    }
-  ; _∘_ = λ {I} {J} {K} f g →
-    let module f = Idempotent⇒ f
-        module g = Idempotent⇒ g
-    in record
-    { hom = f.hom ∘ g.hom
-    ; absorbˡ = begin
-      idem K ∘ f.hom ∘ g.hom ≈⟨ pullˡ f.absorbˡ ⟩
-      f.hom ∘ g.hom ∎
-    ; absorbʳ = begin
-      (f.hom ∘ g.hom) ∘ idem I ≈⟨ pullʳ g.absorbʳ ⟩
-      f.hom ∘ g.hom ∎
-    }
+  ; id = idempotent⇒-id
+  ; _∘_ = idempotent⇒-∘
   ; assoc = assoc
   ; sym-assoc = sym-assoc
   ; identityˡ = λ {I} {J} {f} → absorbˡ f
@@ -64,8 +31,8 @@ KaroubiEnvelope = record
   ; identity² = λ {I} → idempotent I
   ; equiv = record
     { refl = refl
-    ; sym = λ eq → sym eq
-    ; trans = λ eq₁ eq₂ → trans eq₁ eq₂
+    ; sym = sym
+    ; trans = trans
     }
-  ; ∘-resp-≈ = λ eq₁ eq₂ → ∘-resp-≈ eq₁ eq₂
+  ; ∘-resp-≈ = ∘-resp-≈
   }

--- a/src/Categories/Category/Construction/KaroubiEnvelope.agda
+++ b/src/Categories/Category/Construction/KaroubiEnvelope.agda
@@ -1,0 +1,68 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core
+
+module Categories.Category.Construction.KaroubiEnvelope {o ℓ e} (𝒞 : Category o ℓ e) where
+
+open import Level
+
+open import Categories.Morphism.Reasoning 𝒞
+
+open Category 𝒞
+open HomReasoning
+open Equiv
+
+record Idempotent : Set (o ⊔ ℓ ⊔ e) where
+  field
+    {obj} : Obj
+    idem  : obj ⇒ obj
+    idempotent : idem ∘ idem ≈ idem
+
+record Idempotent⇒ (I J : Idempotent) : Set (ℓ ⊔ e) where
+  private
+    module I = Idempotent I
+    module J = Idempotent J
+  field
+    hom : I.obj ⇒ J.obj
+    absorbˡ : J.idem ∘ hom ≈ hom
+    absorbʳ : hom ∘ I.idem ≈ hom
+
+open Idempotent
+open Idempotent⇒
+
+KaroubiEnvelope : Category (o ⊔ ℓ ⊔ e) (ℓ ⊔ e) e
+KaroubiEnvelope = record
+  { Obj = Idempotent
+  ; _⇒_ = Idempotent⇒
+  ; _≈_ = λ f g → Idempotent⇒.hom f ≈ Idempotent⇒.hom g
+  ; id = λ {I} →
+    let module I = Idempotent I
+    in record
+      { hom = I.idem
+      ; absorbˡ = I.idempotent
+      ; absorbʳ = I.idempotent
+      }
+  ; _∘_ = λ {I} {J} {K} f g →
+    let module f = Idempotent⇒ f
+        module g = Idempotent⇒ g
+    in record
+    { hom = f.hom ∘ g.hom
+    ; absorbˡ = begin
+      idem K ∘ f.hom ∘ g.hom ≈⟨ pullˡ f.absorbˡ ⟩
+      f.hom ∘ g.hom ∎
+    ; absorbʳ = begin
+      (f.hom ∘ g.hom) ∘ idem I ≈⟨ pullʳ g.absorbʳ ⟩
+      f.hom ∘ g.hom ∎
+    }
+  ; assoc = assoc
+  ; sym-assoc = sym-assoc
+  ; identityˡ = λ {I} {J} {f} → absorbˡ f
+  ; identityʳ = λ {I} {J} {f} → absorbʳ f
+  ; identity² = λ {I} → idempotent I
+  ; equiv = record
+    { refl = refl
+    ; sym = λ eq → sym eq
+    ; trans = λ eq₁ eq₂ → trans eq₁ eq₂
+    }
+  ; ∘-resp-≈ = λ eq₁ eq₂ → ∘-resp-≈ eq₁ eq₂
+  }

--- a/src/Categories/Category/Construction/KaroubiEnvelope/Properties.agda
+++ b/src/Categories/Category/Construction/KaroubiEnvelope/Properties.agda
@@ -12,6 +12,7 @@ open import Categories.Functor.Properties
 open import Categories.Category.Construction.KaroubiEnvelope
 
 open import Categories.Morphism.Idempotent
+open import Categories.Morphism.Idempotent.Bundles
 
 open Category 𝒞
 open Equiv

--- a/src/Categories/Category/Construction/KaroubiEnvelope/Properties.agda
+++ b/src/Categories/Category/Construction/KaroubiEnvelope/Properties.agda
@@ -12,7 +12,7 @@ open import Categories.Functor.Properties
 open import Categories.Category.Construction.KaroubiEnvelope
 
 open import Categories.Morphism.Idempotent
-open import Categories.Morphism.Idempotent.Bundles
+import Categories.Morphism.Idempotent.Bundles as BundledIdem
 
 open Category 𝒞
 open Equiv
@@ -45,7 +45,7 @@ private
 karoubi-embedding-full : Full KaroubiEmbedding
 karoubi-embedding-full = record
   { from = record
-    { _⟨$⟩_ = λ f → Idempotent⇒.hom f
+    { _⟨$⟩_ = λ f → BundledIdem.Idempotent⇒.hom f
     ; cong = λ eq → eq
     }
   ; right-inverse-of = λ _ → refl
@@ -86,6 +86,6 @@ idempotent-split {A} I = record
     }
   }
   where
-    module A = BundledIdempotent A
+    module A = BundledIdem.Idempotent A
     open Idempotent I
-    module idem = Idempotent⇒ idem
+    module idem = BundledIdem.Idempotent⇒ idem

--- a/src/Categories/Category/Construction/KaroubiEnvelope/Properties.agda
+++ b/src/Categories/Category/Construction/KaroubiEnvelope/Properties.agda
@@ -1,0 +1,90 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core
+
+module Categories.Category.Construction.KaroubiEnvelope.Properties {o ℓ e} (𝒞 : Category o ℓ e) where
+
+open import Data.Product using (_,_)
+
+open import Categories.Functor renaming (id to idF)
+open import Categories.Functor.Properties
+
+open import Categories.Category.Construction.KaroubiEnvelope
+
+open import Categories.Morphism.Idempotent
+
+open Category 𝒞
+open Equiv
+
+--------------------------------------------------------------------------------
+-- Some facts about embedding 𝒞 into it's Karoubi Envelope
+
+KaroubiEmbedding : Functor 𝒞 (KaroubiEnvelope 𝒞)
+KaroubiEmbedding = record
+  { F₀ = λ X → record
+    { obj = X
+    ; isIdempotent = record
+      { idem = id
+      ; idempotent = identity²
+      }
+    }
+  ; F₁ = λ f → record
+    { hom = f
+    ; absorbˡ = identityˡ
+    ; absorbʳ = identityʳ
+    }
+  ; identity = refl
+  ; homomorphism = refl
+  ; F-resp-≈ = λ eq → eq
+  }
+
+private
+  module KaroubiEmbedding = Functor KaroubiEmbedding
+
+karoubi-embedding-full : Full KaroubiEmbedding
+karoubi-embedding-full = record
+  { from = record
+    { _⟨$⟩_ = λ f → Idempotent⇒.hom f
+    ; cong = λ eq → eq
+    }
+  ; right-inverse-of = λ _ → refl
+  }
+
+karoubi-embedding-faithful : Faithful KaroubiEmbedding
+karoubi-embedding-faithful f g eq = eq
+
+karoubi-embedding-fully-faithful : FullyFaithful KaroubiEmbedding
+karoubi-embedding-fully-faithful = karoubi-embedding-full , karoubi-embedding-faithful
+
+--------------------------------------------------------------------------------
+-- Some facts about splitting idempotents
+
+-- All idempotents in the Karoubi Envelope are split
+idempotent-split : ∀ {A} → Idempotent (KaroubiEnvelope 𝒞) A → SplitIdempotent (KaroubiEnvelope 𝒞) A
+idempotent-split {A} I = record
+  { idem = idem
+  ; isSplitIdempotent = record
+    { R = record
+      { isIdempotent = record
+        { idem = idem.hom
+        ; idempotent = idempotent
+        }
+      }
+    ; retract = record
+      { hom = idem.hom
+      ; absorbˡ = idempotent
+      ; absorbʳ = idem.absorbʳ
+      }
+    ; section = record
+      { hom = idem.hom
+      ; absorbˡ = idem.absorbˡ
+      ; absorbʳ = idempotent
+      }
+    ; retracts = idempotent
+    ; splits = idempotent
+    }
+  }
+  where
+    module A = BundledIdempotent A
+    open Idempotent I
+    module idem = Idempotent⇒ idem

--- a/src/Categories/Category/Construction/KaroubiEnvelope/Properties.agda
+++ b/src/Categories/Category/Construction/KaroubiEnvelope/Properties.agda
@@ -64,7 +64,7 @@ idempotent-split : ∀ {A} → Idempotent (KaroubiEnvelope 𝒞) A → SplitIdem
 idempotent-split {A} I = record
   { idem = idem
   ; isSplitIdempotent = record
-    { R = record
+    { obj = record
       { isIdempotent = record
         { idem = idem.hom
         ; idempotent = idempotent

--- a/src/Categories/Morphism/Idempotent.agda
+++ b/src/Categories/Morphism/Idempotent.agda
@@ -1,0 +1,45 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core
+
+-- Idempotents and Split Idempotents
+module Categories.Morphism.Idempotent {o ℓ e} (𝒞 : Category o ℓ e) where
+
+open import Level
+
+open import Categories.Morphism.Reasoning 𝒞
+
+open Category 𝒞
+open HomReasoning
+
+record Idempotent (A : Obj) : Set (ℓ ⊔ e) where
+  field
+    idem       : A ⇒ A
+    idempotent : idem ∘ idem ≈ idem
+
+record IsSplitIdempotent {A : Obj} (i : A ⇒ A) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    {R}      : Obj
+    retract  : A ⇒ R
+    section  : R ⇒ A
+    retracts : retract ∘ section ≈ id 
+    splits   : section ∘ retract ≈ i
+
+  retract-absorb : retract ∘ i ≈ retract
+  retract-absorb = begin
+    retract ∘ i                 ≈˘⟨ refl⟩∘⟨ splits ⟩
+    retract ∘ section ∘ retract ≈⟨ cancelˡ retracts ⟩
+    retract                     ∎
+
+  section-absorb : i ∘ section ≈ section
+  section-absorb = begin
+    i ∘ section                   ≈˘⟨ splits ⟩∘⟨refl ⟩
+    (section ∘ retract) ∘ section ≈⟨ cancelʳ retracts ⟩
+    section                       ∎
+
+record SplitIdempotent (A : Obj) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    idem : A ⇒ A
+    isSplitIdempotent : IsSplitIdempotent idem
+
+  open IsSplitIdempotent isSplitIdempotent public

--- a/src/Categories/Morphism/Idempotent.agda
+++ b/src/Categories/Morphism/Idempotent.agda
@@ -54,32 +54,29 @@ record SplitIdempotent (A : Obj) : Set (o ⊔ ℓ ⊔ e) where
 
 -- All split idempotents are idempotent
 SplitIdempotent⇒Idempotent : ∀ {A} → SplitIdempotent A → Idempotent A
-SplitIdempotent⇒Idempotent Split = record
-  { idem = idem
-  ; idempotent = idempotent
-  }
+SplitIdempotent⇒Idempotent Split = record { Split }
   where
-    open SplitIdempotent Split
+    module Split = SplitIdempotent Split
 
 module _ {A} {f : A ⇒ A} (S T : IsSplitIdempotent f) where
   private
     module S = IsSplitIdempotent S
     module T = IsSplitIdempotent T
 
-    split-idempotent-unique : S.obj ≅ T.obj
-    split-idempotent-unique = record
-      { from = T.retract ∘ S.section
-      ; to = S.retract ∘ T.section
-      ; iso = record
-        { isoˡ = begin
-          (S.retract ∘ T.section) ∘ (T.retract ∘ S.section) ≈⟨ center T.splits ⟩
-          S.retract ∘ f ∘ S.section                         ≈⟨ pullˡ S.retract-absorb ⟩
-          S.retract ∘ S.section                             ≈⟨ S.retracts ⟩
-          id                                                ∎
-        ; isoʳ = begin
-          (T.retract ∘ S.section) ∘ (S.retract ∘ T.section) ≈⟨ center S.splits ⟩
-          T.retract ∘ f ∘ T.section                         ≈⟨ pullˡ T.retract-absorb ⟩
-          T.retract ∘ T.section                             ≈⟨ T.retracts ⟩
-          id                                                ∎
-        }
+  split-idempotent-unique : S.obj ≅ T.obj
+  split-idempotent-unique = record
+    { from = T.retract ∘ S.section
+    ; to = S.retract ∘ T.section
+    ; iso = record
+      { isoˡ = begin
+        (S.retract ∘ T.section) ∘ (T.retract ∘ S.section) ≈⟨ center T.splits ⟩
+        S.retract ∘ f ∘ S.section                         ≈⟨ pullˡ S.retract-absorb ⟩
+        S.retract ∘ S.section                             ≈⟨ S.retracts ⟩
+        id                                                ∎
+      ; isoʳ = begin
+        (T.retract ∘ S.section) ∘ (S.retract ∘ T.section) ≈⟨ center S.splits ⟩
+        T.retract ∘ f ∘ T.section                         ≈⟨ pullˡ T.retract-absorb ⟩
+        T.retract ∘ T.section                             ≈⟨ T.retracts ⟩
+        id                                                ∎
       }
+    }

--- a/src/Categories/Morphism/Idempotent.agda
+++ b/src/Categories/Morphism/Idempotent.agda
@@ -7,6 +7,7 @@ module Categories.Morphism.Idempotent {o ℓ e} (𝒞 : Category o ℓ e) where
 
 open import Level
 
+open import Categories.Morphism 𝒞
 open import Categories.Morphism.Reasoning 𝒞
 
 open Category 𝒞
@@ -19,9 +20,9 @@ record Idempotent (A : Obj) : Set (ℓ ⊔ e) where
 
 record IsSplitIdempotent {A : Obj} (i : A ⇒ A) : Set (o ⊔ ℓ ⊔ e) where
   field
-    {R}      : Obj
-    retract  : A ⇒ R
-    section  : R ⇒ A
+    {obj}    : Obj
+    retract  : A ⇒ obj
+    section  : obj ⇒ A
     retracts : retract ∘ section ≈ id 
     splits   : section ∘ retract ≈ i
 
@@ -59,3 +60,26 @@ SplitIdempotent⇒Idempotent Split = record
   }
   where
     open SplitIdempotent Split
+
+module _ {A} {f : A ⇒ A} (S T : IsSplitIdempotent f) where
+  private
+    module S = IsSplitIdempotent S
+    module T = IsSplitIdempotent T
+
+    split-idempotent-unique : S.obj ≅ T.obj
+    split-idempotent-unique = record
+      { from = T.retract ∘ S.section
+      ; to = S.retract ∘ T.section
+      ; iso = record
+        { isoˡ = begin
+          (S.retract ∘ T.section) ∘ (T.retract ∘ S.section) ≈⟨ center T.splits ⟩
+          S.retract ∘ f ∘ S.section                         ≈⟨ pullˡ S.retract-absorb ⟩
+          S.retract ∘ S.section                             ≈⟨ S.retracts ⟩
+          id                                                ∎
+        ; isoʳ = begin
+          (T.retract ∘ S.section) ∘ (S.retract ∘ T.section) ≈⟨ center S.splits ⟩
+          T.retract ∘ f ∘ T.section                         ≈⟨ pullˡ T.retract-absorb ⟩
+          T.retract ∘ T.section                             ≈⟨ T.retracts ⟩
+          id                                                ∎
+        }
+      }

--- a/src/Categories/Morphism/Idempotent.agda
+++ b/src/Categories/Morphism/Idempotent.agda
@@ -37,9 +37,25 @@ record IsSplitIdempotent {A : Obj} (i : A ⇒ A) : Set (o ⊔ ℓ ⊔ e) where
     (section ∘ retract) ∘ section ≈⟨ cancelʳ retracts ⟩
     section                       ∎
 
+  idempotent : i ∘ i ≈ i
+  idempotent = begin
+    i ∘ i                                     ≈˘⟨ splits ⟩∘⟨ splits ⟩
+    (section ∘ retract) ∘ (section ∘ retract) ≈⟨ cancelInner retracts ⟩
+    section ∘ retract                         ≈⟨ splits ⟩
+    i                                         ∎
+
 record SplitIdempotent (A : Obj) : Set (o ⊔ ℓ ⊔ e) where
   field
     idem : A ⇒ A
     isSplitIdempotent : IsSplitIdempotent idem
 
   open IsSplitIdempotent isSplitIdempotent public
+
+-- All split idempotents are idempotent
+SplitIdempotent⇒Idempotent : ∀ {A} → SplitIdempotent A → Idempotent A
+SplitIdempotent⇒Idempotent Split = record
+  { idem = idem
+  ; idempotent = idempotent
+  }
+  where
+    open SplitIdempotent Split

--- a/src/Categories/Morphism/Idempotent/Bundles.agda
+++ b/src/Categories/Morphism/Idempotent/Bundles.agda
@@ -1,0 +1,58 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core
+
+-- Bundled versions of Idempotents, as well as maps between idempotents
+module Categories.Morphism.Idempotent.Bundles {o ℓ e} (𝒞 : Category o ℓ e) where
+
+open import Level
+
+open import Categories.Morphism.Idempotent 𝒞
+open import Categories.Morphism.Reasoning 𝒞
+
+open Category 𝒞
+open HomReasoning
+open Equiv
+
+--------------------------------------------------------------------------------
+-- Bundled Idempotents, and maps between them
+
+record BundledIdempotent : Set (o ⊔ ℓ ⊔ e) where
+  field
+    {obj} : Obj
+    isIdempotent : Idempotent obj
+
+  open Idempotent isIdempotent public
+
+open BundledIdempotent
+
+record Idempotent⇒ (I J : BundledIdempotent) : Set (ℓ ⊔ e) where
+  private
+    module I = BundledIdempotent I
+    module J = BundledIdempotent J
+  field
+    hom : I.obj ⇒ J.obj
+    absorbˡ : J.idem ∘ hom ≈ hom
+    absorbʳ : hom ∘ I.idem ≈ hom
+
+open Idempotent⇒
+
+--------------------------------------------------------------------------------
+-- Identity and Composition of maps between Idempotents
+
+idempotent⇒-id : ∀ {I} → Idempotent⇒ I I
+idempotent⇒-id {I} = record
+  { hom = idem I
+  ; absorbˡ = idempotent I
+  ; absorbʳ = idempotent I
+  }
+
+idempotent⇒-∘ : ∀ {I J K} → (f : Idempotent⇒ J K) → (g : Idempotent⇒ I J) → Idempotent⇒ I K
+idempotent⇒-∘ {I} {J} {K} f g = record
+  { hom = f.hom ∘ g.hom
+  ; absorbˡ = pullˡ f.absorbˡ
+  ; absorbʳ = pullʳ g.absorbʳ
+  }
+  where
+    module f = Idempotent⇒ f
+    module g = Idempotent⇒ g

--- a/src/Categories/Morphism/Idempotent/Bundles.agda
+++ b/src/Categories/Morphism/Idempotent/Bundles.agda
@@ -1,55 +1,56 @@
 {-# OPTIONS --without-K --safe #-}
 
-open import Categories.Category.Core
+open import Categories.Category using (Category; _[_,_]; _[_∘_]; _[_≈_])
 
--- Bundled versions of Idempotents, as well as maps between idempotents
+-- Bundled versions of Idempotents, as well as maps between idempotents.
 module Categories.Morphism.Idempotent.Bundles {o ℓ e} (𝒞 : Category o ℓ e) where
 
 open import Level
 
-open import Categories.Morphism.Idempotent 𝒞
+import Categories.Morphism.Idempotent 𝒞 as Idem
 open import Categories.Morphism.Reasoning 𝒞
 
-open Category 𝒞
-open HomReasoning
-open Equiv
+private
+  module 𝒞 = Category 𝒞
+  open 𝒞.HomReasoning
+  open 𝒞.Equiv
 
 --------------------------------------------------------------------------------
 -- Bundled Idempotents, and maps between them
 
-record BundledIdempotent : Set (o ⊔ ℓ ⊔ e) where
+record Idempotent : Set (o ⊔ ℓ ⊔ e) where
   field
-    {obj} : Obj
-    isIdempotent : Idempotent obj
+    {obj} : 𝒞.Obj
+    isIdempotent : Idem.Idempotent obj
 
-  open Idempotent isIdempotent public
+  open Idem.Idempotent isIdempotent public
 
-open BundledIdempotent
+open Idempotent
 
-record Idempotent⇒ (I J : BundledIdempotent) : Set (ℓ ⊔ e) where
+record Idempotent⇒ (I J : Idempotent) : Set (ℓ ⊔ e) where
   private
-    module I = BundledIdempotent I
-    module J = BundledIdempotent J
+    module I = Idempotent I
+    module J = Idempotent J
   field
-    hom : I.obj ⇒ J.obj
-    absorbˡ : J.idem ∘ hom ≈ hom
-    absorbʳ : hom ∘ I.idem ≈ hom
+    hom     : 𝒞 [ I.obj , J.obj ]
+    absorbˡ : 𝒞 [ 𝒞 [ J.idem ∘ hom ] ≈ hom ]
+    absorbʳ : 𝒞 [ 𝒞 [ hom ∘ I.idem ] ≈ hom ]
 
 open Idempotent⇒
 
 --------------------------------------------------------------------------------
 -- Identity and Composition of maps between Idempotents
 
-idempotent⇒-id : ∀ {I} → Idempotent⇒ I I
-idempotent⇒-id {I} = record
+id : ∀ {I} → Idempotent⇒ I I
+id {I} = record
   { hom = idem I
   ; absorbˡ = idempotent I
   ; absorbʳ = idempotent I
   }
 
-idempotent⇒-∘ : ∀ {I J K} → (f : Idempotent⇒ J K) → (g : Idempotent⇒ I J) → Idempotent⇒ I K
-idempotent⇒-∘ {I} {J} {K} f g = record
-  { hom = f.hom ∘ g.hom
+_∘_ : ∀ {I J K} → (f : Idempotent⇒ J K) → (g : Idempotent⇒ I J) → Idempotent⇒ I K
+_∘_ {I} {J} {K} f g = record
+  { hom = 𝒞 [ f.hom ∘ g.hom ]
   ; absorbˡ = pullˡ f.absorbˡ
   ; absorbʳ = pullʳ g.absorbʳ
   }


### PR DESCRIPTION
## Patch Description
This PR adds Idempotents, Split Idempotents, and the free completion of categories under split idempotents, Karoubi Envelopes. It also proves some simple facts about these structures.

## References:
- https://ncatlab.org/nlab/show/Karoubi+envelope
- https://ncatlab.org/nlab/show/split+idempotent