### PR TITLE
[ fix #284 ] github actions script

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -1,0 +1,104 @@
+name: Ubuntu build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+########################################################################
+## CONFIGURATION
+########################################################################
+
+env:
+  GHC_VERSION: 8.6.5
+  CABAL_VERSION: 3.2.0.0
+  CABAL_INSTALL: cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS'
+  AGDA_COMMIT: 8eb0d01811a663cf2b27b482b3b18690adfa094b
+  STDLIB_VERSION: 1.6
+  AGDA: agda -Werror +RTS -M3.5G -H3.5G -A128M -RTS -i. -i src/
+
+jobs:
+  test-categories:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Initialise variables
+        run: |
+          # Only deploy if the build follows from pushing to master
+          if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
+             echo "AGDA_DEPLOY=true" >> $GITHUB_ENV
+          fi
+
+      # This caching step allows us to save a lot of building time by only
+      # downloading ghc and cabal and rebuilding Agda if absolutely necessary
+      - name: Cache cabal packages
+        uses: actions/cache@v2
+        id: cache-cabal
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            ~/.cabal/bin
+          key: ${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_COMMIT }}
+
+      - name: Install ghc and cabal
+        if: steps.cache-cabal.outputs.cache-hit != 'true'
+        uses: actions/setup-haskell@v1.1.3
+        with:
+          ghc-version: ${{ env.GHC_VERSION }}
+          cabal-version: ${{ env.CABAL_VERSION }}
+
+      - name: Put cabal programs in PATH
+        run: echo "~/.cabal/bin" >> $GITHUB_PATH
+
+      - name: Cabal update
+        if: steps.cache-cabal.outputs.cache-hit != 'true'
+        run: cabal update
+
+      - name: Download and install Agda from github
+        if: steps.cache-cabal.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/agda/agda
+          cd agda
+          git checkout ${{ env.AGDA_COMMIT }}
+          mkdir -p doc
+          touch doc/user-manual.pdf
+          ${{ env.CABAL_INSTALL }}
+          cd ..
+
+      - name: Install stdlib
+        run: |
+          mkdir -p $HOME/.agda
+          cd $HOME/.agda
+          wget https://github.com/agda/agda-stdlib/archive/v${{ env.STDLIB_VERSION }}.tar.gz
+          tar -xzvf v${{ env.STDLIB_VERSION }}.tar.gz
+          mv agda-stdlib-${{ env.STDLIB_VERSION }} agda-stdlib
+          echo "~/.agda/agda-stdlib/standard-library.agda-lib" > libraries
+          cd -
+
+      - name: Checkout agda-categories
+        uses: actions/checkout@v2
+
+      - name: Test agda-categories
+        run: |
+          cp travis/* .
+          ./everything.sh
+          ${{ env.AGDA }} Everything.agda
+          ${{ env.AGDA }} index.agda
+
+      # Note that if you want to deploy html for different versions like the
+      # standard library does, you will need to be a bit more subtle in this
+      # step.
+      - name: Generate HTML
+        run: |
+          ${{ env.AGDA }} --html --html-dir html index.agda
+
+      - name: Deploy HTML
+        uses: JamesIves/github-pages-deploy-action@4.1.3
+        if: ${{ success() && env.AGDA_DEPLOY }}
+
+        with:
+          branch: gh-pages
+          folder: html

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -9,20 +9,58 @@ on:
 
 ########################################################################
 ## CONFIGURATION
+##
+## Key variables:
+##
+## AGDA_COMMIT picks the version of Agda to use to build the library.
+## It can either be a hash of a specific commit (to target a bugfix for
+## instance) or a tag e.g. tags/v2.6.1.3 (to target a released version).
+##
+## STDLIB_VERSION picks the version of the stdlib to pull. The current
+## design requires that the number corresponds to a released version
+## but we could change that to a commit-based approach if you need to.
+##
+## The rest:
+##
+## Basically do not touch GHC_VERSION and CABAL_VERSION as long as
+## they aren't a problem in the build. If you have time to waste, it
+## could be worth investigating whether newer versions of ghc produce
+## more efficient Agda executable and could cut down the build time.
+## Just be aware that actions are flaky and small variations are to be
+## expected.
+##
+## The CABAL_INSTALL variable only passes `-O1` optimisations to ghc
+## because github actions cannot currently handle a build using `-O2`.
+## To be experimented with again in the future to see if things have
+## gotten better.
+##
+## The AGDA variable specifies the command to use to build the library.
+## It currently passes the flag `-Werror` to ensure maximal compliance
+## with e.g. not relying on deprecated definitions.
+## The rest are some arbitrary runtime arguments that shape the way Agda
+## allocates and garbage collects memory. It should make things faster.
+## Limits can be bumped if the builds start erroring with out of memory
+## errors.
+##
 ########################################################################
 
 env:
+  AGDA_COMMIT: 8eb0d01811a663cf2b27b482b3b18690adfa094b
+  STDLIB_VERSION: 1.6
+
   GHC_VERSION: 8.6.5
   CABAL_VERSION: 3.2.0.0
   CABAL_INSTALL: cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS'
-  AGDA_COMMIT: 8eb0d01811a663cf2b27b482b3b18690adfa094b
-  STDLIB_VERSION: 1.6
   AGDA: agda -Werror +RTS -M3.5G -H3.5G -A128M -RTS -i. -i src/
 
 jobs:
   test-categories:
     runs-on: ubuntu-latest
     steps:
+
+########################################################################
+## SETTINGS
+########################################################################
 
       - name: Initialise variables
         run: |
@@ -31,8 +69,19 @@ jobs:
              echo "AGDA_DEPLOY=true" >> $GITHUB_ENV
           fi
 
+      # The script won't be able to find Agda if we don't tell it to look at the
+      # content of ~/.cabal/bin
+      - name: Put cabal programs in PATH
+        run: echo "~/.cabal/bin" >> $GITHUB_PATH
+
+########################################################################
+## CACHING
+########################################################################
+
       # This caching step allows us to save a lot of building time by only
       # downloading ghc and cabal and rebuilding Agda if absolutely necessary
+      # i.e. if we change either the version of Agda, ghc, or cabal that we want
+      # to use for the build.
       - name: Cache cabal packages
         uses: actions/cache@v2
         id: cache-cabal
@@ -43,15 +92,19 @@ jobs:
             ~/.cabal/bin
           key: ${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_COMMIT }}
 
+########################################################################
+## INSTALLATION STEPS
+########################################################################
+
+      # Note that we do not install ghc if the cache hit is successful.
+      # This is because we are not compiling any of the modules. If we were
+      # we could need to change this to install ghc unconditionally.
       - name: Install ghc and cabal
         if: steps.cache-cabal.outputs.cache-hit != 'true'
         uses: actions/setup-haskell@v1.1.3
         with:
           ghc-version: ${{ env.GHC_VERSION }}
           cabal-version: ${{ env.CABAL_VERSION }}
-
-      - name: Put cabal programs in PATH
-        run: echo "~/.cabal/bin" >> $GITHUB_PATH
 
       - name: Cabal update
         if: steps.cache-cabal.outputs.cache-hit != 'true'
@@ -78,9 +131,15 @@ jobs:
           echo "~/.agda/agda-stdlib/standard-library.agda-lib" > libraries
           cd -
 
+########################################################################
+## TESTING AND DEPLOYMENT
+########################################################################
+
+      # By default github actions do not pull the repo
       - name: Checkout agda-categories
         uses: actions/checkout@v2
 
+      # Generate a fresh Everything.agda & index.agda and start building!
       - name: Test agda-categories
         run: |
           cp travis/* .

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -96,9 +96,6 @@ jobs:
 ## INSTALLATION STEPS
 ########################################################################
 
-      # Note that we do not install ghc if the cache hit is successful.
-      # This is because we are not compiling any of the modules. If we were
-      # we could need to change this to install ghc unconditionally.
       - name: Install ghc and cabal
         if: steps.cache-cabal.outputs.cache-hit != 'true'
         uses: actions/setup-haskell@v1.1.3

--- a/travis/everything.sh
+++ b/travis/everything.sh
@@ -1,0 +1,7 @@
+#/bin/sh
+
+find src/ -name '[^\.]*.agda' \
+    | sed -e 's|^src/[/]*|import |' -e 's|/|.|g' -e 's/.agda//' -e '/import Everything/d' \
+    | LC_COLLATE='C' sort \
+                > Everything.agda
+cat Everything.agda >> index.agda


### PR DESCRIPTION
Not sure why it's not running in this PR. We had a similar issue yesterday with
a frex-project build so it may just be the usual behaviour when you create the
first github actions for a repo.

You can see  [the result](https://github.com/gallais/agda-categories/pull/2/checks?check_run_id=2853290345) of the run that happened [on my fork](https://github.com/gallais/agda-categories/pull/2).