### PR TITLE
Add --auto-inline and -Werror to Makefile and CI script and bump heap size limit.

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -51,7 +51,7 @@ env:
   GHC_VERSION: 8.6.5
   CABAL_VERSION: 3.2.0.0
   CABAL_INSTALL: cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS'
-  AGDA: agda --auto-inline -Werror +RTS -M3.5G -H3.5G -A128M -RTS -i. -i src/
+  AGDA: agda --auto-inline -Werror +RTS -M6G -H3.5G -A128M -RTS -i. -i src/
 
 jobs:
   test-categories:

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -51,7 +51,7 @@ env:
   GHC_VERSION: 8.6.5
   CABAL_VERSION: 3.2.0.0
   CABAL_INSTALL: cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS'
-  AGDA: agda -Werror +RTS -M3.5G -H3.5G -A128M -RTS -i. -i src/
+  AGDA: agda --auto-inline -Werror +RTS -M3.5G -H3.5G -A128M -RTS -i. -i src/
 
 jobs:
   test-categories:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: test Everything.agda clean
 
-OTHEROPTS=
+OTHEROPTS = --auto-inline -Werror
 
-RTSARGS = +RTS -M6G -A128M ${OTHEROPTS} -RTS
+RTSARGS = +RTS -M6G -A128M -RTS ${OTHEROPTS}
 
 test: Everything.agda
 	agda ${RTSARGS} -i. Everything.agda


### PR DESCRIPTION
This is an attempt to "fix" the CI script so PR https://github.com/agda/agda-categories/issues/304#issuecomment-904488072 passes the build.  From the PR discussion:

I noticed we don't use `--auto-inline` in the Makefile (or the CI script). Apparently this was a default option prior to 2.6.2 and can help speed up type checking. Maybe it helps with heap usage too?

See https://github.com/agda/agda/blob/v2.6.2/CHANGELOG.md#pragmas-and-options

_Originally posted by @sstucki in https://github.com/agda/agda-categories/issues/304#issuecomment-904488072_