### PR TITLE
rename Cats in StrictCats to StrictCats

### DIFF
--- a/src/Categories/Adjoint/Instance/Discrete.agda
+++ b/src/Categories/Adjoint/Instance/Discrete.agda
@@ -27,7 +27,7 @@ open import Categories.NaturalTransformation as NT using (NaturalTransformation;
 
 -- The forgetful functor from StrictCats to Sets.
 
-Forgetful : ∀ {o ℓ e} → Functor (Cats o ℓ e) (Sets o)
+Forgetful : ∀ {o ℓ e} → Functor (StrictCats o ℓ e) (Sets o)
 Forgetful {o} {ℓ} {e} = record
   { F₀ = Obj
   ; F₁ = F₀
@@ -42,7 +42,7 @@ Forgetful {o} {ℓ} {e} = record
 
 -- The discrete functor (strict version)
 
-Discrete : ∀ {o} → Functor (Sets o) (Cats o o o)
+Discrete : ∀ {o} → Functor (Sets o) (StrictCats o o o)
 Discrete {o} = record
   { F₀ = D.Discrete
   ; F₁ = λ f → record
@@ -82,7 +82,7 @@ Discrete {o} = record
 
 -- The codiscrete functor (strict version)
 
-Codiscrete : ∀ {o} ℓ e → Functor (Sets o) (Cats o ℓ e)
+Codiscrete : ∀ {o} ℓ e → Functor (Sets o) (StrictCats o ℓ e)
 Codiscrete {o} ℓ e = record
   { F₀ = λ A → record
     { Obj = A
@@ -114,7 +114,7 @@ Codiscrete {o} ℓ e = record
     ; eq₁ = λ _ → lift tt
     }
   }
-  where open Category (Cats o ℓ e)
+  where open Category (StrictCats o ℓ e)
 
 
 -- Discrete is left-adjoint to the forgetful functor from StrictCats to Sets

--- a/src/Categories/Adjoint/Instance/StrictCore.agda
+++ b/src/Categories/Adjoint/Instance/StrictCore.agda
@@ -5,14 +5,13 @@ module Categories.Adjoint.Instance.StrictCore where
 -- The adjunction between the forgetful functor from (strict) Cats to
 -- (strict) Groupoids and the (strict) Core functor.
 
-open import Data.Product
 open import Level using (_⊔_)
 import Function
 open import Relation.Binary using (IsEquivalence)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl)
 
-open import Categories.Adjoint
-open import Categories.Category using (Category)
+open import Categories.Adjoint using (_⊣_)
+open import Categories.Category.Core using (Category)
 open import Categories.Category.Groupoid using (Groupoid)
 import Categories.Category.Construction.Core as C
 open import Categories.Category.Instance.StrictCats
@@ -26,7 +25,7 @@ open import Categories.Morphism.IsoEquiv using (⌞_⌟; _≃_)
 
 -- The forgetful functor from StrictGroupoids to StrictCats
 
-Forgetful : ∀ {o ℓ e} → Functor (Groupoids o ℓ e) (Cats o ℓ e)
+Forgetful : ∀ {o ℓ e} → Functor (StrictGroupoids o ℓ e) (StrictCats o ℓ e)
 Forgetful {o} {ℓ} {e} = record
   { F₀ = Groupoid.category
   ; F₁ = Function.id
@@ -35,7 +34,7 @@ Forgetful {o} {ℓ} {e} = record
   ; F-resp-≈     = Function.id
   }
   where
-    module Groupoids = Category (Groupoids o ℓ e)
+    module Groupoids = Category (StrictGroupoids o ℓ e)
 
 -- Core is right-adjoint to the forgetful functor from Groupoids to
 -- Cats
@@ -93,7 +92,7 @@ CoreAdj = record
       { eq₀ = λ _ → refl
       ; eq₁ = λ _ → MR.id-comm-sym D
       }
-      
+
     counit-sym-commute : ∀ {C D} (F : Functor C D) →
                          F ∘F counit C ≡F counit D ∘F Core.F₁ F
     counit-sym-commute {C} {D} F = record

--- a/src/Categories/Category/Construction/Graphs.agda
+++ b/src/Categories/Category/Construction/Graphs.agda
@@ -327,7 +327,7 @@ Underlying₁ : {C : Category o ℓ e} {D : Category o′ ℓ′ e′} → Funct
 Underlying₁ F = record { M₀ = F.F₀ ; M₁ = F.F₁ ; M-resp-≈ = F.F-resp-≈ }
   where module F = Functor F
 
-Underlying : Functor (Cats o ℓ e) (Graphs o ℓ e)
+Underlying : Functor (StrictCats o ℓ e) (Graphs o ℓ e)
 Underlying = record
   { F₀ = Underlying₀
   ; F₁ = Underlying₁
@@ -448,7 +448,7 @@ module _ (C : Category o ℓ e) where
         g        ≈˘⟨ identityʳ ⟩
         g ∘ id   ∎
 
-CatF : Functor (Graphs o ℓ e) (Cats o (o ⊔ ℓ) (o ⊔ ℓ ⊔ e))
+CatF : Functor (Graphs o ℓ e) (StrictCats o (o ⊔ ℓ) (o ⊔ ℓ ⊔ e))
 CatF = record
   { F₀ = Free
   ; F₁ = λ {G₁} {G₂} G⇒ → record

--- a/src/Categories/Category/Instance/StrictCats.agda
+++ b/src/Categories/Category/Instance/StrictCats.agda
@@ -15,8 +15,8 @@ private
   variable
     o ℓ e : Level
 
-Cats : ∀ o ℓ e → Category (suc (o ⊔ ℓ ⊔  e)) (o ⊔ ℓ ⊔ e) (o ⊔ ℓ ⊔ e)
-Cats o ℓ e = record
+StrictCats : ∀ o ℓ e → Category (suc (o ⊔ ℓ ⊔  e)) (o ⊔ ℓ ⊔ e) (o ⊔ ℓ ⊔ e)
+StrictCats o ℓ e = record
   { Obj       = Category o ℓ e
   ; _⇒_       = Functor
   ; _≈_       = _≡F_

--- a/src/Categories/Category/Instance/StrictGroupoids.agda
+++ b/src/Categories/Category/Instance/StrictGroupoids.agda
@@ -19,8 +19,8 @@ private
 
 open Groupoid using (category)
 
-Groupoids : ∀ o ℓ e → Category (suc (o ⊔ ℓ ⊔  e)) (o ⊔ ℓ ⊔ e) (o ⊔ ℓ ⊔ e)
-Groupoids o ℓ e = record
+StrictGroupoids : ∀ o ℓ e → Category (suc (o ⊔ ℓ ⊔  e)) (o ⊔ ℓ ⊔ e) (o ⊔ ℓ ⊔ e)
+StrictGroupoids o ℓ e = record
   { Obj       = Groupoid o ℓ e
   ; _⇒_       = λ G H → Functor (category G) (category H)
   ; _≈_       = _≡F_

--- a/src/Categories/Category/Monoidal/Instance/StrictCats.agda
+++ b/src/Categories/Category/Monoidal/Instance/StrictCats.agda
@@ -34,7 +34,7 @@ open import Categories.Utils.EqReasoning
 -- (Strict) Cats is a (strict) Monoidal Category with Product as Bifunctor
 module Product {o ℓ e : Level} where
   private
-    C = Cats o ℓ e
+    C = StrictCats o ℓ e
     open _≡F_
 
   Cats-has-all : BinaryProducts C

--- a/src/Categories/Functor/Instance/StrictCore.agda
+++ b/src/Categories/Functor/Instance/StrictCore.agda
@@ -7,17 +7,16 @@ module Categories.Functor.Instance.StrictCore where
 -- StrictGroupoids to StrictCats
 -- (see Categories.Functor.Adjoint.Instance.StrictCore)
 
-open import Data.Product
-open import Level using (_⊔_)
-open import Function.Base using (_on_; _$_) renaming (id to idf)
-open import Relation.Binary.PropositionalEquality as ≡ using (cong; cong-id)
+open import Level using (Level; _⊔_)
+open import Function.Base using (_$_) renaming (id to idf)
+open import Relation.Binary.PropositionalEquality using (refl; cong; cong-id)
 
-open import Categories.Category
+open import Categories.Category.Core using (Category)
 import Categories.Category.Construction.Core as C
 open import Categories.Category.Instance.StrictCats
 open import Categories.Category.Instance.StrictGroupoids
-open import Categories.Functor
-open import Categories.Functor.Equivalence
+open import Categories.Functor using (Functor)
+open import Categories.Functor.Equivalence using (_≡F_)
 open import Categories.Functor.Instance.Core renaming (Core to WeakCore)
 open import Categories.Functor.Properties using ([_]-resp-≅)
 import Categories.Morphism as Morphism
@@ -26,44 +25,39 @@ import Categories.Morphism.HeterogeneousIdentity as HId
 import Categories.Morphism.HeterogeneousIdentity.Properties as HIdProps
 open import Categories.Morphism.IsoEquiv using (⌞_⌟)
 
-Core : ∀ {o ℓ e} → Functor (Cats o ℓ e) (Groupoids o (ℓ ⊔ e) e)
+module _ {o ℓ e : Level} where
+  open Functor (WeakCore {o} {ℓ} {e})
+
+  CoreRespFEq : {A B : Category o ℓ e} {F G : Functor A B} → F ≡F G → F₁ F ≡F F₁ G
+  CoreRespFEq {A} {B} {F} {G} F≡G = record
+    { eq₀ = eq₀
+    ; eq₁ = λ {X} {Y} f → ⌞ begin
+        (from $ hid BC $ eq₀ Y) ∘ F.F₁ (from f)       ≈⟨ ∘-resp-≈ˡ (hid-identity BC B from Equiv.refl (eq₀ Y)) ⟩
+        (hid B $ cong idf $ eq₀ Y) ∘ F.F₁ (from f)    ≡⟨ cong (λ p → hid B p ∘ _) (cong-id (eq₀ Y)) ⟩
+        hid B (eq₀ Y) ∘ F.F₁ (from f)                 ≈⟨ eq₁ (from f) ⟩
+        G.F₁ (from f) ∘ hid B (eq₀ X)                 ≡˘⟨ cong (λ p → _ ∘ hid B p) (cong-id (eq₀ X)) ⟩
+        G.F₁ (from f) ∘ (hid B $ cong idf $ eq₀ X)    ≈˘⟨ ∘-resp-≈ʳ (hid-identity BC B from Equiv.refl (eq₀ X)) ⟩
+        G.F₁ (from f) ∘ (from $ hid BC $ eq₀ X)       ∎ ⌟
+    }
+    where
+      BC = C.Core B
+      module F = Functor F using (F₁)
+      module G = Functor G using (F₁)
+      open Category B using (_∘_; ∘-resp-≈ʳ; ∘-resp-≈ˡ; module HomReasoning; module Equiv)
+      open HomReasoning
+      open HId using (hid)
+      open HIdProps using (hid-identity)
+      open _≡F_ F≡G using (eq₀; eq₁)
+      open Morphism._≅_ using (from)
+
+Core : ∀ {o ℓ e} → Functor (StrictCats o ℓ e) (StrictGroupoids o (ℓ ⊔ e) e)
 Core {o} {ℓ} {e} = record
    { F₀ = F₀
    ; F₁ = F₁
    ; identity = λ {A} →
-       record { eq₀ = λ _ → ≡.refl ; eq₁ = λ _ → ⌞ MR.id-comm-sym A ⌟ }
+       record { eq₀ = λ _ → refl ; eq₁ = λ _ → ⌞ MR.id-comm-sym A ⌟ }
    ; homomorphism = λ {A B C} →
-       record { eq₀ = λ _ → ≡.refl ; eq₁ = λ _ → ⌞ MR.id-comm-sym C ⌟ }
-   ; F-resp-≈ = λ {A B F G} → CoreRespFEq {A} {B} {F} {G}
+       record { eq₀ = λ _ → refl ; eq₁ = λ _ → ⌞ MR.id-comm-sym C ⌟ }
+   ; F-resp-≈ = λ {A B F G} → CoreRespFEq {A = A} {B} {F} {G}
    }
-   where
-     open Functor WeakCore
-
-     CoreRespFEq : {A B : Category o ℓ e} {F G : Functor A B} →
-                   F ≡F G → F₁ F ≡F F₁ G
-     CoreRespFEq {A} {B} {F} {G} F≡G = record
-       { eq₀ = eq₀
-       ; eq₁ = λ {X} {Y} f → ⌞ begin
-           (from $ hid BC $ eq₀ Y) ∘ F.F₁ (from f)
-         ≈⟨ ∘-resp-≈ˡ (hid-identity BC B from Equiv.refl (eq₀ Y)) ⟩
-           (hid B $ ≡.cong idf $ eq₀ Y) ∘ F.F₁ (from f)
-         ≡⟨ cong (λ p → hid B p ∘ _) (cong-id (eq₀ Y)) ⟩
-           hid B (eq₀ Y) ∘ F.F₁ (from f)
-         ≈⟨ eq₁ (from f) ⟩
-           G.F₁ (from f) ∘ hid B (eq₀ X)
-         ≡˘⟨ cong (λ p → _ ∘ hid B p) (cong-id (eq₀ X)) ⟩
-           G.F₁ (from f) ∘ (hid B $ cong idf $ eq₀ X)
-         ≈˘⟨ ∘-resp-≈ʳ (hid-identity BC B from Equiv.refl (eq₀ X)) ⟩
-           G.F₁ (from f) ∘ (from $ hid BC $ eq₀ X)
-         ∎ ⌟
-       }
-       where
-         BC = C.Core B
-         module F = Functor F
-         module G = Functor G
-         open Category B
-         open HomReasoning
-         open HId
-         open HIdProps
-         open _≡F_ F≡G
-         open Morphism._≅_
+   where open Functor (WeakCore {o} {ℓ} {e})


### PR DESCRIPTION
To make it more obvious at the usage site that things are Strict. Same for StrictGroupoid. Adjust as necessary.  Fix up imports in StrictCore while at it.