### PR TITLE
add diagrammatic composition

### DIFF
--- a/src/Categories/Morphism.agda
+++ b/src/Categories/Morphism.agda
@@ -116,3 +116,7 @@ module ≅ = IsEquivalence ≅-isEquivalence
   ; _≈_           = _≅_
   ; isEquivalence = ≅-isEquivalence
   }
+
+-- diagrammatic composition of morphisms; the symbol is (U+FF1B), "Fullwidth Semicolon", not semicolon (U+003B)
+_；_ : {A B C : Obj} → (f : A ⇒ B) → (g : B ⇒ C) → (A ⇒ C)
+f ； g = g ∘ f


### PR DESCRIPTION
diagrammatic composition of morphisms, i.e.

`f ; g : A --f--> B --g--> C`

tuns out to be useful in some proofs, and it usually makes very fast the process of dualising a thing into a co-thing (just put a co- in front of names, and replace \circ with `;` -which, again, is U+FF1B *not* U+003B)