### PR TITLE
Update to standard-library 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
         CABAL_VER=2.2
         ALEX_VER=3.2.5
         HAPPY_VER=1.19.12
-        STDLIB_VER=1.5
+        STDLIB_VER=1.6
       addons:
         apt:
           packages:

--- a/agda-categories.agda-lib
+++ b/agda-categories.agda-lib
@@ -1,3 +1,3 @@
 name: agda-categories
-depend: standard-library-1.5
+depend: standard-library-1.6
 include: src/


### PR DESCRIPTION
stdlib 1.6-rc1 is just out. No source changes are necessary! :-)

If you cut a new release, we can upgrade agda-categories in Nix.