### PR TITLE
Add support for braided/symmetric monoidal natural transformations/isomorphisms.

### DIFF
--- a/Everything.agda
+++ b/Everything.agda
@@ -328,10 +328,14 @@ import Categories.NaturalTransformation.Equivalence
 import Categories.NaturalTransformation.Extranatural
 import Categories.NaturalTransformation.Hom
 import Categories.NaturalTransformation.Monoidal
+import Categories.NaturalTransformation.Monoidal.Braided
+import Categories.NaturalTransformation.Monoidal.Symmetric
 import Categories.NaturalTransformation.NaturalIsomorphism
 import Categories.NaturalTransformation.NaturalIsomorphism.Equivalence
 import Categories.NaturalTransformation.NaturalIsomorphism.Functors
 import Categories.NaturalTransformation.NaturalIsomorphism.Monoidal
+import Categories.NaturalTransformation.NaturalIsomorphism.Monoidal.Braided
+import Categories.NaturalTransformation.NaturalIsomorphism.Monoidal.Symmetric
 import Categories.NaturalTransformation.NaturalIsomorphism.Properties
 import Categories.NaturalTransformation.Properties
 import Categories.Object.Biproduct

--- a/src/Categories/Functor/Monoidal/Braided.agda
+++ b/src/Categories/Functor/Monoidal/Braided.agda
@@ -50,7 +50,7 @@ module Lax where
 
   record BraidedMonoidalFunctor : Set (o ⊔ ℓ ⊔ e ⊔ o′ ⊔ ℓ′ ⊔ e′) where
     field
-      F                   : Functor C.U D.U
+      F                 : Functor C.U D.U
       isBraidedMonoidal : IsBraidedMonoidalFunctor F
 
     open Functor F public
@@ -94,7 +94,7 @@ module Strong where
 
   record BraidedMonoidalFunctor : Set (o ⊔ ℓ ⊔ e ⊔ o′ ⊔ ℓ′ ⊔ e′) where
     field
-      F                   : Functor C.U D.U
+      F                 : Functor C.U D.U
       isBraidedMonoidal : IsBraidedMonoidalFunctor F
 
     open Functor F public

--- a/src/Categories/NaturalTransformation/Monoidal/Braided.agda
+++ b/src/Categories/NaturalTransformation/Monoidal/Braided.agda
@@ -1,0 +1,194 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Monoidal natural transformations between lax and strong braided
+-- monoidal functors.
+--
+-- NOTE. Braided monoidal natural transformations are really just
+-- monoidal natural transformations that happen to go between braided
+-- monoidal functors.  No additional conditions are necessary.
+-- Nevertheless, the definitions in this module are useful when one is
+-- working in a braided monoidal setting.  They also help Agda's type
+-- checker by bundling the (braided monoidal) categories and functors
+-- involved.
+--
+-- See
+--  * John Baez, Some definitions everyone should know,
+--    https://math.ucr.edu/home/baez/qg-fall2004/definitions.pdf
+--  * https://ncatlab.org/nlab/show/monoidal+natural+transformation
+
+module Categories.NaturalTransformation.Monoidal.Braided where
+
+open import Level
+
+open import Categories.Category.Monoidal using (BraidedMonoidalCategory)
+import Categories.Functor.Monoidal.Braided as BMF
+open import Categories.Functor.Monoidal.Properties using ()
+  renaming (∘-BraidedMonoidal to _∘Fˡ_; ∘-StrongBraidedMonoidal to _∘Fˢ_)
+open import Categories.NaturalTransformation as NT using (NaturalTransformation)
+import Categories.NaturalTransformation.Monoidal as MNT
+
+module Lax where
+  open BMF.Lax using (BraidedMonoidalFunctor)
+  open MNT.Lax using (IsMonoidalNaturalTransformation)
+  open BraidedMonoidalFunctor using () renaming (F to UF; monoidalFunctor to MF)
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′} where
+
+    -- Monoidal natural transformations between braided monoidal functors.
+
+    record BraidedMonoidalNaturalTransformation
+           (F G : BraidedMonoidalFunctor C D) : Set (o ⊔ ℓ ⊔ ℓ′ ⊔ e′) where
+
+      field
+        U          : NaturalTransformation (UF F) (UF G)
+        isMonoidal : IsMonoidalNaturalTransformation (MF F) (MF G) U
+
+      open NaturalTransformation           U          public
+      open IsMonoidalNaturalTransformation isMonoidal public
+
+  -- To shorten some definitions
+
+  private
+    _⇛_ = BraidedMonoidalNaturalTransformation
+    module U = MNT.Lax
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′} where
+
+    -- Conversions
+
+    ⌊_⌋ : {F G : BraidedMonoidalFunctor C D} →
+          F ⇛ G → U.MonoidalNaturalTransformation (MF F) (MF G)
+    ⌊ α ⌋ = record { U = U ; isMonoidal = isMonoidal }
+      where open BraidedMonoidalNaturalTransformation α
+
+    ⌈_⌉ : {F G : BraidedMonoidalFunctor C D} →
+          U.MonoidalNaturalTransformation (MF F) (MF G) → F ⇛ G
+    ⌈ α ⌉ = record { U = U ; isMonoidal = isMonoidal }
+      where open U.MonoidalNaturalTransformation α
+
+    -- Identity and compositions
+
+    infixr 9 _∘ᵥ_
+
+    id : {F : BraidedMonoidalFunctor C D} → F ⇛ F
+    id = ⌈ U.id ⌉
+
+    _∘ᵥ_ : {F G H : BraidedMonoidalFunctor C D} → G ⇛ H → F ⇛ G → F ⇛ H
+    α ∘ᵥ β   = ⌈ ⌊ α ⌋ U.∘ᵥ ⌊ β ⌋ ⌉
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′}
+           {E : BraidedMonoidalCategory o″ ℓ″ e″} where
+
+    infixr 9 _∘ₕ_ _∘ˡ_ _∘ʳ_
+
+    _∘ₕ_ : {F G : BraidedMonoidalFunctor C D}
+           {H I : BraidedMonoidalFunctor D E} →
+           H ⇛ I → F ⇛ G → (H ∘Fˡ F) ⇛ (I ∘Fˡ G)
+    α ∘ₕ β = ⌈ ⌊ α ⌋ U.∘ₕ ⌊ β ⌋ ⌉
+
+    _∘ˡ_ : {F G : BraidedMonoidalFunctor C D}
+           (H : BraidedMonoidalFunctor D E) → F ⇛ G → (H ∘Fˡ F) ⇛ (H ∘Fˡ G)
+    H ∘ˡ α = id {F = H} ∘ₕ α
+
+    _∘ʳ_ : {G H : BraidedMonoidalFunctor D E} →
+           G ⇛ H → (F : BraidedMonoidalFunctor C D) → (G ∘Fˡ F) ⇛ (H ∘Fˡ F)
+    α ∘ʳ F = α ∘ₕ id {F = F}
+
+module Strong where
+  open BMF.Strong using (BraidedMonoidalFunctor)
+  open MNT.Strong using (IsMonoidalNaturalTransformation)
+  open BraidedMonoidalFunctor using () renaming
+    ( F                         to UF
+    ; monoidalFunctor           to MF
+    ; laxBraidedMonoidalFunctor to laxBMF
+    )
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′} where
+
+    -- Monoidal natural transformations between braided strong
+    -- monoidal functors.
+
+    record BraidedMonoidalNaturalTransformation
+           (F G : BraidedMonoidalFunctor C D) : Set (o ⊔ ℓ ⊔ ℓ′ ⊔ e′) where
+
+      field
+        U          : NaturalTransformation (UF F) (UF G)
+        isMonoidal : IsMonoidalNaturalTransformation (MF F) (MF G) U
+
+      laxBNT : Lax.BraidedMonoidalNaturalTransformation (laxBMF F) (laxBMF G)
+      laxBNT = record { U = U ; isMonoidal = isMonoidal }
+      open Lax.BraidedMonoidalNaturalTransformation laxBNT public
+        hiding (U; isMonoidal)
+
+  -- To shorten some definitions
+
+  private
+    _⇛_ = BraidedMonoidalNaturalTransformation
+    module U = MNT.Strong
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′} where
+
+    -- Conversions
+
+    ⌊_⌋ : {F G : BraidedMonoidalFunctor C D} →
+          F ⇛ G → U.MonoidalNaturalTransformation (MF F) (MF G)
+    ⌊ α ⌋ = record { U = U ; isMonoidal = isMonoidal }
+      where open BraidedMonoidalNaturalTransformation α
+
+    ⌈_⌉ : {F G : BraidedMonoidalFunctor C D} →
+          U.MonoidalNaturalTransformation (MF F) (MF G) → F ⇛ G
+    ⌈ α ⌉ = record { U = U ; isMonoidal = isMonoidal }
+      where open U.MonoidalNaturalTransformation α
+
+    -- Identity and compositions
+
+    infixr 9 _∘ᵥ_
+
+    id : {F : BraidedMonoidalFunctor C D} → F ⇛ F
+    id = ⌈ U.id ⌉
+
+    _∘ᵥ_ : {F G H : BraidedMonoidalFunctor C D} → G ⇛ H → F ⇛ G → F ⇛ H
+    α ∘ᵥ β   = ⌈ ⌊ α ⌋ U.∘ᵥ ⌊ β ⌋ ⌉
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′}
+           {E : BraidedMonoidalCategory o″ ℓ″ e″} where
+
+    infixr 9 _∘ₕ_ _∘ˡ_ _∘ʳ_
+
+    _∘ₕ_ : {F G : BraidedMonoidalFunctor C D}
+           {H I : BraidedMonoidalFunctor D E} →
+           H ⇛ I → F ⇛ G → (H ∘Fˢ F) ⇛ (I ∘Fˢ G)
+    -- NOTE: this definition is clearly equivalent to
+    --
+    --   α ∘ₕ β = ⌈ ⌊ α ⌋ U.∘ₕ ⌊ β ⌋ ⌉
+    --
+    -- but the latter takes an unreasonably long time to typecheck,
+    -- while the unfolded version typechecks almost immediately.
+    α ∘ₕ β = record
+      { U               = C.U
+      ; isMonoidal      = record
+        { ε-compat      = C.ε-compat
+        ; ⊗-homo-compat = C.⊗-homo-compat
+        }
+      }
+      where module C = U.MonoidalNaturalTransformation (⌊ α ⌋ U.∘ₕ ⌊ β ⌋)
+
+    _∘ˡ_ : {F G : BraidedMonoidalFunctor C D}
+           (H : BraidedMonoidalFunctor D E) → F ⇛ G → (H ∘Fˢ F) ⇛ (H ∘Fˢ G)
+    H ∘ˡ α = id {F = H} ∘ₕ α
+
+    _∘ʳ_ : {G H : BraidedMonoidalFunctor D E} →
+           G ⇛ H → (F : BraidedMonoidalFunctor C D) → (G ∘Fˢ F) ⇛ (H ∘Fˢ F)
+    α ∘ʳ F = α ∘ₕ id {F = F}

--- a/src/Categories/NaturalTransformation/Monoidal/Symmetric.agda
+++ b/src/Categories/NaturalTransformation/Monoidal/Symmetric.agda
@@ -1,0 +1,195 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Monoidal natural transformations between lax and strong symmetric
+-- monoidal functors.
+--
+-- NOTE. Symmetric monoidal natural transformations are really just
+-- monoidal natural transformations that happen to go between
+-- symmetric monoidal functors.  No additional conditions are
+-- necessary.  Nevertheless, the definitions in this module are useful
+-- when one is working in a symmetric monoidal setting.  They also
+-- help Agda's type checker by bundling the (symmetric monoidal)
+-- categories and functors involved.
+--
+-- See
+--  * John Baez, Some definitions everyone should know,
+--    https://math.ucr.edu/home/baez/qg-fall2004/definitions.pdf
+--  * https://ncatlab.org/nlab/show/monoidal+natural+transformation
+
+module Categories.NaturalTransformation.Monoidal.Symmetric where
+
+open import Level
+
+open import Categories.Category.Monoidal using (SymmetricMonoidalCategory)
+import Categories.Functor.Monoidal.Symmetric as BMF
+open import Categories.Functor.Monoidal.Properties using ()
+  renaming (∘-SymmetricMonoidal to _∘Fˡ_; ∘-StrongSymmetricMonoidal to _∘Fˢ_)
+open import Categories.NaturalTransformation as NT using (NaturalTransformation)
+import Categories.NaturalTransformation.Monoidal as MNT
+
+module Lax where
+  open BMF.Lax using (SymmetricMonoidalFunctor)
+  open MNT.Lax using (IsMonoidalNaturalTransformation)
+  open SymmetricMonoidalFunctor using ()
+    renaming (F to UF; monoidalFunctor to MF)
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′} where
+
+    -- Monoidal natural transformations between symmetric monoidal functors.
+
+    record SymmetricMonoidalNaturalTransformation
+           (F G : SymmetricMonoidalFunctor C D) : Set (o ⊔ ℓ ⊔ ℓ′ ⊔ e′) where
+
+      field
+        U          : NaturalTransformation (UF F) (UF G)
+        isMonoidal : IsMonoidalNaturalTransformation (MF F) (MF G) U
+
+      open NaturalTransformation           U          public
+      open IsMonoidalNaturalTransformation isMonoidal public
+
+  -- To shorten some definitions
+
+  private
+    _⇛_ = SymmetricMonoidalNaturalTransformation
+    module U = MNT.Lax
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′} where
+
+    -- Conversions
+
+    ⌊_⌋ : {F G : SymmetricMonoidalFunctor C D} →
+          F ⇛ G → U.MonoidalNaturalTransformation (MF F) (MF G)
+    ⌊ α ⌋ = record { U = U ; isMonoidal = isMonoidal }
+      where open SymmetricMonoidalNaturalTransformation α
+
+    ⌈_⌉ : {F G : SymmetricMonoidalFunctor C D} →
+          U.MonoidalNaturalTransformation (MF F) (MF G) → F ⇛ G
+    ⌈ α ⌉ = record { U = U ; isMonoidal = isMonoidal }
+      where open U.MonoidalNaturalTransformation α
+
+    -- Identity and compositions
+
+    infixr 9 _∘ᵥ_
+
+    id : {F : SymmetricMonoidalFunctor C D} → F ⇛ F
+    id = ⌈ U.id ⌉
+
+    _∘ᵥ_ : {F G H : SymmetricMonoidalFunctor C D} → G ⇛ H → F ⇛ G → F ⇛ H
+    α ∘ᵥ β   = ⌈ ⌊ α ⌋ U.∘ᵥ ⌊ β ⌋ ⌉
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′}
+           {E : SymmetricMonoidalCategory o″ ℓ″ e″} where
+
+    infixr 9 _∘ₕ_ _∘ˡ_ _∘ʳ_
+
+    _∘ₕ_ : {F G : SymmetricMonoidalFunctor C D}
+           {H I : SymmetricMonoidalFunctor D E} →
+           H ⇛ I → F ⇛ G → (H ∘Fˡ F) ⇛ (I ∘Fˡ G)
+    α ∘ₕ β = ⌈ ⌊ α ⌋ U.∘ₕ ⌊ β ⌋ ⌉
+
+    _∘ˡ_ : {F G : SymmetricMonoidalFunctor C D}
+           (H : SymmetricMonoidalFunctor D E) → F ⇛ G → (H ∘Fˡ F) ⇛ (H ∘Fˡ G)
+    H ∘ˡ α = id {F = H} ∘ₕ α
+
+    _∘ʳ_ : {G H : SymmetricMonoidalFunctor D E} →
+           G ⇛ H → (F : SymmetricMonoidalFunctor C D) → (G ∘Fˡ F) ⇛ (H ∘Fˡ F)
+    α ∘ʳ F = α ∘ₕ id {F = F}
+
+module Strong where
+  open BMF.Strong using (SymmetricMonoidalFunctor)
+  open MNT.Strong using (IsMonoidalNaturalTransformation)
+  open SymmetricMonoidalFunctor using () renaming
+    ( F                         to UF
+    ; monoidalFunctor           to MF
+    ; laxSymmetricMonoidalFunctor to laxBMF
+    )
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′} where
+
+    -- Monoidal natural transformations between symmetric strong
+    -- monoidal functors.
+
+    record SymmetricMonoidalNaturalTransformation
+           (F G : SymmetricMonoidalFunctor C D) : Set (o ⊔ ℓ ⊔ ℓ′ ⊔ e′) where
+
+      field
+        U          : NaturalTransformation (UF F) (UF G)
+        isMonoidal : IsMonoidalNaturalTransformation (MF F) (MF G) U
+
+      laxBNT : Lax.SymmetricMonoidalNaturalTransformation (laxBMF F) (laxBMF G)
+      laxBNT = record { U = U ; isMonoidal = isMonoidal }
+      open Lax.SymmetricMonoidalNaturalTransformation laxBNT public
+        hiding (U; isMonoidal)
+
+  -- To shorten some definitions
+
+  private
+    _⇛_ = SymmetricMonoidalNaturalTransformation
+    module U = MNT.Strong
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′} where
+
+    -- Conversions
+
+    ⌊_⌋ : {F G : SymmetricMonoidalFunctor C D} →
+          F ⇛ G → U.MonoidalNaturalTransformation (MF F) (MF G)
+    ⌊ α ⌋ = record { U = U ; isMonoidal = isMonoidal }
+      where open SymmetricMonoidalNaturalTransformation α
+
+    ⌈_⌉ : {F G : SymmetricMonoidalFunctor C D} →
+          U.MonoidalNaturalTransformation (MF F) (MF G) → F ⇛ G
+    ⌈ α ⌉ = record { U = U ; isMonoidal = isMonoidal }
+      where open U.MonoidalNaturalTransformation α
+
+    -- Identity and compositions
+
+    infixr 9 _∘ᵥ_
+
+    id : {F : SymmetricMonoidalFunctor C D} → F ⇛ F
+    id = ⌈ U.id ⌉
+
+    _∘ᵥ_ : {F G H : SymmetricMonoidalFunctor C D} → G ⇛ H → F ⇛ G → F ⇛ H
+    α ∘ᵥ β   = ⌈ ⌊ α ⌋ U.∘ᵥ ⌊ β ⌋ ⌉
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′}
+           {E : SymmetricMonoidalCategory o″ ℓ″ e″} where
+
+    infixr 9 _∘ₕ_ _∘ˡ_ _∘ʳ_
+
+    _∘ₕ_ : {F G : SymmetricMonoidalFunctor C D}
+           {H I : SymmetricMonoidalFunctor D E} →
+           H ⇛ I → F ⇛ G → (H ∘Fˢ F) ⇛ (I ∘Fˢ G)
+    -- NOTE: this definition is clearly equivalent to
+    --
+    --   α ∘ₕ β = ⌈ ⌊ α ⌋ U.∘ₕ ⌊ β ⌋ ⌉
+    --
+    -- but the latter takes an unreasonably long time to typecheck,
+    -- while the unfolded version typechecks almost immediately.
+    α ∘ₕ β = record
+      { U               = C.U
+      ; isMonoidal      = record
+        { ε-compat      = C.ε-compat
+        ; ⊗-homo-compat = C.⊗-homo-compat
+        }
+      }
+      where module C = U.MonoidalNaturalTransformation (⌊ α ⌋ U.∘ₕ ⌊ β ⌋)
+
+    _∘ˡ_ : {F G : SymmetricMonoidalFunctor C D}
+           (H : SymmetricMonoidalFunctor D E) → F ⇛ G → (H ∘Fˢ F) ⇛ (H ∘Fˢ G)
+    H ∘ˡ α = id {F = H} ∘ₕ α
+
+    _∘ʳ_ : {G H : SymmetricMonoidalFunctor D E} →
+           G ⇛ H → (F : SymmetricMonoidalFunctor C D) → (G ∘Fˢ F) ⇛ (H ∘Fˢ F)
+    α ∘ʳ F = α ∘ₕ id {F = F}

--- a/src/Categories/NaturalTransformation/NaturalIsomorphism/Monoidal/Braided.agda
+++ b/src/Categories/NaturalTransformation/NaturalIsomorphism/Monoidal/Braided.agda
@@ -1,0 +1,330 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Monoidal natural isomorphisms between lax and strong braided
+-- monoidal functors.
+--
+-- NOTE. Braided monoidal natural isomorphisms are really just
+-- monoidal natural isomorphisms that happen to go between braided
+-- monoidal functors.  No additional conditions are necessary.
+-- Nevertheless, the definitions in this module are useful when one is
+-- working in a braided monoidal setting.  They also help Agda's type
+-- checker by bundling the (braided monoidal) categories and functors
+-- involved.
+
+module Categories.NaturalTransformation.NaturalIsomorphism.Monoidal.Braided
+  where
+
+open import Level
+open import Relation.Binary using (IsEquivalence)
+
+open import Categories.Category.Monoidal using (BraidedMonoidalCategory)
+import Categories.Functor.Monoidal.Braided as BMF
+open import Categories.Functor.Monoidal.Properties using () renaming
+  ( idF-BraidedMonoidal to idFˡ  ; idF-StrongBraidedMonoidal to idFˢ
+  ; ∘-BraidedMonoidal   to _∘Fˡ_ ; ∘-StrongBraidedMonoidal   to _∘Fˢ_
+  )
+open import Categories.NaturalTransformation.NaturalIsomorphism as NI
+  using (NaturalIsomorphism)
+import Categories.NaturalTransformation.NaturalIsomorphism.Monoidal as MNI
+
+module Lax where
+  open BMF.Lax using (BraidedMonoidalFunctor)
+  open MNI.Lax using (IsMonoidalNaturalIsomorphism)
+  open BraidedMonoidalFunctor using () renaming (F to UF; monoidalFunctor to MF)
+  private module U = MNI.Lax
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′} where
+
+    -- Monoidal natural isomorphisms between lax braided monoidal functors.
+
+    record BraidedMonoidalNaturalIsomorphism
+           (F G : BraidedMonoidalFunctor C D) : Set (o ⊔ ℓ ⊔ ℓ′ ⊔ e′) where
+
+      field
+        U              : NaturalIsomorphism (UF F) (UF G)
+        F⇒G-isMonoidal : IsMonoidalNaturalIsomorphism (MF F) (MF G) U
+
+      ⌊_⌋ : U.MonoidalNaturalIsomorphism (MF F) (MF G)
+      ⌊_⌋ = record { U = U ; F⇒G-isMonoidal = F⇒G-isMonoidal }
+
+      open U.MonoidalNaturalIsomorphism ⌊_⌋ public hiding (U; F⇒G-isMonoidal)
+
+    infix 4 _≃_
+
+    _≃_ = BraidedMonoidalNaturalIsomorphism
+
+    -- "Strengthening"
+
+    ⌈_⌉ : {F G : BraidedMonoidalFunctor C D} →
+          U.MonoidalNaturalIsomorphism (MF F) (MF G) → F ≃ G
+    ⌈ α ⌉ = record { U = U ; F⇒G-isMonoidal = F⇒G-isMonoidal }
+      where open U.MonoidalNaturalIsomorphism α
+
+    open BraidedMonoidalNaturalIsomorphism
+
+    -- Identity and compositions
+
+    infixr 9 _ⓘᵥ_
+
+    id : {F : BraidedMonoidalFunctor C D} → F ≃ F
+    id = ⌈ U.id ⌉
+
+    _ⓘᵥ_ : {F G H : BraidedMonoidalFunctor C D} → G ≃ H → F ≃ G → F ≃ H
+    α ⓘᵥ β   = ⌈ ⌊ α ⌋ U.ⓘᵥ ⌊ β ⌋ ⌉
+
+    isEquivalence : IsEquivalence _≃_
+    isEquivalence = record
+      { refl  = id
+      ; sym   = λ α → record
+        { U              = NI.sym (U α)
+        ; F⇒G-isMonoidal = F⇐G-isMonoidal α
+        }
+      ; trans = λ α β → β ⓘᵥ α
+      }
+      where
+
+  open BraidedMonoidalNaturalIsomorphism
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′}
+           {E : BraidedMonoidalCategory o″ ℓ″ e″} where
+
+    infixr 9 _ⓘₕ_ _ⓘˡ_ _ⓘʳ_
+
+    _ⓘₕ_ : {F G : BraidedMonoidalFunctor C D}
+           {H I : BraidedMonoidalFunctor D E} →
+           H ≃ I → F ≃ G → (H ∘Fˡ F) ≃ (I ∘Fˡ G)
+    -- NOTE: this definition is clearly equivalent to
+    --
+    --   α ⓘₕ β = ⌈ ⌊ α ⌋ U.ⓘₕ ⌊ β ⌋ ⌉
+    --
+    -- but the latter takes an unreasonably long time to typecheck,
+    -- while the unfolded version typechecks almost immediately.
+    α ⓘₕ β = record
+      { U               = C.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = C.ε-compat
+        ; ⊗-homo-compat = C.⊗-homo-compat }
+        }
+      where module C = U.MonoidalNaturalIsomorphism (⌊ α ⌋ U.ⓘₕ ⌊ β ⌋)
+
+    _ⓘˡ_ : {F G : BraidedMonoidalFunctor C D}
+           (H : BraidedMonoidalFunctor D E) → F ≃ G → (H ∘Fˡ F) ≃ (H ∘Fˡ G)
+    H ⓘˡ α = id {F = H} ⓘₕ α
+
+    _ⓘʳ_ : {G H : BraidedMonoidalFunctor D E} →
+           G ≃ H → (F : BraidedMonoidalFunctor C D) → (G ∘Fˡ F) ≃ (H ∘Fˡ F)
+    α ⓘʳ F = α ⓘₕ id {F = F}
+
+  -- Left and right unitors.
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′}
+           {F : BraidedMonoidalFunctor C D} where
+
+    -- NOTE: Again, manual expansion seems necessary to type check in
+    -- reasonable time.
+
+    unitorˡ : idFˡ D ∘Fˡ F ≃ F
+    unitorˡ = record
+      { U               = LU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = LU.ε-compat
+        ; ⊗-homo-compat = LU.⊗-homo-compat
+        }
+      }
+      where module LU = U.MonoidalNaturalIsomorphism (U.unitorˡ {F = MF F})
+
+    unitorʳ : F ∘Fˡ idFˡ C ≃ F
+    unitorʳ = record
+      { U               = RU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = RU.ε-compat
+        ; ⊗-homo-compat = RU.⊗-homo-compat
+        }
+      }
+      where module RU = U.MonoidalNaturalIsomorphism (U.unitorʳ {F = MF F})
+
+  -- Associator.
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″ o‴ ℓ‴ e‴}
+           {B : BraidedMonoidalCategory o ℓ e}
+           {C : BraidedMonoidalCategory o′ ℓ′ e′}
+           {D : BraidedMonoidalCategory o″ ℓ″ e″}
+           {E : BraidedMonoidalCategory o‴ ℓ‴ e‴}
+           {F : BraidedMonoidalFunctor B C} {G : BraidedMonoidalFunctor C D}
+           {H : BraidedMonoidalFunctor D E} where
+
+    -- NOTE: Again, manual expansion seems necessary to type check in
+    -- reasonable time.
+
+    associator : (H ∘Fˡ G) ∘Fˡ F ≃ H ∘Fˡ (G ∘Fˡ F)
+    associator = record
+      { U               = AU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = AU.ε-compat
+        ; ⊗-homo-compat = AU.⊗-homo-compat
+        }
+      }
+      where
+        module AU =
+          U.MonoidalNaturalIsomorphism (U.associator {F = MF F} {MF G} {MF H})
+
+module Strong where
+  open BMF.Strong using (BraidedMonoidalFunctor)
+  open MNI.Strong using (IsMonoidalNaturalIsomorphism)
+  open BraidedMonoidalFunctor using () renaming
+    ( F                         to UF
+    ; monoidalFunctor           to MF
+    ; laxBraidedMonoidalFunctor to laxBMF
+    )
+  private module U = MNI.Strong
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′} where
+
+    -- Monoidal natural isomorphisms between strong braided monoidal functors.
+
+    record BraidedMonoidalNaturalIsomorphism
+           (F G : BraidedMonoidalFunctor C D) : Set (o ⊔ ℓ ⊔ ℓ′ ⊔ e′) where
+
+      field
+        U              : NaturalIsomorphism (UF F) (UF G)
+        F⇒G-isMonoidal : IsMonoidalNaturalIsomorphism (MF F) (MF G) U
+
+      ⌊_⌋ : U.MonoidalNaturalIsomorphism (MF F) (MF G)
+      ⌊_⌋ = record { U = U ; F⇒G-isMonoidal = F⇒G-isMonoidal }
+
+      laxBNI : Lax.BraidedMonoidalNaturalIsomorphism (laxBMF F) (laxBMF G)
+      laxBNI = record { U = U ; F⇒G-isMonoidal = F⇒G-isMonoidal }
+
+      open Lax.BraidedMonoidalNaturalIsomorphism laxBNI public
+        hiding (U; F⇒G-isMonoidal; ⌊_⌋)
+
+    infix 4 _≃_
+
+    _≃_ = BraidedMonoidalNaturalIsomorphism
+
+    -- "Strengthening"
+
+    ⌈_⌉ : {F G : BraidedMonoidalFunctor C D} →
+          U.MonoidalNaturalIsomorphism (MF F) (MF G) → F ≃ G
+    ⌈ α ⌉ = record { U = U ; F⇒G-isMonoidal = F⇒G-isMonoidal }
+      where open U.MonoidalNaturalIsomorphism α
+
+    open BraidedMonoidalNaturalIsomorphism
+
+    -- Identity and compositions
+
+    infixr 9 _ⓘᵥ_
+
+    id : {F : BraidedMonoidalFunctor C D} → F ≃ F
+    id = ⌈ U.id ⌉
+
+    _ⓘᵥ_ : {F G H : BraidedMonoidalFunctor C D} → G ≃ H → F ≃ G → F ≃ H
+    α ⓘᵥ β   = ⌈ ⌊ α ⌋ U.ⓘᵥ ⌊ β ⌋ ⌉
+
+    isEquivalence : IsEquivalence _≃_
+    isEquivalence = record
+      { refl  = id
+      ; sym   = λ α → record
+        { U              = NI.sym (U α)
+        ; F⇒G-isMonoidal = F⇐G-isMonoidal α
+        }
+      ; trans = λ α β → β ⓘᵥ α
+      }
+      where
+
+  open BraidedMonoidalNaturalIsomorphism
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′}
+           {E : BraidedMonoidalCategory o″ ℓ″ e″} where
+
+    infixr 9 _ⓘₕ_ _ⓘˡ_ _ⓘʳ_
+
+    _ⓘₕ_ : {F G : BraidedMonoidalFunctor C D}
+           {H I : BraidedMonoidalFunctor D E} →
+           H ≃ I → F ≃ G → (H ∘Fˢ F) ≃ (I ∘Fˢ G)
+    -- NOTE: this definition is clearly equivalent to
+    --
+    --   α ⓘₕ β = ⌈ ⌊ α ⌋ U.ⓘₕ ⌊ β ⌋ ⌉
+    --
+    -- but the latter takes an unreasonably long time to typecheck,
+    -- while the unfolded version typechecks almost immediately.
+    α ⓘₕ β = record
+      { U               = C.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = C.ε-compat
+        ; ⊗-homo-compat = C.⊗-homo-compat }
+        }
+      where module C = U.MonoidalNaturalIsomorphism (⌊ α ⌋ U.ⓘₕ ⌊ β ⌋)
+
+    _ⓘˡ_ : {F G : BraidedMonoidalFunctor C D}
+           (H : BraidedMonoidalFunctor D E) → F ≃ G → (H ∘Fˢ F) ≃ (H ∘Fˢ G)
+    H ⓘˡ α = id {F = H} ⓘₕ α
+
+    _ⓘʳ_ : {G H : BraidedMonoidalFunctor D E} →
+           G ≃ H → (F : BraidedMonoidalFunctor C D) → (G ∘Fˢ F) ≃ (H ∘Fˢ F)
+    α ⓘʳ F = α ⓘₕ id {F = F}
+
+  -- Left and right unitors.
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : BraidedMonoidalCategory o ℓ e}
+           {D : BraidedMonoidalCategory o′ ℓ′ e′}
+           {F : BraidedMonoidalFunctor C D} where
+
+    -- NOTE: Again, manual expansion seems necessary to type check in
+    -- reasonable time.
+
+    unitorˡ : idFˢ D ∘Fˢ F ≃ F
+    unitorˡ = record
+      { U               = LU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = LU.ε-compat
+        ; ⊗-homo-compat = LU.⊗-homo-compat
+        }
+      }
+      where module LU = U.MonoidalNaturalIsomorphism (U.unitorˡ {F = MF F})
+
+    unitorʳ : F ∘Fˢ idFˢ C ≃ F
+    unitorʳ = record
+      { U               = RU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = RU.ε-compat
+        ; ⊗-homo-compat = RU.⊗-homo-compat
+        }
+      }
+      where module RU = U.MonoidalNaturalIsomorphism (U.unitorʳ {F = MF F})
+
+  -- Associator.
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″ o‴ ℓ‴ e‴}
+           {B : BraidedMonoidalCategory o ℓ e}
+           {C : BraidedMonoidalCategory o′ ℓ′ e′}
+           {D : BraidedMonoidalCategory o″ ℓ″ e″}
+           {E : BraidedMonoidalCategory o‴ ℓ‴ e‴}
+           {F : BraidedMonoidalFunctor B C} {G : BraidedMonoidalFunctor C D}
+           {H : BraidedMonoidalFunctor D E} where
+
+    -- NOTE: Again, manual expansion seems necessary to type check in
+    -- reasonable time.
+
+    associator : (H ∘Fˢ G) ∘Fˢ F ≃ H ∘Fˢ (G ∘Fˢ F)
+    associator = record
+      { U               = AU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = AU.ε-compat
+        ; ⊗-homo-compat = AU.⊗-homo-compat
+        }
+      }
+      where
+        module AU =
+          U.MonoidalNaturalIsomorphism (U.associator {F = MF F} {MF G} {MF H})

--- a/src/Categories/NaturalTransformation/NaturalIsomorphism/Monoidal/Symmetric.agda
+++ b/src/Categories/NaturalTransformation/NaturalIsomorphism/Monoidal/Symmetric.agda
@@ -1,0 +1,333 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Monoidal natural isomorphisms between lax and strong symmetric
+-- monoidal functors.
+--
+-- NOTE. Symmetric monoidal natural isomorphisms are really just
+-- monoidal natural isomorphisms that happen to go between symmetric
+-- monoidal functors.  No additional conditions are necessary.
+-- Nevertheless, the definitions in this module are useful when one is
+-- working in a symmetric monoidal setting.  They also help Agda's
+-- type checker by bundling the (symmetric monoidal) categories and
+-- functors involved.
+
+module Categories.NaturalTransformation.NaturalIsomorphism.Monoidal.Symmetric
+  where
+
+open import Level
+open import Relation.Binary using (IsEquivalence)
+
+open import Categories.Category.Monoidal using (SymmetricMonoidalCategory)
+import Categories.Functor.Monoidal.Symmetric as BMF
+open import Categories.Functor.Monoidal.Properties using () renaming
+  ( idF-SymmetricMonoidal to idFˡ  ; idF-StrongSymmetricMonoidal to idFˢ
+  ; ∘-SymmetricMonoidal   to _∘Fˡ_ ; ∘-StrongSymmetricMonoidal   to _∘Fˢ_
+  )
+open import Categories.NaturalTransformation.NaturalIsomorphism as NI
+  using (NaturalIsomorphism)
+import Categories.NaturalTransformation.NaturalIsomorphism.Monoidal as MNI
+
+module Lax where
+  open BMF.Lax using (SymmetricMonoidalFunctor)
+  open MNI.Lax using (IsMonoidalNaturalIsomorphism)
+  open SymmetricMonoidalFunctor using ()
+    renaming (F to UF; monoidalFunctor to MF)
+  private module U = MNI.Lax
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′} where
+
+    -- Monoidal natural isomorphisms between lax symmetric monoidal functors.
+
+    record SymmetricMonoidalNaturalIsomorphism
+           (F G : SymmetricMonoidalFunctor C D) : Set (o ⊔ ℓ ⊔ ℓ′ ⊔ e′) where
+
+      field
+        U              : NaturalIsomorphism (UF F) (UF G)
+        F⇒G-isMonoidal : IsMonoidalNaturalIsomorphism (MF F) (MF G) U
+
+      ⌊_⌋ : U.MonoidalNaturalIsomorphism (MF F) (MF G)
+      ⌊_⌋ = record { U = U ; F⇒G-isMonoidal = F⇒G-isMonoidal }
+
+      open U.MonoidalNaturalIsomorphism ⌊_⌋ public hiding (U; F⇒G-isMonoidal)
+
+    infix 4 _≃_
+
+    _≃_ = SymmetricMonoidalNaturalIsomorphism
+
+    -- "Strengthening"
+
+    ⌈_⌉ : {F G : SymmetricMonoidalFunctor C D} →
+          U.MonoidalNaturalIsomorphism (MF F) (MF G) → F ≃ G
+    ⌈ α ⌉ = record { U = U ; F⇒G-isMonoidal = F⇒G-isMonoidal }
+      where open U.MonoidalNaturalIsomorphism α
+
+    open SymmetricMonoidalNaturalIsomorphism
+
+    -- Identity and compositions
+
+    infixr 9 _ⓘᵥ_
+
+    id : {F : SymmetricMonoidalFunctor C D} → F ≃ F
+    id = ⌈ U.id ⌉
+
+    _ⓘᵥ_ : {F G H : SymmetricMonoidalFunctor C D} → G ≃ H → F ≃ G → F ≃ H
+    α ⓘᵥ β   = ⌈ ⌊ α ⌋ U.ⓘᵥ ⌊ β ⌋ ⌉
+
+    isEquivalence : IsEquivalence _≃_
+    isEquivalence = record
+      { refl  = id
+      ; sym   = λ α → record
+        { U              = NI.sym (U α)
+        ; F⇒G-isMonoidal = F⇐G-isMonoidal α
+        }
+      ; trans = λ α β → β ⓘᵥ α
+      }
+      where
+
+  open SymmetricMonoidalNaturalIsomorphism
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′}
+           {E : SymmetricMonoidalCategory o″ ℓ″ e″} where
+
+    infixr 9 _ⓘₕ_ _ⓘˡ_ _ⓘʳ_
+
+    _ⓘₕ_ : {F G : SymmetricMonoidalFunctor C D}
+           {H I : SymmetricMonoidalFunctor D E} →
+           H ≃ I → F ≃ G → (H ∘Fˡ F) ≃ (I ∘Fˡ G)
+    -- NOTE: this definition is clearly equivalent to
+    --
+    --   α ⓘₕ β = ⌈ ⌊ α ⌋ U.ⓘₕ ⌊ β ⌋ ⌉
+    --
+    -- but the latter takes an unreasonably long time to typecheck,
+    -- while the unfolded version typechecks almost immediately.
+    α ⓘₕ β = record
+      { U               = C.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = C.ε-compat
+        ; ⊗-homo-compat = C.⊗-homo-compat }
+        }
+      where module C = U.MonoidalNaturalIsomorphism (⌊ α ⌋ U.ⓘₕ ⌊ β ⌋)
+
+    _ⓘˡ_ : {F G : SymmetricMonoidalFunctor C D}
+           (H : SymmetricMonoidalFunctor D E) → F ≃ G → (H ∘Fˡ F) ≃ (H ∘Fˡ G)
+    H ⓘˡ α = id {F = H} ⓘₕ α
+
+    _ⓘʳ_ : {G H : SymmetricMonoidalFunctor D E} →
+           G ≃ H → (F : SymmetricMonoidalFunctor C D) → (G ∘Fˡ F) ≃ (H ∘Fˡ F)
+    α ⓘʳ F = α ⓘₕ id {F = F}
+
+  -- Left and right unitors.
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′}
+           {F : SymmetricMonoidalFunctor C D} where
+
+    -- NOTE: Again, manual expansion seems necessary to type check in
+    -- reasonable time.
+
+    unitorˡ : idFˡ D ∘Fˡ F ≃ F
+    unitorˡ = record
+      { U               = LU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = LU.ε-compat
+        ; ⊗-homo-compat = LU.⊗-homo-compat
+        }
+      }
+      where module LU = U.MonoidalNaturalIsomorphism (U.unitorˡ {F = MF F})
+
+    unitorʳ : F ∘Fˡ idFˡ C ≃ F
+    unitorʳ = record
+      { U               = RU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = RU.ε-compat
+        ; ⊗-homo-compat = RU.⊗-homo-compat
+        }
+      }
+      where module RU = U.MonoidalNaturalIsomorphism (U.unitorʳ {F = MF F})
+
+  -- Associator.
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″ o‴ ℓ‴ e‴}
+           {B : SymmetricMonoidalCategory o ℓ e}
+           {C : SymmetricMonoidalCategory o′ ℓ′ e′}
+           {D : SymmetricMonoidalCategory o″ ℓ″ e″}
+           {E : SymmetricMonoidalCategory o‴ ℓ‴ e‴}
+           {F : SymmetricMonoidalFunctor B C}
+           {G : SymmetricMonoidalFunctor C D}
+           {H : SymmetricMonoidalFunctor D E} where
+
+    -- NOTE: Again, manual expansion seems necessary to type check in
+    -- reasonable time.
+
+    associator : (H ∘Fˡ G) ∘Fˡ F ≃ H ∘Fˡ (G ∘Fˡ F)
+    associator = record
+      { U               = AU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = AU.ε-compat
+        ; ⊗-homo-compat = AU.⊗-homo-compat
+        }
+      }
+      where
+        module AU =
+          U.MonoidalNaturalIsomorphism (U.associator {F = MF F} {MF G} {MF H})
+
+module Strong where
+  open BMF.Strong using (SymmetricMonoidalFunctor)
+  open MNI.Strong using (IsMonoidalNaturalIsomorphism)
+  open SymmetricMonoidalFunctor using () renaming
+    ( F                         to UF
+    ; monoidalFunctor           to MF
+    ; laxSymmetricMonoidalFunctor to laxBMF
+    )
+  private module U = MNI.Strong
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′} where
+
+    -- Monoidal natural isomorphisms between strong symmetric monoidal functors.
+
+    record SymmetricMonoidalNaturalIsomorphism
+           (F G : SymmetricMonoidalFunctor C D) : Set (o ⊔ ℓ ⊔ ℓ′ ⊔ e′) where
+
+      field
+        U              : NaturalIsomorphism (UF F) (UF G)
+        F⇒G-isMonoidal : IsMonoidalNaturalIsomorphism (MF F) (MF G) U
+
+      ⌊_⌋ : U.MonoidalNaturalIsomorphism (MF F) (MF G)
+      ⌊_⌋ = record { U = U ; F⇒G-isMonoidal = F⇒G-isMonoidal }
+
+      laxBNI : Lax.SymmetricMonoidalNaturalIsomorphism (laxBMF F) (laxBMF G)
+      laxBNI = record { U = U ; F⇒G-isMonoidal = F⇒G-isMonoidal }
+
+      open Lax.SymmetricMonoidalNaturalIsomorphism laxBNI public
+        hiding (U; F⇒G-isMonoidal; ⌊_⌋)
+
+    infix 4 _≃_
+
+    _≃_ = SymmetricMonoidalNaturalIsomorphism
+
+    -- "Strengthening"
+
+    ⌈_⌉ : {F G : SymmetricMonoidalFunctor C D} →
+          U.MonoidalNaturalIsomorphism (MF F) (MF G) → F ≃ G
+    ⌈ α ⌉ = record { U = U ; F⇒G-isMonoidal = F⇒G-isMonoidal }
+      where open U.MonoidalNaturalIsomorphism α
+
+    open SymmetricMonoidalNaturalIsomorphism
+
+    -- Identity and compositions
+
+    infixr 9 _ⓘᵥ_
+
+    id : {F : SymmetricMonoidalFunctor C D} → F ≃ F
+    id = ⌈ U.id ⌉
+
+    _ⓘᵥ_ : {F G H : SymmetricMonoidalFunctor C D} → G ≃ H → F ≃ G → F ≃ H
+    α ⓘᵥ β   = ⌈ ⌊ α ⌋ U.ⓘᵥ ⌊ β ⌋ ⌉
+
+    isEquivalence : IsEquivalence _≃_
+    isEquivalence = record
+      { refl  = id
+      ; sym   = λ α → record
+        { U              = NI.sym (U α)
+        ; F⇒G-isMonoidal = F⇐G-isMonoidal α
+        }
+      ; trans = λ α β → β ⓘᵥ α
+      }
+      where
+
+  open SymmetricMonoidalNaturalIsomorphism
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′}
+           {E : SymmetricMonoidalCategory o″ ℓ″ e″} where
+
+    infixr 9 _ⓘₕ_ _ⓘˡ_ _ⓘʳ_
+
+    _ⓘₕ_ : {F G : SymmetricMonoidalFunctor C D}
+           {H I : SymmetricMonoidalFunctor D E} →
+           H ≃ I → F ≃ G → (H ∘Fˢ F) ≃ (I ∘Fˢ G)
+    -- NOTE: this definition is clearly equivalent to
+    --
+    --   α ⓘₕ β = ⌈ ⌊ α ⌋ U.ⓘₕ ⌊ β ⌋ ⌉
+    --
+    -- but the latter takes an unreasonably long time to typecheck,
+    -- while the unfolded version typechecks almost immediately.
+    α ⓘₕ β = record
+      { U               = C.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = C.ε-compat
+        ; ⊗-homo-compat = C.⊗-homo-compat }
+        }
+      where module C = U.MonoidalNaturalIsomorphism (⌊ α ⌋ U.ⓘₕ ⌊ β ⌋)
+
+    _ⓘˡ_ : {F G : SymmetricMonoidalFunctor C D}
+           (H : SymmetricMonoidalFunctor D E) → F ≃ G → (H ∘Fˢ F) ≃ (H ∘Fˢ G)
+    H ⓘˡ α = id {F = H} ⓘₕ α
+
+    _ⓘʳ_ : {G H : SymmetricMonoidalFunctor D E} →
+           G ≃ H → (F : SymmetricMonoidalFunctor C D) → (G ∘Fˢ F) ≃ (H ∘Fˢ F)
+    α ⓘʳ F = α ⓘₕ id {F = F}
+
+  -- Left and right unitors.
+
+  module _ {o ℓ e o′ ℓ′ e′}
+           {C : SymmetricMonoidalCategory o ℓ e}
+           {D : SymmetricMonoidalCategory o′ ℓ′ e′}
+           {F : SymmetricMonoidalFunctor C D} where
+
+    -- NOTE: Again, manual expansion seems necessary to type check in
+    -- reasonable time.
+
+    unitorˡ : idFˢ D ∘Fˢ F ≃ F
+    unitorˡ = record
+      { U               = LU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = LU.ε-compat
+        ; ⊗-homo-compat = LU.⊗-homo-compat
+        }
+      }
+      where module LU = U.MonoidalNaturalIsomorphism (U.unitorˡ {F = MF F})
+
+    unitorʳ : F ∘Fˢ idFˢ C ≃ F
+    unitorʳ = record
+      { U               = RU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = RU.ε-compat
+        ; ⊗-homo-compat = RU.⊗-homo-compat
+        }
+      }
+      where module RU = U.MonoidalNaturalIsomorphism (U.unitorʳ {F = MF F})
+
+  -- Associator.
+
+  module _ {o ℓ e o′ ℓ′ e′ o″ ℓ″ e″ o‴ ℓ‴ e‴}
+           {B : SymmetricMonoidalCategory o ℓ e}
+           {C : SymmetricMonoidalCategory o′ ℓ′ e′}
+           {D : SymmetricMonoidalCategory o″ ℓ″ e″}
+           {E : SymmetricMonoidalCategory o‴ ℓ‴ e‴}
+           {F : SymmetricMonoidalFunctor B C}
+           {G : SymmetricMonoidalFunctor C D}
+           {H : SymmetricMonoidalFunctor D E} where
+
+    -- NOTE: Again, manual expansion seems necessary to type check in
+    -- reasonable time.
+
+    associator : (H ∘Fˢ G) ∘Fˢ F ≃ H ∘Fˢ (G ∘Fˢ F)
+    associator = record
+      { U               = AU.U
+      ; F⇒G-isMonoidal  = record
+        { ε-compat      = AU.ε-compat
+        ; ⊗-homo-compat = AU.⊗-homo-compat
+        }
+      }
+      where
+        module AU =
+          U.MonoidalNaturalIsomorphism (U.associator {F = MF F} {MF G} {MF H})


### PR DESCRIPTION
More boilerplate.

Braided and symmetric monoidal natural transformations (and isomorphisms) are really just monoidal natural transformations (and isomorphisms). But the extra wrappers in this PR seem necessary if one wants to define e.g. symmetric monoidal natural transformations without Agda going into some unification rabbit hole where it takes ages to type check even quire simple definitions. Even with the wrapper performance has been bad in some of my WIP code. I'm not sure what exactly is causing the problem though. See some of the comments in the code of this PR for (possibly?) related issues.
