### PR TITLE
Redo Lawvere Theories

### DIFF
--- a/Everything.agda
+++ b/Everything.agda
@@ -52,6 +52,7 @@ import Categories.Category.CartesianClosed.Locally.Properties
 import Categories.Category.CartesianClosed.Properties
 import Categories.Category.Closed
 import Categories.Category.Cocartesian
+import Categories.Category.Cocartesian.Bundle
 import Categories.Category.Cocomplete
 import Categories.Category.Cocomplete.Finitely
 import Categories.Category.Cocomplete.Finitely.Properties
@@ -138,6 +139,7 @@ import Categories.Category.Instance.Groupoids
 import Categories.Category.Instance.KanComplexes
 import Categories.Category.Instance.LawvereTheories
 import Categories.Category.Instance.Monoidals
+import Categories.Category.Instance.Nat
 import Categories.Category.Instance.One
 import Categories.Category.Instance.PartialFunctions
 import Categories.Category.Instance.PointedSets
@@ -208,6 +210,9 @@ import Categories.Category.Species
 import Categories.Category.Species.Constructions
 import Categories.Category.SubCategory
 import Categories.Category.Topos
+import Categories.Category.Unbundled
+import Categories.Category.Unbundled.Properties
+import Categories.Category.Unbundled.Utilities
 import Categories.CoYoneda
 import Categories.Comonad
 import Categories.Comonad.Relative
@@ -279,6 +284,7 @@ import Categories.Functor.Hom
 import Categories.Functor.Hom.Properties
 import Categories.Functor.Hom.Properties.Contra
 import Categories.Functor.Hom.Properties.Covariant
+import Categories.Functor.IdentityOnObjects
 import Categories.Functor.Instance.0-Truncation
 import Categories.Functor.Instance.01-Truncation
 import Categories.Functor.Instance.Core

--- a/Everything.agda
+++ b/Everything.agda
@@ -87,6 +87,7 @@ import Categories.Category.Construction.KanComplex
 import Categories.Category.Construction.KaroubiEnvelope
 import Categories.Category.Construction.KaroubiEnvelope.Properties
 import Categories.Category.Construction.Kleisli
+import Categories.Category.Construction.LT-Models
 import Categories.Category.Construction.MonoidAsCategory
 import Categories.Category.Construction.MonoidalFunctors
 import Categories.Category.Construction.Monoids
@@ -385,6 +386,8 @@ import Categories.Pseudofunctor.Identity
 import Categories.Pseudofunctor.Instance.EnrichedUnderlying
 import Categories.Tactic.Category
 import Categories.Theory.Lawvere
+import Categories.Theory.Lawvere.Instance.Identity
+import Categories.Theory.Lawvere.Instance.Triv
 import Categories.Utils.EqReasoning
 import Categories.Utils.Product
 import Categories.Yoneda

--- a/src/Categories/Category/Cocartesian/Bundle.agda
+++ b/src/Categories/Category/Cocartesian/Bundle.agda
@@ -1,0 +1,26 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Bundled version of a Cocartesian Category
+module Categories.Category.Cocartesian.Bundle where
+
+open import Level
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Cocartesian using (Cocartesian)
+-- open import Categories.Category.Cartesian.Monoidal using (module CartesianMonoidal)
+-- open import Categories.Category.Monoidal using (MonoidalCategory)
+
+record CocartesianCategory o ℓ e : Set (suc (o ⊔ ℓ ⊔ e)) where
+  field
+    U           : Category o ℓ e  -- U for underlying
+    cocartesian : Cocartesian U
+
+  open Category U public
+  open Cocartesian cocartesian public
+{-
+  monoidalCategory : MonoidalCategory o ℓ e
+  monoidalCategory = record
+    { U        = U
+    ; monoidal = CocartesianMonoidal.monoidal cocartesian
+    }
+-}

--- a/src/Categories/Category/Construction/LT-Models.agda
+++ b/src/Categories/Category/Construction/LT-Models.agda
@@ -1,0 +1,45 @@
+{-# OPTIONS --without-K --safe #-}
+module Categories.Category.Construction.LT-Models where
+
+-- Given a fixed Lawvere Theory LT and a fixed category C,
+-- the Functors [LT , C] form a category.
+
+-- The proof is basically the same as that of Functors.
+
+open import Level
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Cartesian.Bundle using (CartesianCategory)
+open import Categories.Category.Monoidal.Instance.Setoids using (Setoids-CartesianCategory)
+open import Categories.NaturalTransformation
+  using (NaturalTransformation; _∘ᵥ_) renaming (id to idN)
+open import Categories.NaturalTransformation.Equivalence using (_≃_; ≃-isEquivalence)
+open import Categories.Theory.Lawvere using (LawvereTheory; ModelsOf_In_)
+
+private
+  variable
+    o ℓ e o′ ℓ′ e′ : Level
+
+-- The reason the proofs below are so easy is that _∘ᵥ_ 'computes' all the way down into
+-- expressions in C, from which the properties follow.
+LT-Models : LawvereTheory ℓ e → CartesianCategory o′ ℓ′ e′ → Category (ℓ ⊔ e ⊔ o′ ⊔ ℓ′ ⊔ e′) (ℓ ⊔ ℓ′ ⊔ e′) e′
+LT-Models LT C = record
+  { Obj       = ModelsOf LT In C
+  ; _⇒_       = λ m₁ m₂ → NaturalTransformation (ModelsOf_In_.mod m₁) (ModelsOf_In_.mod m₂)
+  ; _≈_       = _≃_
+  ; id        = idN
+  ; _∘_       = _∘ᵥ_
+  ; assoc     = assoc
+  ; sym-assoc = sym-assoc
+  ; identityˡ = identityˡ
+  ; identityʳ = identityʳ
+  ; identity² = identity²
+  ; equiv     = ≃-isEquivalence
+  ; ∘-resp-≈  = λ eq eq′ → ∘-resp-≈ eq eq′
+  }
+  where
+    module C = CartesianCategory C using (U)
+    open Category C.U
+
+LT-SetoidsModels : {ℓ′ e′ : Level} → LawvereTheory ℓ e → Category (ℓ ⊔ e ⊔ suc (ℓ′ ⊔ e′)) (ℓ ⊔ ℓ′ ⊔ e′) (ℓ′ ⊔ e′)
+LT-SetoidsModels {ℓ′ = ℓ′} {e′} LT = LT-Models LT (Setoids-CartesianCategory ℓ′ e′)

--- a/src/Categories/Category/Instance/LawvereTheories.agda
+++ b/src/Categories/Category/Instance/LawvereTheories.agda
@@ -5,14 +5,15 @@ module Categories.Category.Instance.LawvereTheories where
 
 open import Level
 
-open import Categories.Category
-open import Categories.Functor.Cartesian.Properties
+open import Categories.Category.Core using (Category)
+open import Categories.Functor.Cartesian using (CartesianF)
 open import Categories.NaturalTransformation.NaturalIsomorphism
-open import Categories.Theory.Lawvere
+ using (_≃_; associator; sym-associator; unitorˡ; unitorʳ; unitor²; refl; sym; trans; _ⓘₕ_)
+open import Categories.Theory.Lawvere using (LawvereTheory; LT-Hom; LT-id; LT-∘; T-Algebra)
 
-LawvereTheories : (o ℓ e : Level) → Category (suc (o ⊔ ℓ ⊔ e)) (o ⊔ ℓ ⊔ e) (o ⊔ ℓ ⊔ e)
-LawvereTheories o ℓ e = record
-  { Obj = FiniteProduct o ℓ e
+LawvereTheories : (ℓ e : Level) → Category (suc (ℓ ⊔ e)) (ℓ ⊔ e) (ℓ ⊔ e)
+LawvereTheories ℓ e = record
+  { Obj = LawvereTheory ℓ e
   ; _⇒_ = LT-Hom
   ; _≈_ = λ H₁ H₂ → cartF.F H₁ ≃ cartF.F H₂
   ; id = LT-id

--- a/src/Categories/Category/Instance/LawvereTheories.agda
+++ b/src/Categories/Category/Instance/LawvereTheories.agda
@@ -9,7 +9,7 @@ open import Categories.Category.Core using (Category)
 open import Categories.Functor.Cartesian using (CartesianF)
 open import Categories.NaturalTransformation.NaturalIsomorphism
  using (_≃_; associator; sym-associator; unitorˡ; unitorʳ; unitor²; refl; sym; trans; _ⓘₕ_)
-open import Categories.Theory.Lawvere using (LawvereTheory; LT-Hom; LT-id; LT-∘; T-Algebra)
+open import Categories.Theory.Lawvere using (LawvereTheory; LT-Hom; LT-id; LT-∘)
 
 LawvereTheories : (ℓ e : Level) → Category (suc (ℓ ⊔ e)) (ℓ ⊔ e) (ℓ ⊔ e)
 LawvereTheories ℓ e = record

--- a/src/Categories/Category/Instance/Nat.agda
+++ b/src/Categories/Category/Instance/Nat.agda
@@ -1,0 +1,60 @@
+{-# OPTIONS --without-K --safe #-}
+module Categories.Category.Instance.Nat where
+
+-- Skeleton of FinSetoid as a Category
+
+open import Level
+
+open import Data.Fin.Base using (Fin; inject+; raise; splitAt; join)
+open import Data.Fin.Properties
+open import Data.Nat.Base using (ℕ; _+_)
+open import Data.Sum using (inj₁; inj₂; [_,_]′)
+open import Data.Sum.Properties
+open import Relation.Binary.PropositionalEquality
+  using (_≗_; _≡_; refl; sym; trans; cong; module ≡-Reasoning; inspect; [_])
+open import Function using (id; _∘′_)
+
+open import Categories.Category.Core using (Category)
+open import Categories.Object.Coproduct
+
+Nat : Category 0ℓ 0ℓ 0ℓ
+Nat = record
+  { Obj = ℕ
+  ; _⇒_ = λ m n → (Fin m → Fin n)
+  ; _≈_ = _≗_
+  ; id = id
+  ; _∘_ = _∘′_
+  ; assoc = λ _ → refl
+  ; sym-assoc = λ _ → refl
+  ; identityˡ = λ _ → refl
+  ; identityʳ = λ _ → refl
+  ; identity² = λ _ → refl
+  ; equiv = record
+    { refl = λ _ → refl
+    ; sym = λ x≡y z → sym (x≡y z)
+    ; trans = λ x≡y y≡z w → trans (x≡y w) (y≡z w)
+    }
+  ; ∘-resp-≈ = λ {_ _ _ f h g i} f≗h g≗i x → trans (f≗h (g x)) (cong h (g≗i x))
+  }
+
+-- For other uses, it is important to choose coproducts
+-- in theory, it should be strictly associative... but it's not, and won't be for any choice.
+Coprod : (m n : ℕ) → Coproduct Nat m n
+Coprod m n = record
+  { A+B = m + n
+  ; i₁ = inject+ n
+  ; i₂ = raise m
+  ; [_,_] = λ l r z → [ l , r ]′ (splitAt m z)
+  ; inject₁ = λ {_ f g} x → cong [ f , g ]′ (splitAt-inject+ m n x)
+  ; inject₂ = λ {_ f g} x → cong [ f , g ]′ (splitAt-raise m n x)
+  ; unique = uniq
+  }
+  where
+    open ≡-Reasoning
+    uniq : {o : ℕ} {h : Fin (m + n) → Fin o} {f : Fin m → Fin o} {g : Fin n → Fin o} →
+      h ∘′ inject+ n ≗ f → h ∘′ raise m ≗ g → (λ z → [ f , g ]′ (splitAt m z)) ≗ h
+    uniq {_} {h} {f} {g} h≗f h≗g w = begin
+      [ f , g ]′ (splitAt m w)                         ≡⟨ [,]-cong (λ x → sym (h≗f x)) (λ x → sym (h≗g x)) (splitAt m w) ⟩
+      [ h ∘′ inject+ n , h ∘′ raise m ]′ (splitAt m w) ≡˘⟨ [,]-∘-distr h (splitAt m w) ⟩
+      h ([ inject+ n , raise m ]′ (splitAt m w))       ≡⟨ cong h (join-splitAt m n w) ⟩
+      h w                                              ∎

--- a/src/Categories/Category/Instance/Nat.agda
+++ b/src/Categories/Category/Instance/Nat.agda
@@ -20,6 +20,8 @@ open import Categories.Category.Cocartesian.Bundle using (CocartesianCategory)
 open import Categories.Category.Core using (Category)
 open import Categories.Category.Duality using (Cocartesian⇒coCartesian)
 open import Categories.Object.Coproduct
+open import Categories.Object.Duality using (Coproduct⇒coProduct)
+open import Categories.Object.Product
 
 Nat : Category 0ℓ 0ℓ 0ℓ
 Nat = record
@@ -75,8 +77,15 @@ Nat-Cocartesian = record
   ; coproducts = record { coproduct = λ {m} {n} → Coprod m n }
   }
 
+-- And Natop is what is used a lot, so record some things here too
+Natop : Category 0ℓ 0ℓ 0ℓ
+Natop = Category.op Nat
+
+Natop-Product : (m n : ℕ) → Product Natop m n
+Natop-Product m n = Coproduct⇒coProduct Nat (Coprod m n)
+
 Natop-Cartesian : CartesianCategory 0ℓ 0ℓ 0ℓ
 Natop-Cartesian = record
-  { U = Category.op Nat
+  { U = Natop
   ; cartesian = Cocartesian⇒coCartesian Nat Nat-Cocartesian
   }

--- a/src/Categories/Category/Instance/Nat.agda
+++ b/src/Categories/Category/Instance/Nat.agda
@@ -14,7 +14,11 @@ open import Relation.Binary.PropositionalEquality
   using (_≗_; _≡_; refl; sym; trans; cong; module ≡-Reasoning; inspect; [_])
 open import Function using (id; _∘′_)
 
+open import Categories.Category.Cartesian.Bundle using (CartesianCategory)
+open import Categories.Category.Cocartesian using (Cocartesian)
+open import Categories.Category.Cocartesian.Bundle using (CocartesianCategory)
 open import Categories.Category.Core using (Category)
+open import Categories.Category.Duality using (Cocartesian⇒coCartesian)
 open import Categories.Object.Coproduct
 
 Nat : Category 0ℓ 0ℓ 0ℓ
@@ -58,3 +62,21 @@ Coprod m n = record
       [ h ∘′ inject+ n , h ∘′ raise m ]′ (splitAt m w) ≡˘⟨ [,]-∘-distr h (splitAt m w) ⟩
       h ([ inject+ n , raise m ]′ (splitAt m w))       ≡⟨ cong h (join-splitAt m n w) ⟩
       h w                                              ∎
+
+Nat-Cocartesian : Cocartesian Nat
+Nat-Cocartesian = record
+  { initial = record
+    { ⊥ = 0
+    ; ⊥-is-initial = record
+      { ! = λ ()
+      ; !-unique = λ _ ()
+      }
+    }
+  ; coproducts = record { coproduct = λ {m} {n} → Coprod m n }
+  }
+
+Natop-Cartesian : CartesianCategory 0ℓ 0ℓ 0ℓ
+Natop-Cartesian = record
+  { U = Category.op Nat
+  ; cartesian = Cocartesian⇒coCartesian Nat Nat-Cocartesian
+  }

--- a/src/Categories/Category/Unbundled.agda
+++ b/src/Categories/Category/Unbundled.agda
@@ -1,0 +1,36 @@
+{-# OPTIONS --without-K --safe #-}
+module Categories.Category.Unbundled where
+
+-- This is basically identical to Category, except that the
+-- Obj type is a parameter rather than a field.
+
+open import Level
+open import Function.Base using (flip)
+
+open import Relation.Binary using (Rel; IsEquivalence)
+
+record Category {o : Level} (Obj : Set o) (ℓ e : Level) : Set (suc (o ⊔ ℓ ⊔ e)) where
+  eta-equality
+  infix  4 _≈_ _⇒_
+  infixr 9 _∘_
+
+  field
+    _⇒_ : Rel Obj ℓ
+    _≈_ : ∀ {A B} → Rel (A ⇒ B) e
+
+    id  : ∀ {A} → (A ⇒ A)
+    _∘_ : ∀ {A B C} → (B ⇒ C) → (A ⇒ B) → (A ⇒ C)
+
+  field
+    assoc     : ∀ {A B C D} {f : A ⇒ B} {g : B ⇒ C} {h : C ⇒ D} → (h ∘ g) ∘ f ≈ h ∘ (g ∘ f)
+    -- We add a symmetric proof of associativity so that the opposite category of the
+    -- opposite category is definitionally equal to the original category. See how
+    -- `op` is implemented.
+    sym-assoc : ∀ {A B C D} {f : A ⇒ B} {g : B ⇒ C} {h : C ⇒ D} → h ∘ (g ∘ f) ≈ (h ∘ g) ∘ f
+    identityˡ : ∀ {A B} {f : A ⇒ B} → id ∘ f ≈ f
+    identityʳ : ∀ {A B} {f : A ⇒ B} → f ∘ id ≈ f
+    -- We add a proof of "neutral" identity proof, in order to ensure the opposite of
+    -- constant functor is definitionally equal to itself.
+    identity² : ∀ {A} → id ∘ id {A} ≈ id {A}
+    equiv     : ∀ {A B} → IsEquivalence (_≈_ {A} {B})
+    ∘-resp-≈  : ∀ {A B C} {f h : B ⇒ C} {g i : A ⇒ B} → f ≈ h → g ≈ i → f ∘ g ≈ h ∘ i

--- a/src/Categories/Category/Unbundled/Properties.agda
+++ b/src/Categories/Category/Unbundled/Properties.agda
@@ -20,6 +20,10 @@ unpack : Category o ℓ e → Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e)
 unpack C = C.Obj , record { C }
   where module C = Category C
 
+unpack′ : (C : Category o ℓ e) → Unb-Cat (Category.Obj C) ℓ e
+unpack′ C = record { C }
+  where module C = Category C
+
 pack : Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e) → Category o ℓ e
 pack (o , uc)  = record { Obj = o; UC }
   where module UC = Unb-Cat uc

--- a/src/Categories/Category/Unbundled/Properties.agda
+++ b/src/Categories/Category/Unbundled/Properties.agda
@@ -16,13 +16,13 @@ private
   variable
     o ℓ e : Level
 
-  to : Category o ℓ e → Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e)
-  to C = C.Obj , record { C }
-    where module C = Category C
+unpack : Category o ℓ e → Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e)
+unpack C = C.Obj , record { C }
+  where module C = Category C
 
-  from :  Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e) → Category o ℓ e
-  from (o , uc)  = record { Obj = o; UC }
-    where module UC = Unb-Cat uc
+pack :  Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e) → Category o ℓ e
+pack (o , uc)  = record { Obj = o; UC }
+  where module UC = Unb-Cat uc
 
 equiv : (Category o ℓ e) ↔ (Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e))
-equiv = mk↔′ to from (λ _ → refl) λ _ → refl
+equiv = mk↔′ unpack pack (λ _ → refl) λ _ → refl

--- a/src/Categories/Category/Unbundled/Properties.agda
+++ b/src/Categories/Category/Unbundled/Properties.agda
@@ -1,0 +1,28 @@
+{-# OPTIONS --without-K --safe #-}
+module Categories.Category.Unbundled.Properties where
+
+-- The Obj-unbundled Category is equivalent (as a type) to the
+-- usual kind. Quite straightforward and because of η, the proofs are just refl.
+
+open import Data.Product using (Σ; _,_)
+open import Level
+open import Function using (_↔_; mk↔′)
+open import Relation.Binary.PropositionalEquality using (refl)
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Unbundled renaming (Category to Unb-Cat)
+
+private
+  variable
+    o ℓ e : Level
+
+  to : Category o ℓ e → Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e)
+  to C = C.Obj , record { C }
+    where module C = Category C
+
+  from :  Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e) → Category o ℓ e
+  from (o , uc)  = record { Obj = o; UC }
+    where module UC = Unb-Cat uc
+
+equiv : (Category o ℓ e) ↔ (Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e))
+equiv = mk↔′ to from (λ _ → refl) λ _ → refl

--- a/src/Categories/Category/Unbundled/Properties.agda
+++ b/src/Categories/Category/Unbundled/Properties.agda
@@ -20,8 +20,12 @@ unpack : Category o ℓ e → Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e)
 unpack C = C.Obj , record { C }
   where module C = Category C
 
-pack :  Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e) → Category o ℓ e
+pack : Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e) → Category o ℓ e
 pack (o , uc)  = record { Obj = o; UC }
+  where module UC = Unb-Cat uc
+
+pack′ :  {Obj : Set o} → Unb-Cat Obj ℓ e → Category o ℓ e
+pack′ {Obj = o} uc  = record { Obj = o; UC }
   where module UC = Unb-Cat uc
 
 equiv : (Category o ℓ e) ↔ (Σ (Set o) (λ Obj → Unb-Cat Obj ℓ e))

--- a/src/Categories/Category/Unbundled/Utilities.agda
+++ b/src/Categories/Category/Unbundled/Utilities.agda
@@ -1,0 +1,91 @@
+{-# OPTIONS --without-K --safe #-}
+module Categories.Category.Unbundled.Utilities where
+
+-- various functions that are 'normally' in the Category record, but
+-- are here done separately
+
+open import Level
+open import Function.Base using (flip)
+
+open import Relation.Binary using (Rel; IsEquivalence; Setoid)
+open import Relation.Binary.PropositionalEquality as ≡ using (_≡_)
+import Relation.Binary.Reasoning.Setoid as SetoidR
+
+open import Categories.Category.Unbundled using (Category)
+
+private
+  variable
+    o ℓ e : Level
+
+module _ {Obj : Set o} (C : Category Obj ℓ e) where
+
+  open Category C
+
+  module Equiv {A B : Obj} = IsEquivalence (equiv {A} {B})
+
+  open Equiv
+
+  ∘-resp-≈ˡ : ∀ {A B C} {f h : B ⇒ C} {g : A ⇒ B} → f ≈ h → f ∘ g ≈ h ∘ g
+  ∘-resp-≈ˡ pf = ∘-resp-≈ pf refl
+
+  ∘-resp-≈ʳ : ∀ {A B C} {f h : A ⇒ B} {g : B ⇒ C} → f ≈ h → g ∘ f ≈ g ∘ h
+  ∘-resp-≈ʳ pf = ∘-resp-≈ refl pf
+
+  hom-setoid : ∀ {A B} → Setoid _ _
+  hom-setoid {A} {B} = record
+    { Carrier       = A ⇒ B
+    ; _≈_           = _≈_
+    ; isEquivalence = equiv
+    }
+
+  -- When a category is quantified, it is convenient to refer to the levels from a module,
+  -- so we do not have to explicitly quantify over a category when universe levels do not
+  -- play a big part in a proof (which is the case probably all the time).
+  o-level : Level
+  o-level = o
+
+  ℓ-level : Level
+  ℓ-level = ℓ
+
+  e-level : Level
+  e-level = e
+
+  -- Reasoning combinators.  _≈⟨_⟩_ and _≈˘⟨_⟩_ from SetoidR.
+  -- Also some useful combinators for doing reasoning on _∘_ chains
+  module HomReasoning {A B : Obj} where
+    open SetoidR (hom-setoid {A} {B}) public
+    -- open Equiv {A = A} {B = B} public
+
+    infixr 4 _⟩∘⟨_ refl⟩∘⟨_
+    infixl 5 _⟩∘⟨refl
+    _⟩∘⟨_ : ∀ {M} {f h : M ⇒ B} {g i : A ⇒ M} → f ≈ h → g ≈ i → f ∘ g ≈ h ∘ i
+    _⟩∘⟨_ = ∘-resp-≈
+
+    refl⟩∘⟨_ : ∀ {M} {f : M ⇒ B} {g i : A ⇒ M} → g ≈ i → f ∘ g ≈ f ∘ i
+    refl⟩∘⟨_ = Equiv.refl ⟩∘⟨_
+
+    _⟩∘⟨refl : ∀ {M} {f h : M ⇒ B} {g : A ⇒ M} → f ≈ h → f ∘ g ≈ h ∘ g
+    _⟩∘⟨refl = _⟩∘⟨ Equiv.refl
+
+    -- convenient inline versions
+    infix 2 ⟺
+    infixr 3 _○_
+    ⟺ : {f g : A ⇒ B} → f ≈ g → g ≈ f
+    ⟺ = Equiv.sym
+    _○_ : {f g h : A ⇒ B} → f ≈ g → g ≈ h → f ≈ h
+    _○_ = Equiv.trans
+
+  op : Category Obj ℓ e
+  op = record
+    { _⇒_       = flip _⇒_
+    ; _≈_       = _≈_
+    ; _∘_       = flip _∘_
+    ; id        = id
+    ; assoc     = sym-assoc
+    ; sym-assoc = assoc
+    ; identityˡ = identityʳ
+    ; identityʳ = identityˡ
+    ; identity² = identity²
+    ; equiv     = equiv
+    ; ∘-resp-≈  = flip ∘-resp-≈
+    }

--- a/src/Categories/Functor/IdentityOnObjects.agda
+++ b/src/Categories/Functor/IdentityOnObjects.agda
@@ -11,6 +11,7 @@ open import Level
 
 open import Categories.Category.Unbundled using (Category)
 open import Categories.Category.Unbundled.Properties using (pack′)
+open import Categories.Category.Unbundled.Utilities using (module Equiv)
 open import Categories.Functor.Core using (Functor)
 
 private
@@ -34,3 +35,7 @@ IOO⇒Functor : {Ob : Set o} {C : Category Ob ℓ e} {D : Category Ob ℓ′ e�
   (F : IdentityOnObjects C D) → Functor (pack′ C) (pack′ D)
 IOO⇒Functor F = record { F₀ = id→; IOO }
   where module IOO = IdentityOnObjects F
+
+id-IOO : {Obj : Set o} {C : Category Obj ℓ e} → IdentityOnObjects C C
+id-IOO {C = C} = record { F₁ = id→ ; identity = refl ; homomorphism = refl ; F-resp-≈ = id→ }
+  where open Equiv C

--- a/src/Categories/Functor/IdentityOnObjects.agda
+++ b/src/Categories/Functor/IdentityOnObjects.agda
@@ -10,7 +10,7 @@ open import Function using () renaming (id to id→)
 open import Level
 
 open import Categories.Category.Unbundled using (Category)
-open import Categories.Category.Unbundled.Properties using (pack)
+open import Categories.Category.Unbundled.Properties using (pack′)
 open import Categories.Functor.Core using (Functor)
 
 private
@@ -31,6 +31,6 @@ record IdentityOnObjects {Obj : Set o} (C : Category Obj ℓ e) (D : Category Ob
     F-resp-≈     : ∀ {A B} {f g : A C.⇒ B} → f C.≈ g → F₁ f D.≈ F₁ g
 
 IOO⇒Functor : {Ob : Set o} {C : Category Ob ℓ e} {D : Category Ob ℓ′ e′} →
-  (F : IdentityOnObjects C D) → Functor (pack (Ob , C)) (pack (Ob , D))
+  (F : IdentityOnObjects C D) → Functor (pack′ C) (pack′ D)
 IOO⇒Functor F = record { F₀ = id→; IOO }
   where module IOO = IdentityOnObjects F

--- a/src/Categories/Functor/IdentityOnObjects.agda
+++ b/src/Categories/Functor/IdentityOnObjects.agda
@@ -1,0 +1,36 @@
+{-# OPTIONS --without-K --safe #-}
+
+
+-- Identity-on-Objects Functor for (Object-)Unbundled Categories
+
+module Categories.Functor.IdentityOnObjects where
+
+open import Data.Product using (_,_)
+open import Function using () renaming (id to id→)
+open import Level
+
+open import Categories.Category.Unbundled using (Category)
+open import Categories.Category.Unbundled.Properties using (pack)
+open import Categories.Functor.Core using (Functor)
+
+private
+  variable
+    o ℓ e ℓ′ e′ : Level
+
+record IdentityOnObjects {Obj : Set o} (C : Category Obj ℓ e) (D : Category Obj ℓ′ e′) : Set (o ⊔ ℓ ⊔ e ⊔ ℓ′ ⊔ e′) where
+  eta-equality
+  private module C = Category C
+  private module D = Category D
+
+  field
+    F₁ : ∀ {A B} → (A C.⇒ B) → A D.⇒ B
+
+    identity     : ∀ {A} → F₁ (C.id {A}) D.≈ D.id
+    homomorphism : ∀ {X Y Z} {f : X C.⇒ Y} {g : Y C.⇒ Z} →
+                     F₁ (g C.∘ f) D.≈ F₁ g D.∘ F₁ f
+    F-resp-≈     : ∀ {A B} {f g : A C.⇒ B} → f C.≈ g → F₁ f D.≈ F₁ g
+
+IOO⇒Functor : {Ob : Set o} {C : Category Ob ℓ e} {D : Category Ob ℓ′ e′} →
+  (F : IdentityOnObjects C D) → Functor (pack (Ob , C)) (pack (Ob , D))
+IOO⇒Functor F = record { F₀ = id→; IOO }
+  where module IOO = IdentityOnObjects F

--- a/src/Categories/Theory/Lawvere.agda
+++ b/src/Categories/Theory/Lawvere.agda
@@ -26,7 +26,7 @@ open import Categories.Functor.IdentityOnObjects
 
 private
   variable
-    ℓ e ℓ′ e′ ℓ″ e″ : Level
+    ℓ e o′ ℓ′ e′ ℓ″ e″ : Level
 
 record LawvereTheory (ℓ e : Level) : Set (suc (ℓ ⊔ e)) where
   private
@@ -61,7 +61,8 @@ LT-∘ : {A : LawvereTheory ℓ e} {B : LawvereTheory ℓ′ e′} {C : LawvereT
 LT-∘ G H = record { cartF = ∘-CartesianF (cartF G) (cartF H) }
   where open LT-Hom
 
-record T-Algebra (LT : LawvereTheory ℓ e) : Set (ℓ ⊔ e ⊔ suc (ℓ′ ⊔ e′)) where
+-- A 'Model' will be taken to be in Setoids.
+record Model (LT : LawvereTheory ℓ e) : Set (ℓ ⊔ e ⊔ suc (ℓ′ ⊔ e′)) where
   private
     module LT = LawvereTheory LT
   field
@@ -71,3 +72,14 @@ record T-Algebra (LT : LawvereTheory ℓ e) : Set (ℓ ⊔ e ⊔ suc (ℓ′ ⊔
 
   mod : Functor LT.L′ (Setoids ℓ′ e′)
   mod = cartF.F
+
+-- But we can have more general models 'in' a cartesian category
+record ModelsOf_In_ (LT : LawvereTheory ℓ e) (𝒞 : CartesianCategory o′ ℓ′ e′) : Set (ℓ ⊔ e ⊔ o′ ⊔ ℓ′ ⊔ e′) where
+  private
+    module LT = LawvereTheory LT using (L′; CartT)
+    module CC = CartesianCategory 𝒞 using (U)
+  field
+    cartF : CartesianF LT.CartT 𝒞
+
+  mod : Functor LT.L′ CC.U
+  mod = CartesianF.F cartF

--- a/src/Categories/Theory/Lawvere.agda
+++ b/src/Categories/Theory/Lawvere.agda
@@ -9,7 +9,6 @@
 module Categories.Theory.Lawvere where
 
 open import Data.Nat using (ℕ)
-open import Data.Product using (proj₂)
 open import Level
 
 open import Categories.Category.Cartesian using (Cartesian)
@@ -19,7 +18,7 @@ open import Categories.Category.Instance.Nat using (Nat; Natop-Cartesian)
 open import Categories.Category.Instance.Setoids
 open import Categories.Category.Monoidal.Instance.Setoids using (Setoids-CartesianCategory)
 open import Categories.Category.Unbundled using (Category)
-open import Categories.Category.Unbundled.Properties using (pack′; unpack)
+open import Categories.Category.Unbundled.Properties using (pack′; unpack′)
 open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
 open import Categories.Functor.Cartesian
 open import Categories.Functor.Cartesian.Properties
@@ -27,7 +26,7 @@ open import Categories.Functor.IdentityOnObjects
 
 private
   variable
-    o ℓ e o′ ℓ′ e′ o″ ℓ″ e″ : Level
+    ℓ e ℓ′ e′ ℓ″ e″ : Level
 
 record LawvereTheory (ℓ e : Level) : Set (suc (ℓ ⊔ e)) where
   private
@@ -41,7 +40,7 @@ record LawvereTheory (ℓ e : Level) : Set (suc (ℓ ⊔ e)) where
   CartT : CartesianCategory 0ℓ ℓ e
   CartT = record { U = L′ ; cartesian = T }
   field
-    I : IdentityOnObjects (proj₂ (unpack 𝒩)) L
+    I : IdentityOnObjects (unpack′ 𝒩) L
     CartF : IsCartesianF Natop-Cartesian CartT (IOO⇒Functor I)
 
 record LT-Hom (T₁ : LawvereTheory ℓ e) (T₂ : LawvereTheory ℓ′ e′) : Set (ℓ ⊔ e ⊔ ℓ′ ⊔ e′) where
@@ -62,7 +61,7 @@ LT-∘ : {A : LawvereTheory ℓ e} {B : LawvereTheory ℓ′ e′} {C : LawvereT
 LT-∘ G H = record { cartF = ∘-CartesianF (cartF G) (cartF H) }
   where open LT-Hom
 
-record T-Algebra (LT : LawvereTheory ℓ e) : Set (o ⊔ ℓ ⊔ e ⊔ suc (ℓ′ ⊔ e′)) where
+record T-Algebra (LT : LawvereTheory ℓ e) : Set (ℓ ⊔ e ⊔ suc (ℓ′ ⊔ e′)) where
   private
     module LT = LawvereTheory LT
   field

--- a/src/Categories/Theory/Lawvere.agda
+++ b/src/Categories/Theory/Lawvere.agda
@@ -1,68 +1,74 @@
 {-# OPTIONS --without-K --safe #-}
 
--- a categorical (i.e. non-skeletal) version of Lawvere Theory,
--- as per https://ncatlab.org/nlab/show/Lawvere+theory
+-- The 'original' version of Lawvere Theory, based on
+-- Nat^op and IOO functors. Contrast with the weak version at
+-- https://ncatlab.org/nlab/show/Lawvere+theory
+-- Unfortunately, many results on the weak version are not in
+-- the literature, so doing that development would be new research.
 
 module Categories.Theory.Lawvere where
 
 open import Data.Nat using (ℕ)
-open import Data.Product using (Σ; _,_)
+open import Data.Product using (proj₂)
 open import Level
 
+open import Categories.Category.Cartesian using (Cartesian)
 open import Categories.Category.Cartesian.Bundle using (CartesianCategory)
-open import Categories.Category using (Category; _[_,_])
+import Categories.Category.Core as Cat
+open import Categories.Category.Instance.Nat using (Nat; Natop-Cartesian)
 open import Categories.Category.Instance.Setoids
 open import Categories.Category.Monoidal.Instance.Setoids using (Setoids-CartesianCategory)
-open import Categories.Category.Product
+open import Categories.Category.Unbundled using (Category)
+open import Categories.Category.Unbundled.Properties using (pack′; unpack)
 open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
 open import Categories.Functor.Cartesian
 open import Categories.Functor.Cartesian.Properties
-import Categories.Morphism as Mor
-open import Categories.NaturalTransformation using (NaturalTransformation)
+open import Categories.Functor.IdentityOnObjects
 
 private
   variable
     o ℓ e o′ ℓ′ e′ o″ ℓ″ e″ : Level
 
-record FiniteProduct (o ℓ e : Level) : Set (suc (o ⊔ ℓ ⊔ e)) where
-  field
-    T : CartesianCategory o ℓ e
-
-  module T = CartesianCategory T
-  open Mor T.U
-
-  field
-    generic : T.Obj
-
-  field
-    obj-iso-to-generic-power : ∀ x → Σ ℕ (λ n → x ≅ T.power generic n)
-
-record LT-Hom (T₁ : FiniteProduct o ℓ e) (T₂ : FiniteProduct o′ ℓ′ e′) : Set (o ⊔ ℓ ⊔ e ⊔ o′ ⊔ ℓ′ ⊔ e′) where
+record LawvereTheory (ℓ e : Level) : Set (suc (ℓ ⊔ e)) where
   private
-    module T₁ = FiniteProduct T₁
-    module T₂ = FiniteProduct T₂
+    𝒩 = Cat.Category.op Nat
+  field
+    L : Category ℕ ℓ e
+  L′ : Cat.Category 0ℓ ℓ e
+  L′ = pack′ L
+  field
+    T : Cartesian L′
+  CartT : CartesianCategory 0ℓ ℓ e
+  CartT = record { U = L′ ; cartesian = T }
+  field
+    I : IdentityOnObjects (proj₂ (unpack 𝒩)) L
+    CartF : IsCartesianF Natop-Cartesian CartT (IOO⇒Functor I)
+
+record LT-Hom (T₁ : LawvereTheory ℓ e) (T₂ : LawvereTheory ℓ′ e′) : Set (ℓ ⊔ e ⊔ ℓ′ ⊔ e′) where
+  private
+    module T₁ = LawvereTheory T₁
+    module T₂ = LawvereTheory T₂
 
   field
-    cartF : CartesianF T₁.T T₂.T
+    cartF : CartesianF T₁.CartT T₂.CartT
 
-  module cartF = CartesianF cartF
+  module cartF = CartesianF cartF using (F)
 
-LT-id : {A : FiniteProduct o ℓ e} → LT-Hom A A
+LT-id : {A : LawvereTheory ℓ e} → LT-Hom A A
 LT-id = record { cartF = idF-CartesianF _ }
 
-LT-∘ : {A : FiniteProduct o ℓ e} {B : FiniteProduct o′ ℓ′ e′} {C : FiniteProduct o″ ℓ″ e″} →
+LT-∘ : {A : LawvereTheory ℓ e} {B : LawvereTheory ℓ′ e′} {C : LawvereTheory ℓ″ e″} →
        LT-Hom B C → LT-Hom A B → LT-Hom A C
 LT-∘ G H = record { cartF = ∘-CartesianF (cartF G) (cartF H) }
   where open LT-Hom
 
-
-record T-Algebra (FP : FiniteProduct o ℓ e) : Set (o ⊔ ℓ ⊔ e ⊔ suc (ℓ′ ⊔ e′)) where
+record T-Algebra (LT : LawvereTheory ℓ e) : Set (o ⊔ ℓ ⊔ e ⊔ suc (ℓ′ ⊔ e′)) where
   private
-    module FP = FiniteProduct FP
+    module LT = LawvereTheory LT
   field
-    cartF : CartesianF FP.T (Setoids-CartesianCategory ℓ′ e′)
+    cartF : CartesianF LT.CartT (Setoids-CartesianCategory ℓ′ e′)
 
   module cartF = CartesianF cartF
 
-  mod : Functor FP.T.U (Setoids ℓ′ e′)
+  mod : Functor LT.L′ (Setoids ℓ′ e′)
   mod = cartF.F

--- a/src/Categories/Theory/Lawvere/Instance/Identity.agda
+++ b/src/Categories/Theory/Lawvere/Instance/Identity.agda
@@ -1,0 +1,33 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- The 'Identity' instance, with all of Setoids as models
+
+module Categories.Theory.Lawvere.Instance.Identity where
+
+open import Data.Fin using (splitAt)
+open import Data.Sum using ([_,_]′)
+open import Data.Unit.Polymorphic using (⊤; tt)
+open import Level
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; isEquivalence)
+
+open import Categories.Category.Cartesian.Bundle using (CartesianCategory)
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Instance.Nat
+open import Categories.Category.Unbundled.Properties using (unpack′)
+open import Categories.Functor.IdentityOnObjects using (id-IOO)
+open import Categories.Object.Product using (Product)
+open import Categories.Theory.Lawvere using (LawvereTheory)
+
+Identity : LawvereTheory 0ℓ 0ℓ
+Identity = record
+  { L = unpack′ (Category.op Nat)
+  ; T = CartesianCategory.cartesian Natop-Cartesian
+  ; I = id-IOO
+  ; CartF = record
+    { F-resp-⊤ = record { ! = λ () ; !-unique = λ _ () }
+    ; F-resp-× = λ {m} {n} → record { P m n }
+    }
+  }
+  where
+  module P m n = Product Natop (Natop-Product m n)

--- a/src/Categories/Theory/Lawvere/Instance/Triv.agda
+++ b/src/Categories/Theory/Lawvere/Instance/Triv.agda
@@ -1,0 +1,48 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- The 'Trivial' instance, with a single arrow between objects
+
+module Categories.Theory.Lawvere.Instance.Triv where
+
+open import Data.Nat using (_*_)
+open import Data.Unit.Polymorphic using (⊤; tt)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; isEquivalence)
+
+open import Categories.Theory.Lawvere using (LawvereTheory)
+
+Triv : ∀ {ℓ} → LawvereTheory ℓ ℓ
+Triv = record
+  { L = record
+          { _⇒_ = λ _ _ → ⊤
+          ; _≈_ = _≡_
+          ; assoc = refl
+          ; sym-assoc = refl
+          ; identityˡ = refl
+          ; identityʳ = refl
+          ; identity² = refl
+          ; equiv = isEquivalence
+          ; ∘-resp-≈ = λ _ _ → refl
+          }
+  ; T = record
+    { terminal = record { ⊤ = 0 ; ⊤-is-terminal = record { ! = tt ; !-unique = λ _ → refl } }
+    ; products = record
+      { product = λ {m} {n} → record
+        { A×B = m * n
+        ; project₁ = refl
+        ; project₂ = refl
+        ; unique = λ _ _ → refl
+        }
+      }
+    }
+  ; I = record
+    { F₁ = λ _ → tt
+    ; identity = refl
+    ; homomorphism = refl
+    ; F-resp-≈ = λ _ → refl
+    }
+  ; CartF = record
+    { F-resp-⊤ = record { ! = tt ; !-unique = λ _ → refl }
+    ; F-resp-× = record { ⟨_,_⟩ = λ _ _ → tt ; project₁ = refl ; project₂ = refl ; unique = λ _ _ → refl }
+    }
+  }


### PR DESCRIPTION
The previous attempt was based on the very general view currently sketched on nLab. Unfortunately, that view isn't worked out very much in the literature, so doing even fairly basic stuff would be new, substantial work.

So instead, do them 'as usual'. This forced the implementation of quite a few things (that were worthwhile):
1. "unbundled" categories (`Categories.Category.Unbundled`) which are Categories with `Obj` as a *parameter* instead of a field. This permits making two categories with evidently definitionally equal objects.
2. some utilities and properties (such as conversions, i.e. pack/unpack, with usual categories).
3. IdentityOnObjects 'functors', that are easy to define on "unbundled" categories
4. An instance of the category 'Nat' with objects natural numbers and morphism all Fin m -> Fin n functions. Coproducts and Cocartesian. And then, by Duality that Nat^op has products and is Cartesian.
5. Use all of the above to define Lawvere Theories, and the Category of Lawvere Theories.
6. Implement a couple of simple instances, called 'Triv' and 'Identity'. Interestingly, 'Triv' requires a lot more code (even though it's all trivial) than Identity.