### PR TITLE
Kan Complexes and Weak Kan Complexes

### DIFF
--- a/README/KanComplexes.md
+++ b/README/KanComplexes.md
@@ -10,9 +10,7 @@ distinguished fillers.
 ## Implementation Notes
 * The inequality in the definition of Horn seems like it could become a bit awkward down the line?
   As equality of `Fin` is decidable, it isn't *too* bad, but does pose the potential to be annoying.
-* The proof obligations in WeakKanComplex seem pretty painful. Perhaps there is a more clever way of doing this?
-  Something akin to a clever encoding of the dimension, where we embed some smaller `k : Fin (n - 2)` into the larger dimension set.
-* The unfolded equality in ∂Δ[_] and Λ[_,_] does better than just lifting the equality from Δ, but it still falls on it's face from time to time (See KanComplex⇒WeakKanComplex)
+* The unfolded equality in ∂Δ[_] and Λ[_,_] does better than just lifting the equality from Δ, but it still falls on it's face from time to time
 
 ## References
 * https://ncatlab.org/nlab/show/Kan+complex

--- a/README/KanComplexes.md
+++ b/README/KanComplexes.md
@@ -1,0 +1,20 @@
+# Kan Complexes
+
+The classical definition of Kan Complex is a bit tricky in Agda, as
+they explicitly don't specify a choice of filler for horns, merely their
+existence. Instead, we have opted to implement *Algebraic Kan Complexes*,
+which are Kan Complexes with a distinguished choice of filler. This does
+mean that the Category of Kan Complexes needs morphisms to preserve these
+distinguished fillers.
+
+## Implementation Notes
+* The inequality in the definition of Horn seems like it could become a bit awkward down the line?
+  As equality of `Fin` is decidable, it isn't *too* bad, but does pose the potential to be annoying.
+* The proof obligations in WeakKanComplex seem pretty painful. Perhaps there is a more clever way of doing this?
+  Something akin to a clever encoding of the dimension, where we embed some smaller `k : Fin (n - 2)` into the larger dimension set.
+* The unfolded equality in ∂Δ[_] and Λ[_,_] does better than just lifting the equality from Δ, but it still falls on it's face from time to time (See KanComplex⇒WeakKanComplex)
+
+## References
+* https://ncatlab.org/nlab/show/Kan+complex
+* https://ncatlab.org/nlab/show/weak+Kan+complex
+* https://ncatlab.org/nlab/show/algebraic+Kan+complex

--- a/src/Categories/Category/Construction/KanComplex.agda
+++ b/src/Categories/Category/Construction/KanComplex.agda
@@ -1,0 +1,58 @@
+{-# OPTIONS --without-K --safe #-}
+
+
+open import Level
+
+-- Kan Complexes
+--
+-- These are technically "Algebraic" Kan Complexes, as they come with a choice of fillers
+-- However, this notion is far easier than the more geometric flavor,
+-- as we can sidestep questions about choice.
+
+module Categories.Category.Construction.KanComplex (o ℓ : Level) where
+
+open import Data.Nat using (ℕ)
+open import Data.Fin using (Fin; inject₁)
+
+open import Categories.Category using (Category)
+
+open import Categories.Category.Instance.SimplicialSet using (SimplicialSet)
+open import Categories.Category.Instance.SimplicialSet.Properties o ℓ using (ΔSet; Δ[_]; Λ[_,_]; Λ-inj)
+
+open Category (SimplicialSet o ℓ)
+
+-- A Kan complex is a simplicial set where every k-horn has a filler.
+record IsKanComplex (X : ΔSet) : Set (o ⊔ ℓ) where
+  field
+    filler      : ∀ {n} {k} → Λ[ n , k ] ⇒ X → Δ[ n ] ⇒ X
+    filler-cong : ∀ {n} {k} → {f g : Λ[ n , k ] ⇒ X} → f ≈ g → filler {n} f ≈ filler g
+    is-filler   : ∀ {n} {k} → (f : Λ[ n , k ] ⇒ X) → filler f ∘ Λ-inj k ≈ f
+
+-- 'inner k' will embed 'k : Fin n' into the "inner" portion of 'Fin (n + 2)'
+-- Visually, it looks a little something like:
+-- 
+--   * * *
+--   | | | 
+--   v v v
+-- * * * * *
+-- 
+-- Note that this is set up in such a way that we can normalize
+-- as far as possible without pattern matching on 'i' in proofs.
+inner : ∀ {n} → Fin n → Fin (ℕ.suc (ℕ.suc n))
+inner i = Fin.suc (inject₁ i)
+
+-- A Weak Kan complex is similar to a Kan Complex, but where only "inner horns" have fillers.
+--
+-- The indexing here is tricky, but it lets us avoid extra proof conditions that the horn is an inner horn.
+-- The basic idea is that if we want an n-dimensional inner horn, then we only want to allow the faces {1,2,3...n-1}
+-- to be missing. We could do this by requiring proofs that the missing face is greater than 0 and less than n, but
+-- this makes working with the definition _extremely_ difficult.
+--
+-- To avoid this, we only allow an missing face index that ranges from 0 to n-2, and then embed that index
+-- into the full range of face indexes via 'inner'. This does require us to shift our indexes around a bit.
+-- To make this indexing more obvious, we use the suggestively named variable 'n-2'.
+record IsWeakKanComplex (X : ΔSet) : Set (o ⊔ ℓ) where
+  field
+    filler      : ∀ {n-2} {k : Fin n-2} → Λ[ ℕ.suc (ℕ.suc n-2) , inner k ] ⇒ X → Δ[ ℕ.suc (ℕ.suc n-2) ] ⇒ X
+    filler-cong : ∀ {n-2} {k : Fin n-2} → {f g : Λ[ ℕ.suc (ℕ.suc n-2) , inner k ] ⇒ X} → f ≈ g → filler f ≈ filler g
+    is-filler   : ∀ {n-2} {k : Fin n-2} → (f : Λ[ ℕ.suc (ℕ.suc n-2) , inner k ] ⇒ X) → filler f ∘ Λ-inj (inner k) ≈ f

--- a/src/Categories/Category/Construction/KanComplex.agda
+++ b/src/Categories/Category/Construction/KanComplex.agda
@@ -58,10 +58,4 @@ record IsWeakKanComplex (X : ΔSet) : Set (o ⊔ ℓ) where
     is-filler   : ∀ {n-2} {k : Fin n-2} → (f : Λ[ ℕ.suc (ℕ.suc n-2) , inner k ] ⇒ X) → filler f ∘ Λ-inj (inner k) ≈ f
 
 KanComplex⇒WeakKanComplex : ∀ {X} → IsKanComplex X → IsWeakKanComplex X
-KanComplex⇒WeakKanComplex complex = record
-  { filler = filler
-  ; filler-cong = filler-cong
-  ; is-filler = is-filler
-  }
-  where
-    open IsKanComplex complex
+KanComplex⇒WeakKanComplex complex = record { IsKanComplex complex }

--- a/src/Categories/Category/Construction/KanComplex.agda
+++ b/src/Categories/Category/Construction/KanComplex.agda
@@ -56,3 +56,12 @@ record IsWeakKanComplex (X : ΔSet) : Set (o ⊔ ℓ) where
     filler      : ∀ {n-2} {k : Fin n-2} → Λ[ ℕ.suc (ℕ.suc n-2) , inner k ] ⇒ X → Δ[ ℕ.suc (ℕ.suc n-2) ] ⇒ X
     filler-cong : ∀ {n-2} {k : Fin n-2} → {f g : Λ[ ℕ.suc (ℕ.suc n-2) , inner k ] ⇒ X} → f ≈ g → filler f ≈ filler g
     is-filler   : ∀ {n-2} {k : Fin n-2} → (f : Λ[ ℕ.suc (ℕ.suc n-2) , inner k ] ⇒ X) → filler f ∘ Λ-inj (inner k) ≈ f
+
+KanComplex⇒WeakKanComplex : ∀ {X} → IsKanComplex X → IsWeakKanComplex X
+KanComplex⇒WeakKanComplex complex = record
+  { filler = filler
+  ; filler-cong = filler-cong
+  ; is-filler = is-filler
+  }
+  where
+    open IsKanComplex complex

--- a/src/Categories/Category/Instance/KanComplexes.agda
+++ b/src/Categories/Category/Instance/KanComplexes.agda
@@ -33,13 +33,13 @@ module _ (o ℓ : Level) where
   KanComplexes : Category (suc o ⊔ suc ℓ) (o ⊔ ℓ ⊔ (o ⊔ ℓ)) (o ⊔ ℓ)
   KanComplexes = SubCategory (SimplicialSet o ℓ) {I = Σ ΔSet (IsKanComplex o ℓ)} $ record
     { U = proj₁
-    ; R = λ { {X , X-Kan} {Y , Y-Kan} f → PreservesFiller X-Kan Y-Kan f }
-    ; Rid = λ { {X , X-Kan} i → begin
+    ; R = λ { {_ , X-Kan} {_ , Y-Kan} f → PreservesFiller X-Kan Y-Kan f }
+    ; Rid = λ { {_ , X-Kan} i → begin
         id ∘ filler X-Kan i   ≈⟨ identityˡ {f = filler X-Kan i} ⟩
         filler X-Kan i        ≈˘⟨ filler-cong X-Kan (identityˡ {f = i}) ⟩
         filler X-Kan (id ∘ i) ∎
       }
-    ; _∘R_ = λ { {X , X-Kan} {Y , Y-Kan} {Z , Z-Kan} {f} {g} f-preserves g-preserves i → begin
+    ; _∘R_ = λ { {_ , X-Kan} {_ , Y-Kan} {_ , Z-Kan} {f} {g} f-preserves g-preserves i → begin
         (f ∘ g) ∘ filler X-Kan i ≈⟨ assoc {f = filler X-Kan i} {g = g} {h = f} ⟩
         f ∘ (g ∘ filler X-Kan i) ≈⟨ ∘-resp-≈ʳ {f = (g ∘ filler X-Kan i)} {h = filler Y-Kan (g ∘ i)} {g = f} (g-preserves i) ⟩
         f ∘ filler Y-Kan (g ∘ i) ≈⟨ f-preserves (g ∘ i) ⟩

--- a/src/Categories/Category/Instance/KanComplexes.agda
+++ b/src/Categories/Category/Instance/KanComplexes.agda
@@ -1,0 +1,34 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- The Category of Algebraic Kan Complexes
+module Categories.Category.Instance.KanComplexes where
+
+open import Level
+
+open import Function using (_$_)
+open import Data.Product using (Σ; _,_; proj₁)
+
+open import Categories.Category
+open import Categories.Category.SubCategory
+open import Categories.Category.Instance.SimplicialSet
+
+import Categories.Category.Instance.SimplicialSet.Properties as ΔSetₚ
+
+module _ (o ℓ : Level) where
+  open Category (SimplicialSet o ℓ)
+  open ΔSetₚ o ℓ
+  open IsKanComplex
+  open Equiv
+  
+  -- As we are working with Algebraic Kan Complexes, maps between two Kan Complexes ought
+  -- to take the chosen filler in 'X' to the chosen filler in 'Y'.
+  PreservesFiller : ∀ {X Y : ΔSet} → IsKanComplex X → IsKanComplex Y → (X ⇒ Y) → Set (o ⊔ ℓ)
+  PreservesFiller {X} {Y} X-Kan Y-Kan f = ∀ {n} {k} → (i : Λ[ n , k ] ⇒ X) → (f ∘ filler X-Kan {n} i) ≈ filler Y-Kan (f ∘ i)  
+
+  KanComplexes : Category (suc o ⊔ suc ℓ) (o ⊔ ℓ ⊔ (o ⊔ ℓ)) (o ⊔ ℓ)
+  KanComplexes = SubCategory (SimplicialSet o ℓ) {I = Σ ΔSet IsKanComplex} $ record
+    { U = proj₁
+    ; R = λ { {X , X-Kan} {Y , Y-Kan} f → PreservesFiller X-Kan Y-Kan f }
+    ; Rid = λ _ → refl
+    ; _∘R_ = λ _ _ _ → refl
+    }

--- a/src/Categories/Category/Instance/KanComplexes.agda
+++ b/src/Categories/Category/Instance/KanComplexes.agda
@@ -1,4 +1,4 @@
-
+{-# OPTIONS --without-K --safe #-}
 
 -- The Category of Algebraic Kan Complexes
 module Categories.Category.Instance.KanComplexes where
@@ -10,7 +10,9 @@ open import Data.Product using (Σ; _,_; proj₁)
 
 open import Categories.Category
 open import Categories.Category.SubCategory
+open import Categories.Category.Construction.KanComplex
 open import Categories.Category.Instance.SimplicialSet
+
 
 import Categories.Category.Instance.SimplicialSet.Properties as ΔSetₚ
 
@@ -25,11 +27,11 @@ module _ (o ℓ : Level) where
   
   -- As we are working with Algebraic Kan Complexes, maps between two Kan Complexes ought
   -- to take the chosen filler in 'X' to the chosen filler in 'Y'.
-  PreservesFiller : ∀ {X Y : ΔSet} → IsKanComplex X → IsKanComplex Y → (X ⇒ Y) → Set (o ⊔ ℓ)
+  PreservesFiller : ∀ {X Y : ΔSet} → IsKanComplex o ℓ X → IsKanComplex o ℓ Y → (X ⇒ Y) → Set (o ⊔ ℓ)
   PreservesFiller {X} {Y} X-Kan Y-Kan f = ∀ {n} {k} → (i : Λ[ n , k ] ⇒ X) → (f ∘ filler X-Kan {n} i) ≈ filler Y-Kan (f ∘ i)  
 
   KanComplexes : Category (suc o ⊔ suc ℓ) (o ⊔ ℓ ⊔ (o ⊔ ℓ)) (o ⊔ ℓ)
-  KanComplexes = SubCategory (SimplicialSet o ℓ) {I = Σ ΔSet IsKanComplex} $ record
+  KanComplexes = SubCategory (SimplicialSet o ℓ) {I = Σ ΔSet (IsKanComplex o ℓ)} $ record
     { U = proj₁
     ; R = λ { {X , X-Kan} {Y , Y-Kan} f → PreservesFiller X-Kan Y-Kan f }
     ; Rid = λ { {X , X-Kan} i → begin

--- a/src/Categories/Category/Instance/KanComplexes.agda
+++ b/src/Categories/Category/Instance/KanComplexes.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --safe #-}
+
 
 -- The Category of Algebraic Kan Complexes
 module Categories.Category.Instance.KanComplexes where
@@ -14,11 +14,14 @@ open import Categories.Category.Instance.SimplicialSet
 
 import Categories.Category.Instance.SimplicialSet.Properties as ΔSetₚ
 
+import Categories.Morphism.Reasoning as MR
+
 module _ (o ℓ : Level) where
   open Category (SimplicialSet o ℓ)
   open ΔSetₚ o ℓ
   open IsKanComplex
   open Equiv
+  open MR (SimplicialSet o ℓ)
   
   -- As we are working with Algebraic Kan Complexes, maps between two Kan Complexes ought
   -- to take the chosen filler in 'X' to the chosen filler in 'Y'.
@@ -29,6 +32,18 @@ module _ (o ℓ : Level) where
   KanComplexes = SubCategory (SimplicialSet o ℓ) {I = Σ ΔSet IsKanComplex} $ record
     { U = proj₁
     ; R = λ { {X , X-Kan} {Y , Y-Kan} f → PreservesFiller X-Kan Y-Kan f }
-    ; Rid = λ _ → refl
-    ; _∘R_ = λ _ _ _ → refl
+    ; Rid = λ { {X , X-Kan} i → begin
+        id ∘ filler X-Kan i   ≈⟨ identityˡ {f = filler X-Kan i} ⟩
+        filler X-Kan i        ≈˘⟨ filler-cong X-Kan (identityˡ {f = i}) ⟩
+        filler X-Kan (id ∘ i) ∎
+      }
+    ; _∘R_ = λ { {X , X-Kan} {Y , Y-Kan} {Z , Z-Kan} {f} {g} f-preserves g-preserves i → begin
+        (f ∘ g) ∘ filler X-Kan i ≈⟨ assoc {f = filler X-Kan i} {g = g} {h = f} ⟩
+        f ∘ (g ∘ filler X-Kan i) ≈⟨ ∘-resp-≈ʳ {f = (g ∘ filler X-Kan i)} {h = filler Y-Kan (g ∘ i)} {g = f} (g-preserves i) ⟩
+        f ∘ filler Y-Kan (g ∘ i) ≈⟨ f-preserves (g ∘ i) ⟩
+        filler Z-Kan (f ∘ g ∘ i) ≈˘⟨ filler-cong Z-Kan (assoc {f = i} {g = g} {h = f}) ⟩
+        filler Z-Kan ((f ∘ g) ∘ i) ∎
+      }
     }
+    where
+      open HomReasoning

--- a/src/Categories/Category/Instance/Simplex.agda
+++ b/src/Categories/Category/Instance/Simplex.agda
@@ -7,10 +7,10 @@ module Categories.Category.Instance.Simplex where
 open import Level
 open import Data.Product
 open import Data.Fin.Base using (Fin; _≤_)
-open import Data.Nat.Base using (ℕ)
+open import Data.Nat.Base using (ℕ; z≤n; s≤s)
 open import Function renaming (id to idF; _∘_ to _∙_)
 
-open import Relation.Binary
+open import Relation.Binary using (_=[_]⇒_)
 open import Relation.Binary.PropositionalEquality
 
 Δ : Category 0ℓ 0ℓ 0ℓ
@@ -32,3 +32,38 @@ open import Relation.Binary.PropositionalEquality
     }
   ; ∘-resp-≈  = λ {_ _ _ f g h i} eq₁ eq₂ x → trans (cong (λ t → proj₁ f t) (eq₂ x)) (eq₁ (proj₁ i x))
   }
+
+open Category Δ
+
+--------------------------------------------------------------------------------
+-- Face + Degeneracy Maps
+
+face-map : ∀ {n} → Fin (ℕ.suc n) → Fin n → Fin (ℕ.suc n)
+face-map Fin.zero k = Fin.suc k
+face-map (Fin.suc i) Fin.zero = Fin.zero
+face-map (Fin.suc i) (Fin.suc k) = Fin.suc (face-map i k)
+
+face-mono : ∀ {n} → (i : Fin (ℕ.suc n)) → _≤_ =[ face-map i ]⇒ _≤_
+face-mono Fin.zero {x} {y} le = s≤s le
+face-mono (Fin.suc i) {Fin.zero} {y} le = z≤n
+face-mono (Fin.suc i) {Fin.suc x} {Fin.suc y} (s≤s le) = s≤s (face-mono i le)
+
+face : ∀ {n} → Fin (ℕ.suc n) → n ⇒ ℕ.suc n
+face i = face-map i , face-mono i
+
+degeneracy-map : ∀ {n} → Fin n → Fin (ℕ.suc n) → Fin n
+degeneracy-map Fin.zero Fin.zero = Fin.zero
+degeneracy-map Fin.zero (Fin.suc Fin.zero) = Fin.zero
+degeneracy-map Fin.zero (Fin.suc (Fin.suc k)) = Fin.suc k
+degeneracy-map (Fin.suc i) Fin.zero = Fin.zero
+degeneracy-map (Fin.suc i) (Fin.suc k) = Fin.suc (degeneracy-map i k)
+
+degeneracy-mono : ∀ {n} → (i : Fin n) → _≤_ =[ degeneracy-map i ]⇒ _≤_
+degeneracy-mono Fin.zero {Fin.zero} {y} le = z≤n
+degeneracy-mono Fin.zero {Fin.suc (Fin.zero)} {Fin.suc y} le = z≤n
+degeneracy-mono Fin.zero {Fin.suc (Fin.suc x)} {Fin.suc (Fin.suc y)} (s≤s le) = le
+degeneracy-mono (Fin.suc i) {Fin.zero} {y} le = z≤n
+degeneracy-mono (Fin.suc i) {Fin.suc x} {Fin.suc y} (s≤s le) = s≤s (degeneracy-mono i le)
+
+degeneracy : ∀ {n} → Fin n → ℕ.suc n ⇒ n
+degeneracy i = degeneracy-map i , degeneracy-mono i

--- a/src/Categories/Category/Instance/Simplex.agda
+++ b/src/Categories/Category/Instance/Simplex.agda
@@ -39,31 +39,29 @@ open Category Δ
 -- Face + Degeneracy Maps
 
 face-map : ∀ {n} → Fin (ℕ.suc n) → Fin n → Fin (ℕ.suc n)
-face-map Fin.zero k = Fin.suc k
-face-map (Fin.suc i) Fin.zero = Fin.zero
+face-map Fin.zero    k           = Fin.suc k
+face-map (Fin.suc i) Fin.zero    = Fin.zero
 face-map (Fin.suc i) (Fin.suc k) = Fin.suc (face-map i k)
 
 face-mono : ∀ {n} → (i : Fin (ℕ.suc n)) → _≤_ =[ face-map i ]⇒ _≤_
-face-mono Fin.zero {x} {y} le = s≤s le
-face-mono (Fin.suc i) {Fin.zero} {y} le = z≤n
-face-mono (Fin.suc i) {Fin.suc x} {Fin.suc y} (s≤s le) = s≤s (face-mono i le)
+face-mono Fin.zero    {_}         {_}         le       = s≤s le
+face-mono (Fin.suc i) {Fin.zero}  {_}         _        = z≤n
+face-mono (Fin.suc i) {Fin.suc _} {Fin.suc _} (s≤s le) = s≤s (face-mono i le)
 
 face : ∀ {n} → Fin (ℕ.suc n) → n ⇒ ℕ.suc n
 face i = face-map i , face-mono i
 
 degeneracy-map : ∀ {n} → Fin n → Fin (ℕ.suc n) → Fin n
-degeneracy-map Fin.zero Fin.zero = Fin.zero
-degeneracy-map Fin.zero (Fin.suc Fin.zero) = Fin.zero
-degeneracy-map Fin.zero (Fin.suc (Fin.suc k)) = Fin.suc k
-degeneracy-map (Fin.suc i) Fin.zero = Fin.zero
+degeneracy-map Fin.zero    Fin.zero    = Fin.zero
+degeneracy-map Fin.zero    (Fin.suc k) = k
+degeneracy-map (Fin.suc i) Fin.zero    = Fin.zero
 degeneracy-map (Fin.suc i) (Fin.suc k) = Fin.suc (degeneracy-map i k)
 
 degeneracy-mono : ∀ {n} → (i : Fin n) → _≤_ =[ degeneracy-map i ]⇒ _≤_
-degeneracy-mono Fin.zero {Fin.zero} {y} le = z≤n
-degeneracy-mono Fin.zero {Fin.suc (Fin.zero)} {Fin.suc y} le = z≤n
-degeneracy-mono Fin.zero {Fin.suc (Fin.suc x)} {Fin.suc (Fin.suc y)} (s≤s le) = le
-degeneracy-mono (Fin.suc i) {Fin.zero} {y} le = z≤n
-degeneracy-mono (Fin.suc i) {Fin.suc x} {Fin.suc y} (s≤s le) = s≤s (degeneracy-mono i le)
+degeneracy-mono Fin.zero    {Fin.zero}  {_}         _        = z≤n
+degeneracy-mono Fin.zero    {Fin.suc _} {Fin.suc _} (s≤s le) = le
+degeneracy-mono (Fin.suc i) {Fin.zero}  {_}         _        = z≤n
+degeneracy-mono (Fin.suc i) {Fin.suc _} {Fin.suc _} (s≤s le) = s≤s (degeneracy-mono i le)
 
 degeneracy : ∀ {n} → Fin n → ℕ.suc n ⇒ n
 degeneracy i = degeneracy-map i , degeneracy-mono i

--- a/src/Categories/Category/Instance/SimplicialSet/Properties.agda
+++ b/src/Categories/Category/Instance/SimplicialSet/Properties.agda
@@ -173,16 +173,19 @@ module _ where
   record IsKanComplex (X : ΔSet) : Set (o ⊔ ℓ) where
     field
       filler : ∀ {n} {k} → Λ[ n , k ] ⇒ X → Δ[ n ] ⇒ X
+      filler-cong : ∀ {n} {k} → {f g : Λ[ n , k ] ⇒ X} → f ≈ g → filler {n} f ≈ filler g
       is-filler : ∀ {n} {k} → (f : Λ[ n , k ] ⇒ X) → filler f ∘ Λ-inj k ≈ f
 
   record IsWeakKanComplex (X : ΔSet) : Set (o ⊔ ℓ) where
     field
       filler : ∀ {n} {k : Fin (ℕ.suc n)} → 0F < k → k < fromℕ n → Λ[ ℕ.suc n , k ] ⇒ X → Δ[ ℕ.suc n ] ⇒ X
+      filler-cong : ∀ {n} {k} → (0<k : 0F < k) → (k<n : k < fromℕ n) → {f g : Λ[ ℕ.suc n , k ] ⇒ X} → f ≈ g → filler 0<k k<n f ≈ filler 0<k k<n g
       is-filler : ∀ {n} {k : Fin (ℕ.suc n)} → (0<k : 0F < k) → (k<n : k < fromℕ n) → (f : Λ[ ℕ.suc n , k ] ⇒ X) → filler 0<k k<n f ∘ Λ-inj k ≈ f
 
   KanComplex⇒WeakKanComplex : ∀ {X} → IsKanComplex X → IsWeakKanComplex X
   KanComplex⇒WeakKanComplex complex = record
     { filler = λ _ _ f → filler f
+    ; filler-cong = λ _ _ eq x → filler-cong eq x
     ; is-filler = λ { {n} {k} 0<k k<n f {m} {h} {h′} x → is-filler f {m} {h} x }
     }
     where

--- a/src/Categories/Category/Instance/SimplicialSet/Properties.agda
+++ b/src/Categories/Category/Instance/SimplicialSet/Properties.agda
@@ -158,6 +158,25 @@ record Horn (m n-1 : ℕ) (k : Fin (ℕ.suc n-1)) : Set where
 module _ where
   open Category (SimplicialSet o ℓ)
 
+  -- Inclusion of boundaries
+  ∂Δ-inj : ∀ {n} → ∂Δ[ n ] ⇒ Δ[ n ]
+  ∂Δ-inj {ℕ.zero} = ntHelper record
+    { η = λ X → record
+      { _⟨$⟩_ = ⊥-elim
+      ; cong = λ { {()} }
+      }
+    ; commute = λ { _ {()} _ }
+    }
+  ∂Δ-inj {ℕ.suc n} = ntHelper record
+    { η = λ X → record
+      { _⟨$⟩_ = λ (lift b) → lift (hom b)
+      ; cong = λ eq → lift (λ x → lower (eq x))
+      }
+    ; commute = λ f eq → lift (λ x → lower (eq (proj₁ f x)))
+    }
+    where
+      open Boundary
+
   -- Inclusion of n-horns into n-simplicies
   Λ-inj : ∀ {n} → (k : Fin n) → Λ[ n , k ] ⇒ Δ[ n ]
   Λ-inj {n = ℕ.suc n} k = ntHelper record

--- a/src/Categories/Category/Instance/SimplicialSet/Properties.agda
+++ b/src/Categories/Category/Instance/SimplicialSet/Properties.agda
@@ -1,0 +1,190 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Level
+open import Function using (_$_)
+
+module Categories.Category.Instance.SimplicialSet.Properties (o ℓ : Level) where
+
+open import Data.Empty.Polymorphic
+open import Data.Nat using (ℕ)
+open import Data.Fin using (Fin; _<_; fromℕ)
+open import Data.Fin.Patterns
+open import Data.Product using (proj₁)
+
+import Relation.Binary.PropositionalEquality as Eq
+
+open import Categories.Category
+open import Categories.Category.Instance.SimplicialSet
+open import Categories.Category.Instance.Simplex
+
+open import Categories.Functor
+open import Categories.Functor.Construction.Constant
+open import Categories.Functor.Construction.LiftSetoids
+
+open import Categories.NaturalTransformation
+
+open import Categories.Yoneda
+
+private
+  module Y = Functor (Yoneda.embed Δ)
+
+-- Some useful notation for a simplicial set
+ΔSet : Set (suc o ⊔ suc ℓ)
+ΔSet = Category.Obj (SimplicialSet o ℓ )
+
+-- The standard n-simplex.
+Δ[_] : ℕ → ΔSet
+Δ[_] n = LiftSetoids o ℓ ∘F Y.F₀ n
+
+--------------------------------------------------------------------------------
+-- Boundaries of the Standard Simplicies
+--
+-- The basic idea here is that we will build up boundary of 'Δ[ n ]' by considering
+-- all of the morphisms 'Δ[ m , n ]' that factor through some face map 'face i : Δ[ n - 1 , n ]'
+
+-- The indexing here is a bit tricky, but this is the price we pay to avoid 'pred'
+-- A 'Boundary m n' represents some set of maps into 'Δ[ ℕ.suc n ]' that factor through
+-- a face map. To make this indexing more obvious, we use the suggestively named variable 'n-1'.
+record Boundary (m n-1 : ℕ) : Set where
+  field
+    hom : Δ [ m , (ℕ.suc n-1) ]
+    factor : Δ [ m , n-1 ]
+    factor-dim : Fin (ℕ.suc n-1)
+    factor-face : Δ [ hom ≈ Δ [ face factor-dim ∘ factor ] ]
+
+-- Lift morphisms in Δ to maps between boundary sets on 'Δ[ n ]'
+boundary-map : ∀ {x y n} → Δ [ x , y ] → Boundary y n → Boundary x n
+boundary-map {n = n} f b = record
+  { hom = hom b ∘ f
+  ; factor = factor b ∘ f
+  ; factor-dim = factor-dim b
+  ; factor-face = λ x → factor-face b (proj₁ f x)
+  }
+  where
+    open Category Δ
+    open Boundary
+
+-- The boundary of an n-simplex
+∂Δ[_] : ℕ → ΔSet 
+∂Δ[_] ℕ.zero = const record
+  { Carrier = ⊥
+  ; _≈_ = λ ()
+  ; isEquivalence = record
+    { refl  = λ { {()} }
+    ; sym   = λ { {()} }
+    ; trans = λ { {()} }
+    }
+  }
+∂Δ[_] (ℕ.suc n) = record
+  { F₀ = λ m → record
+    { Carrier = Lift o (Boundary m n)
+    -- Unwinding the equality by hand here leads to less unsolved metavariables down the line
+    ; _≈_ = λ (lift b) (lift b′) → ∀ x → Lift ℓ (proj₁ (hom b) x ≡ proj₁ (hom b′) x)
+    ; isEquivalence = record
+      { refl = λ x → lift refl
+      ; sym = λ eq x → lift (sym (lower (eq x)))
+      ; trans = λ eq₁ eq₂ x → lift (trans (lower (eq₁ x)) (lower (eq₂ x)))
+      }
+    }
+  ; F₁ = λ f → record
+    { _⟨$⟩_ = λ (lift b) → lift (boundary-map f b)
+    ; cong = λ eq x → eq (proj₁ f x)
+    }
+  ; identity = λ eq → eq
+  ; homomorphism = λ {_} {_} {_} {f} {g} eq x → eq (proj₁ f (proj₁ g x))
+  ; F-resp-≈ = λ {_} {_} {f} {g} f≈g {b} {b′} eq x → lift $ begin
+    proj₁ (hom (lower b)) (proj₁ f x)  ≡⟨ lower (eq (proj₁ f x)) ⟩
+    proj₁ (hom (lower b′)) (proj₁ f x) ≡⟨ cong (proj₁ (hom (lower b′))) (f≈g x) ⟩
+    proj₁ (hom (lower b′)) (proj₁ g x) ∎
+  } 
+  where
+    open Boundary
+    open Eq
+    open ≡-Reasoning
+
+--------------------------------------------------------------------------------
+-- Horns
+-- 
+-- The idea here is essentially the same as the boundaries, but we exclude the kth
+-- face map as a possible factor.
+
+record Horn (m n-1 : ℕ) (k : Fin (ℕ.suc n-1)) : Set where
+  field
+    horn : Boundary m n-1
+
+  open Boundary horn public
+
+  field
+    is-horn : factor-dim Eq.≢ k
+
+Λ[_,_] : (n : ℕ) → Fin n → ΔSet
+Λ[ ℕ.suc n , k ] = record
+  { F₀ = λ m → record
+    { Carrier = Lift o (Horn m n k)
+    ; _≈_ = λ (lift b) (lift b′) → ∀ x → Lift ℓ (proj₁ (hom b) x ≡ proj₁ (hom b′) x)
+    ; isEquivalence = record
+      { refl = λ x → lift refl
+      ; sym = λ eq x → lift (sym (lower (eq x)))
+      ; trans = λ eq₁ eq₂ x → lift (trans (lower (eq₁ x)) (lower (eq₂ x)))
+      }
+    }
+  ; F₁ = λ f → record
+    { _⟨$⟩_ = λ (lift h) → lift $ record
+      { horn = boundary-map f (horn h)
+      ; is-horn = is-horn h
+      }
+    ; cong = λ eq x → eq (proj₁ f x)
+    }
+  ; identity = λ eq → eq
+  ; homomorphism = λ {_} {_} {_} {f} {g} eq x → eq (proj₁ f (proj₁ g x))
+  ; F-resp-≈ = λ {_} {_} {f} {g} f≈g {b} {b′} eq x → lift $ begin
+    proj₁ (hom (lower b)) (proj₁ f x)  ≡⟨ lower (eq (proj₁ f x)) ⟩
+    proj₁ (hom (lower b′)) (proj₁ f x) ≡⟨ cong (proj₁ (hom (lower b′))) (f≈g x) ⟩
+    proj₁ (hom (lower b′)) (proj₁ g x) ∎
+  }
+  where
+    open Horn
+    open Eq
+    open ≡-Reasoning
+
+
+--------------------------------------------------------------------------------
+-- Kan Complexes
+--
+-- These are technically "Algebraic" Kan Complexes, as they come with a choice of fillers
+-- However, this notion is far easier than the more geometric flavor,
+-- as we can sidestep questions about choice.
+
+module _ where
+  open Category (SimplicialSet o ℓ)
+
+  -- Inclusion of n-horns into n-simplicies
+  Λ-inj : ∀ {n} → (k : Fin n) → Λ[ n , k ] ⇒ Δ[ n ]
+  Λ-inj {n = ℕ.suc n} k = ntHelper record
+    { η = λ X → record
+      { _⟨$⟩_ = λ (lift h) → lift (hom h)
+      ; cong = λ eq → lift (λ x → lower (eq x))
+      }
+    ; commute = λ f eq → lift (λ x → lower (eq (proj₁ f x)))
+    }
+    where
+      open Horn
+  
+  record IsKanComplex (X : ΔSet) : Set (o ⊔ ℓ) where
+    field
+      filler : ∀ {n} {k} → Λ[ n , k ] ⇒ X → Δ[ n ] ⇒ X
+      is-filler : ∀ {n} {k} → (f : Λ[ n , k ] ⇒ X) → filler f ∘ Λ-inj k ≈ f
+
+  record IsWeakKanComplex (X : ΔSet) : Set (o ⊔ ℓ) where
+    field
+      filler : ∀ {n} {k : Fin (ℕ.suc n)} → 0F < k → k < fromℕ n → Λ[ ℕ.suc n , k ] ⇒ X → Δ[ ℕ.suc n ] ⇒ X
+      is-filler : ∀ {n} {k : Fin (ℕ.suc n)} → (0<k : 0F < k) → (k<n : k < fromℕ n) → (f : Λ[ ℕ.suc n , k ] ⇒ X) → filler 0<k k<n f ∘ Λ-inj k ≈ f
+
+  KanComplex⇒WeakKanComplex : ∀ {X} → IsKanComplex X → IsWeakKanComplex X
+  KanComplex⇒WeakKanComplex complex = record
+    { filler = λ _ _ f → filler f
+    ; is-filler = λ { {n} {k} 0<k k<n f {m} {h} {h′} x → is-filler f {m} {h} x }
+    }
+    where
+      open IsKanComplex complex
+  


### PR DESCRIPTION
## Patch Description
This PR implements Kan Complexes and Weak Kan Complexes, as well as adding some machinery surrounding Simplicial Sets that is required to do so. Of note are definitions for face and degeneracy maps, as well as boundaries and horns.
Particularly, this implements _Algebraic_ Kan Complexes, as those have less fiddly issues with choice.

## Notes
The combinatorics here were not as bad as I initially thought they would be! Everything works out rather well. However, there are a few things that I'm not 100% sure of.
- The inequality in the definition of `Horn` seems like it could become a bit awkward down the line?
- The proof obligations in `WeakKanComplex` seem pretty painful. Perhaps there is a more clever way of doing this?
- The unfolded equality in `∂Δ[_]` and `Λ[_,_]` does better than just lifting the equality from `Δ`, but it still falls on it's face from time to time (See `KanComplex⇒WeakKanComplex`)

## References
- https://ncatlab.org/nlab/show/Kan+complex
- https://ncatlab.org/nlab/show/weak+Kan+complex
- https://ncatlab.org/nlab/show/algebraic+Kan+complex