### PR TITLE
Stub for representable profunctor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 src/MAlonzo
 
 agda-categories.agda-lib
+agda-categories.agda-lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.agdai
 .DS_Store
 src/MAlonzo
+
+agda-categories.agda-lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 *.agdai
 .DS_Store
 src/MAlonzo
-
-agda-categories.agda-lib
-agda-categories.agda-lib

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -12,40 +12,67 @@ open import Categories.Functor hiding (id)
 open import Categories.Functor.Bifunctor
 open import Categories.Functor.Hom
 
-Profunctor : ∀ {o ℓ e} {o′ ℓ′ e′} → Category o ℓ e → Category o′ ℓ′ e′ → Set _
-Profunctor {ℓ = ℓ} {e} {ℓ′ = ℓ′} {e′} C D = Bifunctor (Category.op D) C (Setoids (ℓ ⊔ ℓ′) (e ⊔ e′))
+module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
 
-id : ∀ {o ℓ e} → {C : Category o ℓ e} → Profunctor C C
-id {C = C} = Hom[ C ][-,-]
+  open import Categories.Morphism.Reasoning D as MR
 
-private
-  variable
-    o ℓ e o′ ℓ′ e′ : Level
-    C : Category o ℓ e
-    D : Category o′ ℓ′ e′
+  Profunctor : ∀ {o ℓ e} {o′ ℓ′ e′} → Category o ℓ e → Category o′ ℓ′ e′ → Set _
+  Profunctor {ℓ = ℓ} {e} {ℓ′ = ℓ′} {e′} C D = Bifunctor (Category.op D) C (Setoids (ℓ ⊔ ℓ′) (e ⊔ e′))
 
--- stub for representable profunctors
-repˡ : (F : Functor C D) → Profunctor D C
-repˡ F = record
-  { F₀ = {!   !}
-  ; F₁ = {!   !}
-  ; identity = {!   !}
-  ; homomorphism = {!   !}
-  ; F-resp-≈ = {!   !}
-  }
-  where
-  F0 : Σ (Category.Obj C) (λ x → Category.Obj D) → Setoid (ℓ ⊔ ℓ′) (e ⊔ e′)
-  F0 (c , d) = record
-    { Carrier = {!   !}
-    ; _≈_ = {! _≈_   !}
-    ; isEquivalence = record { refl = {!   !} ; sym = {!   !} ; trans = {!   !} }
+  id : ∀ {o ℓ e} → {C : Category o ℓ e} → Profunctor C C
+  id {C = C} = Hom[ C ][-,-]
+
+  -- representable profunctor
+  -- hom(f,1)
+  repˡ : (F : Functor C D) → Profunctor {o} {ℓ} {e} {o} {ℓ} {e} D C
+  repˡ F = record
+    { F₀ = λ {(c , d) → record
+        { Carrier = D [ Functor.F₀ F c , d ]
+        ; _≈_ = D._≈_
+        ; isEquivalence = D.equiv
+        }}
+    ; F₁ = λ { {A = A0 , A1} {B = B0 , B1} (f , g) → record
+      { _⟨$⟩_ = λ x → g D.∘ x D.∘ Functor.F₁ F f
+      ; cong = λ x → D.∘-resp-≈ D.Equiv.refl (D.∘-resp-≈ x D.Equiv.refl)
+      }}
+    ; identity = λ {x} {y} {y'} y≈y' → begin
+      D.id D.∘ y D.∘ Functor.F₁ F C.id ≈⟨ D.identityˡ ⟩
+      y D.∘ Functor.F₁ F C.id ≈⟨ (refl⟩∘⟨ Functor.identity F) ⟩
+      y D.∘ D.id ≈⟨ D.Equiv.trans D.identityʳ y≈y' ⟩
+      y' ∎
+    ; homomorphism = λ { {X = X0 , X1} {Y = Y0 , Y1} {Z = Z0 , Z1} {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y →
+      begin
+       (g1 D.∘ f1) D.∘ x D.∘ Functor.F₁ F (f0 C.∘ g0)              ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ Functor.homomorphism F)) ⟩
+       (g1 D.∘ f1) D.∘ x D.∘ Functor.F₁ F f0 D.∘ Functor.F₁ F g0   ≈⟨ (refl⟩∘⟨ (x≈y ⟩∘⟨refl)) ⟩
+       (g1 D.∘ f1) D.∘ y D.∘ Functor.F₁ F f0 D.∘ Functor.F₁ F g0   ≈⟨ (refl⟩∘⟨ D.Equiv.sym (Category.assoc D)) ⟩
+       (g1 D.∘ f1) D.∘ (y D.∘ Functor.F₁ F f0) D.∘ Functor.F₁ F g0 ≈⟨ Category.assoc D ⟩
+       g1 D.∘ f1 D.∘ (y D.∘ Functor.F₁ F f0) D.∘ Functor.F₁ F g0   ≈⟨ (refl⟩∘⟨ D.Equiv.sym (Category.assoc D)) ⟩
+       g1 D.∘ (f1 D.∘ y D.∘ Functor.F₁ F f0) D.∘ Functor.F₁ F g0 ∎ }
+    ; F-resp-≈ = resp
     }
+    where
+     module C = Category C
+     module D = Category D
+     open D.HomReasoning
+     resp : {A B : Σ C.Obj (λ x → D.Obj)}
+      {f g : Σ (proj₁ B C.⇒ proj₁ A) (λ x → proj₂ A D.⇒ proj₂ B)} →
+      Σ (proj₁ f C.≈ proj₁ g) (λ x → proj₂ f D.≈ proj₂ g) →
+      {x y : Functor.F₀ F (proj₁ A) D.⇒ proj₂ A} →
+      x D.≈ y →
+      proj₂ f D.∘ x D.∘ Functor.F₁ F (proj₁ f) D.≈
+      proj₂ g D.∘ y D.∘ Functor.F₁ F (proj₁ g)
+     resp {A = A0 , A1} {B = B0 , B1} {f = f0 , f1} {g = g0 , g1} (eq0 , eq1) {x} {y} eq' = begin
+       f1 D.∘ x D.∘ Functor.F₁ F f0 ≈⟨ (refl⟩∘⟨ (eq' ⟩∘⟨refl)) ⟩
+       f1 D.∘ y D.∘ Functor.F₁ F f0 ≈⟨ D.∘-resp-≈ eq1 D.Equiv.refl ⟩
+       g1 D.∘ y D.∘ Functor.F₁ F f0 ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ Functor.F-resp-≈ F eq0)) ⟩
+       g1 D.∘ y D.∘ Functor.F₁ F g0 ∎
 
-repʳ : (F : Functor C D) → Profunctor C D
-repʳ F = record
-  { F₀ = λ x → {!   !}
-  ; F₁ = {!   !}
-  ; identity = {!   !}
-  ; homomorphism = {!   !}
-  ; F-resp-≈ = {!   !}
-  }
+  -- hom(1,f)
+  repʳ : (F : Functor C D) → Profunctor C D
+  repʳ F = record
+    { F₀ = λ x → {!   !}
+    ; F₁ = {!   !}
+    ; identity = {!   !}
+    ; homomorphism = {!   !}
+    ; F-resp-≈ = {!   !}
+    }

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -91,34 +91,46 @@ module Profunctor {o ℓ e} {o′} (C : Category o ℓ e) (D : Category o′ ℓ
     where
       open module F = Functor F
 
-  -- each Prof(C,D) is a category
-  homProf : (C : Category o ℓ e) → (D : Category o′ ℓ e) → Category _ _ _
-  homProf C D = record
-    { Obj = Profunctor C D
-    ; _⇒_ = λ P Q → NaturalTransformation P Q
-    ; _≈_ = _≃_
-    ; id = id
-    ; _∘_ = _∘ᵥ_
-    ; assoc = {!   !}
-    ; sym-assoc = {!   !}
-    ; identityˡ = {!  !}
-      -- λ { {P} {Q} {f} {(d , c)} {u} {v} u≈v → {!  !}}
-    ; identityʳ = {!   !}
-      -- λ { {P} {Q} {f} {(d , c)} {u} {v} u≈v → {!   !}}
-    ; identity² = λ z → z
-    ; equiv = ≃-isEquivalence
-    ; ∘-resp-≈ = {!   !}
-    }
-    where
-    assoc-proof : {A B : Profunctor C D} {C = C₂ : Profunctor C D}
-      {D = D₂ : Profunctor C D}
-      {f : NaturalTransformation A B} {g : NaturalTransformation B C₂}
-      {h : NaturalTransformation C₂ D₂} →
-      (h ∘ᵥ g) ∘ᵥ f ≃ h ∘ᵥ g ∘ᵥ f
-    assoc-proof {P} {Q} {R} {S} {f} {g} {h} {(d , c)} {u} {v} = λ u≈v → {!  !}
-    idl-proof : {A B : Profunctor C D} {f : NaturalTransformation A B} →
-      id ∘ᵥ f ≃ f
-    idl-proof {P} {Q} {f} {(d , c)} {u} {v} u≈v = {!   !}
-    idr-proof : {A B : Profunctor C D} {f : NaturalTransformation A B} →
-      f ∘ᵥ id ≃ f
-    idr-proof {P} {Q} {f} {(d , c)} {u} {v} u≈v = {!   !}
+-- each Prof(C,D) is a category
+homProf : {o o′ ℓ e : Level} → (C : Category o ℓ e) → (D : Category o′ ℓ e) → Category _ _ _
+homProf {o} {o′} {ℓ} {e} C D = record
+  { Obj = Profunctor C D
+  ; _⇒_ = λ P Q → NaturalTransformation P Q
+  ; _≈_ = _≃_
+  ; id = id
+  ; _∘_ = _∘ᵥ_
+  ; assoc     = λ { {f = f} {g} {h} → assoc-lemma {f = f} {g} {h}}
+  ; sym-assoc = λ { {f = f} {g} {h} → sym-assoc-lemma {f = f} {g} {h}}
+  ; identityˡ = λ { {f = f} → id-lemmaˡ {f = f}}
+  ; identityʳ = λ { {f = f} → id-lemmaʳ {f = f} }
+  ; identity² = λ z → z
+  ; equiv = ≃-isEquivalence
+  ; ∘-resp-≈ = λ { {f = f} {h} {g} {i} eq eq' → ∘ᵥ-resp-≃ {f = f} {h} {g} {i} eq eq' }
+  }
+  where
+    id-lemmaˡ : ∀ {o o′ ℓ ℓ′ e e′} {C : Category o ℓ e} {D : Category o′ ℓ′ e′} {P K : Functor C D}
+            {f : NaturalTransformation P K} → id ∘ᵥ f ≃ f
+    id-lemmaˡ {D = D} = Category.identityˡ D
+
+    id-lemmaʳ : ∀ {o o′ ℓ ℓ′ e e′} {C : Category o ℓ e} {D : Category o′ ℓ′ e′} {P K : Functor C D}
+            {f : NaturalTransformation P K} → f ∘ᵥ id ≃ f
+    id-lemmaʳ {D = D} = Category.identityʳ D
+
+    assoc-lemma : ∀ {o o′ ℓ ℓ′ e e′} {C : Category o ℓ e} {D : Category o′ ℓ′ e′} {E F G H : Functor C D}
+              {f : NaturalTransformation E F}
+              {g : NaturalTransformation F G}
+              {h : NaturalTransformation G H}
+               → (h ∘ᵥ g) ∘ᵥ f ≃ h ∘ᵥ g ∘ᵥ f
+    assoc-lemma {D = D} = Category.assoc D
+
+    sym-assoc-lemma : ∀ {o o′ ℓ ℓ′ e e′} {C : Category o ℓ e} {D : Category o′ ℓ′ e′} {E F G H : Functor C D}
+              {f : NaturalTransformation E F}
+              {g : NaturalTransformation F G}
+              {h : NaturalTransformation G H}
+               → h ∘ᵥ g ∘ᵥ f ≃ (h ∘ᵥ g) ∘ᵥ f
+    sym-assoc-lemma {D = D} = Category.sym-assoc D
+
+    ∘ᵥ-resp-≃ : ∀ {o o′ ℓ ℓ′ e e′} {C : Category o ℓ e} {D : Category o′ ℓ′ e′} {R P K : Functor C D}
+        {f h : NaturalTransformation P K}
+        {g i : NaturalTransformation R P} → f ≃ h → g ≃ i → f ∘ᵥ g ≃ h ∘ᵥ i
+    ∘ᵥ-resp-≃ {D = D} fh gi = Category.∘-resp-≈ D fh gi

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -11,12 +11,14 @@ open import Categories.Category.Instance.Setoids
 open import Categories.Functor hiding (id)
 open import Categories.Functor.Bifunctor
 open import Categories.Functor.Hom
+open import Categories.NaturalTransformation
 
 Profunctor : ∀ {o ℓ e} {o′ ℓ′ e′} → Category o ℓ e → Category o′ ℓ′ e′ → Set _
 Profunctor {ℓ = ℓ} {e} {ℓ′ = ℓ′} {e′} C D = Bifunctor (Category.op D) C (Setoids (ℓ ⊔ ℓ′) (e ⊔ e′))
 
-id : ∀ {o ℓ e} → {C : Category o ℓ e} → Profunctor C C
-id {C = C} = Hom[ C ][-,-]
+-- Calling the profunctor identity "id" is a bad idea
+proid : ∀ {o ℓ e} → {C : Category o ℓ e} → Profunctor C C
+proid {C = C} = Hom[ C ][-,-]
 
 module Profunctor {o ℓ e} {o′} (C : Category o ℓ e) (D : Category o′ ℓ e) where
   module C = Category C
@@ -86,3 +88,20 @@ module Profunctor {o ℓ e} {o′} (C : Category o ℓ e) (D : Category o′ ℓ
     }
     where
       open module F = Functor F
+
+  -- each Prof(C,D) is a category
+  homProf : (C : Category o ℓ e) → (D : Category o′ ℓ e) → Category _ _ e
+  homProf C D = record
+    { Obj = Profunctor C D
+    ; _⇒_ = λ P Q → NaturalTransformation P Q
+    ; _≈_ = λ α β → {!    !} -- equality of nat transf
+    ; id = Categories.NaturalTransformation.id
+    ; _∘_ = _∘ᵥ_
+    ; assoc = λ {A} {B} {C₂} {D₂} {f} {g} {h} → {!   !}
+    ; sym-assoc = {!   !}
+    ; identityˡ = {!   !}
+    ; identityʳ = {!   !}
+    ; identity² = {!   !}
+    ; equiv = {!   !}
+    ; ∘-resp-≈ = {!   !}
+    }

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -12,6 +12,8 @@ open import Categories.Functor hiding (id)
 open import Categories.Functor.Bifunctor
 open import Categories.Functor.Hom
 open import Categories.NaturalTransformation
+open import Categories.NaturalTransformation.Equivalence
+open import Function.Equality using (Π; _⟨$⟩_; cong)
 
 Profunctor : ∀ {o ℓ e} {o′ ℓ′ e′} → Category o ℓ e → Category o′ ℓ′ e′ → Set _
 Profunctor {ℓ = ℓ} {e} {ℓ′ = ℓ′} {e′} C D = Bifunctor (Category.op D) C (Setoids (ℓ ⊔ ℓ′) (e ⊔ e′))
@@ -22,7 +24,7 @@ proid {C = C} = Hom[ C ][-,-]
 
 module Profunctor {o ℓ e} {o′} (C : Category o ℓ e) (D : Category o′ ℓ e) where
   module C = Category C
-  open module D = Category D
+  open module D = Category D hiding (id)
   open D.HomReasoning
   open import Categories.Morphism.Reasoning D using (assoc²''; elimˡ; elimʳ)
 
@@ -90,18 +92,33 @@ module Profunctor {o ℓ e} {o′} (C : Category o ℓ e) (D : Category o′ ℓ
       open module F = Functor F
 
   -- each Prof(C,D) is a category
-  homProf : (C : Category o ℓ e) → (D : Category o′ ℓ e) → Category _ _ e
+  homProf : (C : Category o ℓ e) → (D : Category o′ ℓ e) → Category _ _ _
   homProf C D = record
     { Obj = Profunctor C D
     ; _⇒_ = λ P Q → NaturalTransformation P Q
-    ; _≈_ = λ α β → {!    !} -- equality of nat transf
-    ; id = Categories.NaturalTransformation.id
+    ; _≈_ = _≃_
+    ; id = id
     ; _∘_ = _∘ᵥ_
-    ; assoc = λ {A} {B} {C₂} {D₂} {f} {g} {h} → {!   !}
+    ; assoc = {!   !}
     ; sym-assoc = {!   !}
-    ; identityˡ = {!   !}
+    ; identityˡ = {!  !}
+      -- λ { {P} {Q} {f} {(d , c)} {u} {v} u≈v → {!  !}}
     ; identityʳ = {!   !}
-    ; identity² = {!   !}
-    ; equiv = {!   !}
+      -- λ { {P} {Q} {f} {(d , c)} {u} {v} u≈v → {!   !}}
+    ; identity² = λ z → z
+    ; equiv = ≃-isEquivalence
     ; ∘-resp-≈ = {!   !}
     }
+    where
+    assoc-proof : {A B : Profunctor C D} {C = C₂ : Profunctor C D}
+      {D = D₂ : Profunctor C D}
+      {f : NaturalTransformation A B} {g : NaturalTransformation B C₂}
+      {h : NaturalTransformation C₂ D₂} →
+      (h ∘ᵥ g) ∘ᵥ f ≃ h ∘ᵥ g ∘ᵥ f
+    assoc-proof {P} {Q} {R} {S} {f} {g} {h} {(d , c)} {u} {v} = λ u≈v → {!  !}
+    idl-proof : {A B : Profunctor C D} {f : NaturalTransformation A B} →
+      id ∘ᵥ f ≃ f
+    idl-proof {P} {Q} {f} {(d , c)} {u} {v} u≈v = {!   !}
+    idr-proof : {A B : Profunctor C D} {f : NaturalTransformation A B} →
+      f ∘ᵥ id ≃ f
+    idr-proof {P} {Q} {f} {(d , c)} {u} {v} u≈v = {!   !}

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -49,8 +49,8 @@ module Profunctor {o ℓ e} {o′} (C : Category o ℓ e) (D : Category o′ ℓ
     ; homomorphism = λ { {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y → begin
         (g1 ∘ f1) ∘ x ∘ F₁ (f0 C.∘ g0)  ≈⟨ refl⟩∘⟨ x≈y ⟩∘⟨ F.homomorphism ⟩
         (g1 ∘ f1) ∘ y ∘ F₁ f0 ∘ F₁ g0   ≈⟨ refl⟩∘⟨ D.sym-assoc ⟩
-        (g1 ∘ f1) ∘ (y ∘ F₁ f0) ∘ F₁ g0 ≈⟨ {!   !} ⟩ -- was assoc²''
-        g1 ∘ (f1 ∘ y ∘ F₁ f0) ∘ F₁ g0 ∎
+        (g1 ∘ f1) ∘ (y ∘ F₁ f0) ∘ F₁ g0 ≈⟨ Equiv.sym assoc²'' ⟩
+        g1 ∘ (f1 ∘ y ∘ F₁ f0) ∘ F₁ g0   ∎
       }
     ; F-resp-≈ = λ { {f = f0 , f1} {g = g0 , g1} (f0≈g0 , f1≈g1) {x} {y} x≈y → begin
         f1 ∘ x ∘ F₁ f0 ≈⟨ f1≈g1 ⟩∘⟨ x≈y ⟩∘⟨ F-resp-≈ f0≈g0 ⟩
@@ -80,7 +80,7 @@ module Profunctor {o ℓ e} {o′} (C : Category o ℓ e) (D : Category o′ ℓ
     ; homomorphism = λ { {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y → begin
         F₁ (g1 C.∘ f1) ∘ x ∘ f0 ∘ g0    ≈⟨ F.homomorphism ⟩∘⟨ x≈y ⟩∘⟨refl ⟩
         (F₁ g1 ∘ F₁ f1) ∘ y ∘ f0 ∘ g0   ≈⟨ refl⟩∘⟨ D.sym-assoc ⟩
-        (F₁ g1 ∘ F₁ f1) ∘ (y ∘ f0) ∘ g0 ≈⟨ {!   !} ⟩ -- was assoc²''
+        (F₁ g1 ∘ F₁ f1) ∘ (y ∘ f0) ∘ g0 ≈⟨ Equiv.sym assoc²'' ⟩
         F₁ g1 ∘ (F₁ f1 ∘ y ∘ f0) ∘ g0   ∎
       }
     ; F-resp-≈ = λ { {f = f0 , f1} {g = g0 , g1} (f0≈g0 , f1≈g1) {x} {y} x≈y → begin

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -11,6 +11,7 @@ open import Categories.Category.Instance.Setoids
 open import Categories.Functor hiding (id)
 open import Categories.Functor.Bifunctor
 open import Categories.Functor.Hom
+open import Categories.Morphism.Reasoning as MR hiding (assoc²)
 
 module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
 
@@ -20,12 +21,12 @@ module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
   id : ∀ {o ℓ e} → {C : Category o ℓ e} → Profunctor C C
   id {C = C} = Hom[ C ][-,-]
 
-  -- representable profunctor
+  -- representable profunctors
   -- hom(f,1)
   repˡ : (F : Functor C D) → Profunctor D C
   repˡ F = record
     { F₀ = λ (c , d) → record
-      { Carrier = D [ F.F₀ c , d ]
+      { Carrier = D [ F₀ c , d ]
       ; _≈_ = D._≈_
       ; isEquivalence = D.equiv
       }
@@ -35,21 +36,18 @@ module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
       }
     ; identity = λ {x} {y} {y'} y≈y' → begin
         D.id ∘ y ∘ F₁ C.id ≈⟨ D.identityˡ ⟩
-        y ∘ F₁ C.id        ≈⟨ refl⟩∘⟨ Functor.identity F ⟩
-        y ∘ D.id           ≈⟨ D.identityʳ ⟩
+        y ∘ F₁ C.id        ≈⟨ elimʳ D identity ⟩
         y                  ≈⟨ y≈y' ⟩
         y'                 ∎
     ; homomorphism = λ { {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y → begin
-        (g1 ∘ f1) ∘ x ∘ F₁ (f0 C.∘ g0)  ≈⟨ refl⟩∘⟨ refl⟩∘⟨ Functor.homomorphism F ⟩
-        (g1 ∘ f1) ∘ x ∘ F₁ f0 ∘ F₁ g0   ≈⟨ refl⟩∘⟨ x≈y ⟩∘⟨refl ⟩
+        (g1 ∘ f1) ∘ x ∘ F₁ (f0 C.∘ g0)  ≈⟨ refl⟩∘⟨ x≈y ⟩∘⟨ Functor.homomorphism F ⟩
         (g1 ∘ f1) ∘ y ∘ F₁ f0 ∘ F₁ g0   ≈⟨ refl⟩∘⟨ D.Equiv.sym D.assoc ⟩
-        (g1 ∘ f1) ∘ (y ∘ F₁ f0) ∘ F₁ g0 ≈⟨ D.assoc ⟩
-        g1 ∘ f1 ∘ (y ∘ F₁ f0) ∘ F₁ g0   ≈⟨ refl⟩∘⟨ D.Equiv.sym D.assoc ⟩
+        (g1 ∘ f1) ∘ (y ∘ F₁ f0) ∘ F₁ g0 ≈⟨ assoc²'' D ⟩
         g1 ∘ (f1 ∘ y ∘ F₁ f0) ∘ F₁ g0 ∎
       }
     ; F-resp-≈ = λ { {f = f0 , f1} {g = g0 , g1} (f0≈g0 , f1≈g1) {x} {y} x≈y → begin
-        f1 ∘ x ∘ F.F₁ f0 ≈⟨ f1≈g1 ⟩∘⟨ x≈y ⟩∘⟨ F-resp-≈ f0≈g0 ⟩
-        g1 ∘ y ∘ F.F₁ g0 ∎
+        f1 ∘ x ∘ F₁ f0 ≈⟨ f1≈g1 ⟩∘⟨ x≈y ⟩∘⟨ F-resp-≈ f0≈g0 ⟩
+        g1 ∘ y ∘ F₁ g0 ∎
       }
     }
     where
@@ -62,27 +60,26 @@ module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
   repʳ : (F : Functor C D) → Profunctor C D
   repʳ F = record
     { F₀ = λ (c , d) → record
-      { Carrier = D [ c , F.F₀ d ]
+      { Carrier = D [ c , F₀ d ]
       ; _≈_ = D._≈_
       ; isEquivalence = D.equiv
       }
     ; F₁ = λ (f , g) → record
-      { _⟨$⟩_ = λ x → F.F₁ g ∘ x ∘ f
+      { _⟨$⟩_ = λ x → F₁ g ∘ x ∘ f
       ; cong = λ x → begin _ ≈⟨ refl⟩∘⟨ x ⟩∘⟨refl ⟩ _ ∎
       }
     ; identity = λ {x} {y} {y'} y≈y' → begin
-        F.F₁ C.id ∘ y ∘ D.id ≈⟨ (Functor.identity F ⟩∘⟨refl) ⟩
-        D.id ∘ y ∘ D.id      ≈⟨ D.identityˡ ⟩
+        F₁ C.id ∘ y ∘ D.id ≈⟨ elimˡ D identity ⟩
         y ∘ D.id             ≈⟨ D.identityʳ ⟩
         y                    ≈⟨ y≈y' ⟩
         y'                   ∎
     ; homomorphism = λ { {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y → begin
-        F.F₁ (g1 C.∘ f1) ∘ x ∘ f0 ∘ g0    ≈⟨ refl⟩∘⟨ x≈y ⟩∘⟨refl ⟩
-        F.F₁ (g1 C.∘ f1) ∘ y ∘ f0 ∘ g0    ≈⟨ Functor.homomorphism F ⟩∘⟨refl ⟩
-        (F.F₁ g1 ∘ F.F₁ f1) ∘ y ∘ f0 ∘ g0 ≈⟨ D.assoc ⟩
+        F₁ (g1 C.∘ f1) ∘ x ∘ f0 ∘ g0    ≈⟨ refl⟩∘⟨ x≈y ⟩∘⟨refl ⟩
+        F₁ (g1 C.∘ f1) ∘ y ∘ f0 ∘ g0    ≈⟨ Functor.homomorphism F ⟩∘⟨refl ⟩
+        (F₁ g1 ∘ F₁ f1) ∘ y ∘ f0 ∘ g0 ≈⟨ D.assoc ⟩
         F₁ g1 ∘ F₁ f1 ∘ y ∘ f0 ∘ g0       ≈⟨ refl⟩∘⟨ D.Equiv.sym assoc² ⟩
         F₁ g1 ∘ ((F₁ f1 ∘ y) ∘ f0) ∘ g0   ≈⟨ refl⟩∘⟨ D.assoc ⟩∘⟨refl ⟩
-        F.F₁ g1 ∘ (F.F₁ f1 ∘ y ∘ f0) ∘ g0 ∎
+        F₁ g1 ∘ (F₁ f1 ∘ y ∘ f0) ∘ g0 ∎
       }
     ; F-resp-≈ = λ { {f = f0 , f1} {g = g0 , g1} (f0≈g0 , f1≈g1) {x} {y} x≈y → begin
         F₁ f1 ∘ x ∘ f0 ≈⟨ F-resp-≈ f1≈g1 ⟩∘⟨ x≈y ⟩∘⟨ f0≈g0 ⟩

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -4,7 +4,7 @@ module Categories.Functor.Profunctor where
 
 open import Level
 
-open import Data.Product 
+open import Data.Product
 open import Relation.Binary.Bundles
 open import Categories.Category
 open import Categories.Category.Instance.Setoids
@@ -25,7 +25,7 @@ private
     D : Category o′ ℓ′ e′
 
 -- stub for representable profunctors
-repˡ : (F : Functor C D) → Profunctor D C 
+repˡ : (F : Functor C D) → Profunctor D C
 repˡ F = record
   { F₀ = {!   !}
   ; F₁ = {!   !}
@@ -35,10 +35,10 @@ repˡ F = record
   }
   where
   F0 : Σ (Category.Obj C) (λ x → Category.Obj D) → Setoid (ℓ ⊔ ℓ′) (e ⊔ e′)
-  F0 (c , d) = record 
-    { Carrier = {!   !} 
-    ; _≈_ = {! _≈_   !} 
-    ; isEquivalence = record { refl = {!   !} ; sym = {!   !} ; trans = {!   !} } 
+  F0 (c , d) = record
+    { Carrier = {!   !}
+    ; _≈_ = {! _≈_   !}
+    ; isEquivalence = record { refl = {!   !} ; sym = {!   !} ; trans = {!   !} }
     }
 
 repʳ : (F : Functor C D) → Profunctor C D

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -93,15 +93,15 @@ module Profunctor {o ℓ e} {o′} (C : Category o ℓ e) (D : Category o′ ℓ
 
 -- each Prof(C,D) is a category
 homProf : {o o′ ℓ e : Level} → (C : Category o ℓ e) → (D : Category o′ ℓ e) → Category _ _ _
-homProf {o} {o′} {ℓ} {e} C D = record
+homProf C D = record
   { Obj = Profunctor C D
-  ; _⇒_ = λ P Q → NaturalTransformation P Q
+  ; _⇒_ = NaturalTransformation
   ; _≈_ = _≃_
   ; id = id
   ; _∘_ = _∘ᵥ_
   ; assoc     = λ { {f = f} {g} {h} → assoc-lemma {f = f} {g} {h}}
   ; sym-assoc = λ { {f = f} {g} {h} → sym-assoc-lemma {f = f} {g} {h}}
-  ; identityˡ = λ { {f = f} → id-lemmaˡ {f = f}}
+  ; identityˡ = λ { {f = f} → id-lemmaˡ {f = f} }
   ; identityʳ = λ { {f = f} → id-lemmaʳ {f = f} }
   ; identity² = λ z → z
   ; equiv = ≃-isEquivalence

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -14,8 +14,6 @@ open import Categories.Functor.Hom
 
 module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
 
-  open import Categories.Morphism.Reasoning D as MR
-
   Profunctor : ∀ {o ℓ e} {o′ ℓ′ e′} → Category o ℓ e → Category o′ ℓ′ e′ → Set _
   Profunctor {ℓ = ℓ} {e} {ℓ′ = ℓ′} {e′} C D = Bifunctor (Category.op D) C (Setoids (ℓ ⊔ ℓ′) (e ⊔ e′))
 
@@ -24,55 +22,76 @@ module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
 
   -- representable profunctor
   -- hom(f,1)
-  repˡ : (F : Functor C D) → Profunctor {o} {ℓ} {e} {o} {ℓ} {e} D C
+  repˡ : (F : Functor C D) → Profunctor D C
   repˡ F = record
-    { F₀ = λ {(c , d) → record
-        { Carrier = D [ Functor.F₀ F c , d ]
-        ; _≈_ = D._≈_
-        ; isEquivalence = D.equiv
-        }}
-    ; F₁ = λ { {A = A0 , A1} {B = B0 , B1} (f , g) → record
-      { _⟨$⟩_ = λ x → g D.∘ x D.∘ Functor.F₁ F f
-      ; cong = λ x → D.∘-resp-≈ D.Equiv.refl (D.∘-resp-≈ x D.Equiv.refl)
-      }}
+    { F₀ = λ (c , d) → record
+      { Carrier = D [ F.F₀ c , d ]
+      ; _≈_ = D._≈_
+      ; isEquivalence = D.equiv
+      }
+    ; F₁ = λ (f , g) → record
+      { _⟨$⟩_ = λ x → g ∘ x ∘ F₁ f
+      ; cong = λ x → begin _ ≈⟨ refl⟩∘⟨ x ⟩∘⟨refl ⟩ _ ∎
+      }
     ; identity = λ {x} {y} {y'} y≈y' → begin
-      D.id D.∘ y D.∘ Functor.F₁ F C.id ≈⟨ D.identityˡ ⟩
-      y D.∘ Functor.F₁ F C.id ≈⟨ (refl⟩∘⟨ Functor.identity F) ⟩
-      y D.∘ D.id ≈⟨ D.Equiv.trans D.identityʳ y≈y' ⟩
-      y' ∎
-    ; homomorphism = λ { {X = X0 , X1} {Y = Y0 , Y1} {Z = Z0 , Z1} {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y →
-      begin
-       (g1 D.∘ f1) D.∘ x D.∘ Functor.F₁ F (f0 C.∘ g0)              ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ Functor.homomorphism F)) ⟩
-       (g1 D.∘ f1) D.∘ x D.∘ Functor.F₁ F f0 D.∘ Functor.F₁ F g0   ≈⟨ (refl⟩∘⟨ (x≈y ⟩∘⟨refl)) ⟩
-       (g1 D.∘ f1) D.∘ y D.∘ Functor.F₁ F f0 D.∘ Functor.F₁ F g0   ≈⟨ (refl⟩∘⟨ D.Equiv.sym (Category.assoc D)) ⟩
-       (g1 D.∘ f1) D.∘ (y D.∘ Functor.F₁ F f0) D.∘ Functor.F₁ F g0 ≈⟨ Category.assoc D ⟩
-       g1 D.∘ f1 D.∘ (y D.∘ Functor.F₁ F f0) D.∘ Functor.F₁ F g0   ≈⟨ (refl⟩∘⟨ D.Equiv.sym (Category.assoc D)) ⟩
-       g1 D.∘ (f1 D.∘ y D.∘ Functor.F₁ F f0) D.∘ Functor.F₁ F g0 ∎ }
-    ; F-resp-≈ = resp
+        D.id ∘ y ∘ F₁ C.id ≈⟨ D.identityˡ ⟩
+        y ∘ F₁ C.id        ≈⟨ refl⟩∘⟨ Functor.identity F ⟩
+        y ∘ D.id           ≈⟨ D.identityʳ ⟩
+        y                  ≈⟨ y≈y' ⟩
+        y'                 ∎
+    ; homomorphism = λ { {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y → begin
+        (g1 ∘ f1) ∘ x ∘ F₁ (f0 C.∘ g0)  ≈⟨ refl⟩∘⟨ refl⟩∘⟨ Functor.homomorphism F ⟩
+        (g1 ∘ f1) ∘ x ∘ F₁ f0 ∘ F₁ g0   ≈⟨ refl⟩∘⟨ x≈y ⟩∘⟨refl ⟩
+        (g1 ∘ f1) ∘ y ∘ F₁ f0 ∘ F₁ g0   ≈⟨ refl⟩∘⟨ D.Equiv.sym D.assoc ⟩
+        (g1 ∘ f1) ∘ (y ∘ F₁ f0) ∘ F₁ g0 ≈⟨ D.assoc ⟩
+        g1 ∘ f1 ∘ (y ∘ F₁ f0) ∘ F₁ g0   ≈⟨ refl⟩∘⟨ D.Equiv.sym D.assoc ⟩
+        g1 ∘ (f1 ∘ y ∘ F₁ f0) ∘ F₁ g0 ∎
+      }
+    ; F-resp-≈ = λ { {f = f0 , f1} {g = g0 , g1} (f0≈g0 , f1≈g1) {x} {y} x≈y → begin
+        f1 ∘ x ∘ F.F₁ f0 ≈⟨ f1≈g1 ⟩∘⟨ x≈y ⟩∘⟨ F-resp-≈ f0≈g0 ⟩
+        g1 ∘ y ∘ F.F₁ g0 ∎
+      }
     }
     where
      module C = Category C
-     module D = Category D
+     open module D = Category D
+     open module F = Functor F
      open D.HomReasoning
-     resp : {A B : Σ C.Obj (λ x → D.Obj)}
-      {f g : Σ (proj₁ B C.⇒ proj₁ A) (λ x → proj₂ A D.⇒ proj₂ B)} →
-      Σ (proj₁ f C.≈ proj₁ g) (λ x → proj₂ f D.≈ proj₂ g) →
-      {x y : Functor.F₀ F (proj₁ A) D.⇒ proj₂ A} →
-      x D.≈ y →
-      proj₂ f D.∘ x D.∘ Functor.F₁ F (proj₁ f) D.≈
-      proj₂ g D.∘ y D.∘ Functor.F₁ F (proj₁ g)
-     resp {A = A0 , A1} {B = B0 , B1} {f = f0 , f1} {g = g0 , g1} (eq0 , eq1) {x} {y} eq' = begin
-       f1 D.∘ x D.∘ Functor.F₁ F f0 ≈⟨ (refl⟩∘⟨ (eq' ⟩∘⟨refl)) ⟩
-       f1 D.∘ y D.∘ Functor.F₁ F f0 ≈⟨ D.∘-resp-≈ eq1 D.Equiv.refl ⟩
-       g1 D.∘ y D.∘ Functor.F₁ F f0 ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ Functor.F-resp-≈ F eq0)) ⟩
-       g1 D.∘ y D.∘ Functor.F₁ F g0 ∎
 
   -- hom(1,f)
   repʳ : (F : Functor C D) → Profunctor C D
   repʳ F = record
-    { F₀ = λ x → {!   !}
-    ; F₁ = {!   !}
-    ; identity = {!   !}
-    ; homomorphism = {!   !}
-    ; F-resp-≈ = {!   !}
+    { F₀ = λ (c , d) → record
+      { Carrier = D [ c , F.F₀ d ]
+      ; _≈_ = D._≈_
+      ; isEquivalence = D.equiv
+      }
+    ; F₁ = λ (f , g) → record
+      { _⟨$⟩_ = λ x → F.F₁ g ∘ x ∘ f
+      ; cong = λ x → begin _ ≈⟨ refl⟩∘⟨ x ⟩∘⟨refl ⟩ _ ∎
+      }
+    ; identity = λ {x} {y} {y'} y≈y' → begin
+        F.F₁ C.id ∘ y ∘ D.id ≈⟨ (Functor.identity F ⟩∘⟨refl) ⟩
+        D.id ∘ y ∘ D.id      ≈⟨ D.identityˡ ⟩
+        y ∘ D.id             ≈⟨ D.identityʳ ⟩
+        y                    ≈⟨ y≈y' ⟩
+        y'                   ∎
+    ; homomorphism = λ { {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y → begin
+        F.F₁ (g1 C.∘ f1) ∘ x ∘ f0 ∘ g0    ≈⟨ refl⟩∘⟨ x≈y ⟩∘⟨refl ⟩
+        F.F₁ (g1 C.∘ f1) ∘ y ∘ f0 ∘ g0    ≈⟨ Functor.homomorphism F ⟩∘⟨refl ⟩
+        (F.F₁ g1 ∘ F.F₁ f1) ∘ y ∘ f0 ∘ g0 ≈⟨ D.assoc ⟩
+        F₁ g1 ∘ F₁ f1 ∘ y ∘ f0 ∘ g0       ≈⟨ refl⟩∘⟨ D.Equiv.sym assoc² ⟩
+        F₁ g1 ∘ ((F₁ f1 ∘ y) ∘ f0) ∘ g0   ≈⟨ refl⟩∘⟨ D.assoc ⟩∘⟨refl ⟩
+        F.F₁ g1 ∘ (F.F₁ f1 ∘ y ∘ f0) ∘ g0 ∎
+      }
+    ; F-resp-≈ = λ { {f = f0 , f1} {g = g0 , g1} (f0≈g0 , f1≈g1) {x} {y} x≈y → begin
+        F₁ f1 ∘ x ∘ f0 ≈⟨ F-resp-≈ f1≈g1 ⟩∘⟨ x≈y ⟩∘⟨ f0≈g0 ⟩
+        F₁ g1 ∘ y ∘ g0 ∎
+      }
     }
+    where
+      module C = Category C
+      open module D = Category D
+      open module F = Functor F
+      open D.HomReasoning
+      open import Categories.Morphism.Reasoning D using (assoc²)

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -4,8 +4,11 @@ module Categories.Functor.Profunctor where
 
 open import Level
 
+open import Data.Product 
+open import Relation.Binary.Bundles
 open import Categories.Category
 open import Categories.Category.Instance.Setoids
+open import Categories.Functor hiding (id)
 open import Categories.Functor.Bifunctor
 open import Categories.Functor.Hom
 
@@ -14,3 +17,35 @@ Profunctor {ℓ = ℓ} {e} {ℓ′ = ℓ′} {e′} C D = Bifunctor (Category.op
 
 id : ∀ {o ℓ e} → {C : Category o ℓ e} → Profunctor C C
 id {C = C} = Hom[ C ][-,-]
+
+private
+  variable
+    o ℓ e o′ ℓ′ e′ : Level
+    C : Category o ℓ e
+    D : Category o′ ℓ′ e′
+
+-- stub for representable profunctors
+repˡ : (F : Functor C D) → Profunctor D C 
+repˡ F = record
+  { F₀ = {!   !}
+  ; F₁ = {!   !}
+  ; identity = {!   !}
+  ; homomorphism = {!   !}
+  ; F-resp-≈ = {!   !}
+  }
+  where
+  F0 : Σ (Category.Obj C) (λ x → Category.Obj D) → Setoid (ℓ ⊔ ℓ′) (e ⊔ e′)
+  F0 (c , d) = record 
+    { Carrier = {!   !} 
+    ; _≈_ = {! _≈_   !} 
+    ; isEquivalence = record { refl = {!   !} ; sym = {!   !} ; trans = {!   !} } 
+    }
+
+repʳ : (F : Functor C D) → Profunctor C D
+repʳ F = record
+  { F₀ = λ x → {!   !}
+  ; F₁ = {!   !}
+  ; identity = {!   !}
+  ; homomorphism = {!   !}
+  ; F-resp-≈ = {!   !}
+  }

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -11,7 +11,6 @@ open import Categories.Category.Instance.Setoids
 open import Categories.Functor hiding (id)
 open import Categories.Functor.Bifunctor
 open import Categories.Functor.Hom
-open import Categories.Morphism.Reasoning as MR hiding (assoc²)
 
 module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
 
@@ -36,13 +35,13 @@ module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
       }
     ; identity = λ {x} {y} {y'} y≈y' → begin
         D.id ∘ y ∘ F₁ C.id ≈⟨ D.identityˡ ⟩
-        y ∘ F₁ C.id        ≈⟨ elimʳ D identity ⟩
+        y ∘ F₁ C.id        ≈⟨ elimʳ identity ⟩
         y                  ≈⟨ y≈y' ⟩
         y'                 ∎
     ; homomorphism = λ { {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y → begin
         (g1 ∘ f1) ∘ x ∘ F₁ (f0 C.∘ g0)  ≈⟨ refl⟩∘⟨ x≈y ⟩∘⟨ Functor.homomorphism F ⟩
         (g1 ∘ f1) ∘ y ∘ F₁ f0 ∘ F₁ g0   ≈⟨ refl⟩∘⟨ D.Equiv.sym D.assoc ⟩
-        (g1 ∘ f1) ∘ (y ∘ F₁ f0) ∘ F₁ g0 ≈⟨ assoc²'' D ⟩
+        (g1 ∘ f1) ∘ (y ∘ F₁ f0) ∘ F₁ g0 ≈⟨ assoc²'' ⟩
         g1 ∘ (f1 ∘ y ∘ F₁ f0) ∘ F₁ g0 ∎
       }
     ; F-resp-≈ = λ { {f = f0 , f1} {g = g0 , g1} (f0≈g0 , f1≈g1) {x} {y} x≈y → begin
@@ -55,6 +54,7 @@ module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
      open module D = Category D
      open module F = Functor F
      open D.HomReasoning
+     open import Categories.Morphism.Reasoning D using (assoc²; assoc²''; elimʳ)
 
   -- hom(1,f)
   repʳ : (F : Functor C D) → Profunctor C D
@@ -69,7 +69,7 @@ module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
       ; cong = λ x → begin _ ≈⟨ refl⟩∘⟨ x ⟩∘⟨refl ⟩ _ ∎
       }
     ; identity = λ {x} {y} {y'} y≈y' → begin
-        F₁ C.id ∘ y ∘ D.id ≈⟨ elimˡ D identity ⟩
+        F₁ C.id ∘ y ∘ D.id ≈⟨ elimˡ identity ⟩
         y ∘ D.id             ≈⟨ D.identityʳ ⟩
         y                    ≈⟨ y≈y' ⟩
         y'                   ∎
@@ -91,4 +91,4 @@ module Profunctor {o ℓ e} (C : Category o ℓ e) (D : Category o ℓ e) where
       open module D = Category D
       open module F = Functor F
       open D.HomReasoning
-      open import Categories.Morphism.Reasoning D using (assoc²)
+      open import Categories.Morphism.Reasoning D using (assoc²; elimˡ)

--- a/src/Categories/Functor/Profunctor.agda
+++ b/src/Categories/Functor/Profunctor.agda
@@ -49,7 +49,7 @@ module Profunctor {o ℓ e} {o′} (C : Category o ℓ e) (D : Category o′ ℓ
     ; homomorphism = λ { {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y → begin
         (g1 ∘ f1) ∘ x ∘ F₁ (f0 C.∘ g0)  ≈⟨ refl⟩∘⟨ x≈y ⟩∘⟨ F.homomorphism ⟩
         (g1 ∘ f1) ∘ y ∘ F₁ f0 ∘ F₁ g0   ≈⟨ refl⟩∘⟨ D.sym-assoc ⟩
-        (g1 ∘ f1) ∘ (y ∘ F₁ f0) ∘ F₁ g0 ≈⟨ assoc²'' ⟩
+        (g1 ∘ f1) ∘ (y ∘ F₁ f0) ∘ F₁ g0 ≈⟨ {!   !} ⟩ -- was assoc²''
         g1 ∘ (f1 ∘ y ∘ F₁ f0) ∘ F₁ g0 ∎
       }
     ; F-resp-≈ = λ { {f = f0 , f1} {g = g0 , g1} (f0≈g0 , f1≈g1) {x} {y} x≈y → begin
@@ -80,7 +80,7 @@ module Profunctor {o ℓ e} {o′} (C : Category o ℓ e) (D : Category o′ ℓ
     ; homomorphism = λ { {f = f0 , f1} {g = g0 , g1} {x} {y} x≈y → begin
         F₁ (g1 C.∘ f1) ∘ x ∘ f0 ∘ g0    ≈⟨ F.homomorphism ⟩∘⟨ x≈y ⟩∘⟨refl ⟩
         (F₁ g1 ∘ F₁ f1) ∘ y ∘ f0 ∘ g0   ≈⟨ refl⟩∘⟨ D.sym-assoc ⟩
-        (F₁ g1 ∘ F₁ f1) ∘ (y ∘ f0) ∘ g0 ≈⟨ assoc²'' ⟩
+        (F₁ g1 ∘ F₁ f1) ∘ (y ∘ f0) ∘ g0 ≈⟨ {!   !} ⟩ -- was assoc²''
         F₁ g1 ∘ (F₁ f1 ∘ y ∘ f0) ∘ g0   ∎
       }
     ; F-resp-≈ = λ { {f = f0 , f1} {g = g0 , g1} (f0≈g0 , f1≈g1) {x} {y} x≈y → begin

--- a/src/Categories/Morphism/Reasoning/Core.agda
+++ b/src/Categories/Morphism/Reasoning/Core.agda
@@ -48,6 +48,9 @@ module Utils where
   assoc²' : (i ∘ (h ∘ g)) ∘ f ≈ i ∘ (h ∘ (g ∘ f))
   assoc²' = Equiv.trans assoc (∘-resp-≈ʳ assoc)
 
+  assoc²'' : (i ∘ h) ∘ g ∘ f ≈ i ∘ ((h ∘ g) ∘ f)
+  assoc²'' = Equiv.trans assoc (∘-resp-≈ʳ  (Equiv.sym assoc))
+
 open Utils public
 
 module Pulls (ab≡c : a ∘ b ≈ c) where

--- a/src/Categories/Morphism/Reasoning/Core.agda
+++ b/src/Categories/Morphism/Reasoning/Core.agda
@@ -48,8 +48,8 @@ module Utils where
   assoc²' : (i ∘ (h ∘ g)) ∘ f ≈ i ∘ (h ∘ (g ∘ f))
   assoc²' = Equiv.trans assoc (∘-resp-≈ʳ assoc)
 
-  assoc²'' : i ∘ ((h ∘ g) ∘ f) ≈ (i ∘ h) ∘ (g ∘ f)
-  assoc²'' = Equiv.trans (∘-resp-≈ʳ assoc) (Equiv.sym assoc)
+  assoc²'' : (i ∘ h) ∘ g ∘ f ≈ i ∘ ((h ∘ g) ∘ f)
+  assoc²'' = Equiv.trans assoc (∘-resp-≈ʳ  (Equiv.sym assoc))
 
 open Utils public
 

--- a/src/Categories/Morphism/Reasoning/Core.agda
+++ b/src/Categories/Morphism/Reasoning/Core.agda
@@ -48,8 +48,8 @@ module Utils where
   assoc²' : (i ∘ (h ∘ g)) ∘ f ≈ i ∘ (h ∘ (g ∘ f))
   assoc²' = Equiv.trans assoc (∘-resp-≈ʳ assoc)
 
-  assoc²'' : (i ∘ h) ∘ g ∘ f ≈ i ∘ ((h ∘ g) ∘ f)
-  assoc²'' = Equiv.trans assoc (∘-resp-≈ʳ  (Equiv.sym assoc))
+  assoc²'' : i ∘ ((h ∘ g) ∘ f) ≈ (i ∘ h) ∘ (g ∘ f)
+  assoc²'' = Equiv.trans (∘-resp-≈ʳ assoc) (Equiv.sym assoc)
 
 open Utils public
 

--- a/src/Categories/Morphism/Reasoning/Core.agda
+++ b/src/Categories/Morphism/Reasoning/Core.agda
@@ -49,7 +49,7 @@ module Utils where
   assoc²' = Equiv.trans assoc (∘-resp-≈ʳ assoc)
 
   assoc²'' : i ∘ ((h ∘ g) ∘ f) ≈ (i ∘ h) ∘ (g ∘ f)
-  assoc²'' = Equiv.trans (∘-resp-≈ʳ assoc) (Equiv.sym assoc)
+  assoc²'' = Equiv.trans (∘-resp-≈ʳ assoc) sym-assoc
 
 open Utils public
 


### PR DESCRIPTION
Any functor `F : C -> D` induces two "representable" profunctors 

`hom(F,1) : (c,d) \mapsto D(Fc,d)`

and 

`hom(1,F) : (d,c) \mapsto D(d, Fc)`