### PR TITLE
Define Lifting Properties

### DIFF
--- a/src/Categories/Category/Construction/Arrow.agda
+++ b/src/Categories/Category/Construction/Arrow.agda
@@ -22,6 +22,7 @@ private
     A B D E : Obj
 
 record Morphism : Set (o ⊔ ℓ) where
+  constructor mor
   field
     {dom} : Obj
     {cod} : Obj

--- a/src/Categories/Diagram/Pushout.agda
+++ b/src/Categories/Diagram/Pushout.agda
@@ -6,12 +6,17 @@ module Categories.Diagram.Pushout {o ℓ e} (C : Category o ℓ e) where
 
 open Category C
 open HomReasoning
+open Equiv
+
+open import Categories.Morphism.Reasoning C as Square
+  renaming (glue to glue-square) hiding (id-unique)
 
 open import Level
 
 private
   variable
     A B E X Y Z : Obj
+    f g h j : A ⇒ B
 
 record Pushout (f : X ⇒ Y) (g : X ⇒ Z) : Set (o ⊔ ℓ ⊔ e) where
   field
@@ -30,3 +35,12 @@ record Pushout (f : X ⇒ Y) (g : X ⇒ Z) : Set (o ⊔ ℓ ⊔ e) where
                          universal eq ∘ i₁ ≈ h₁
     universal∘i₂≈h₂  : {h₁ : Y ⇒ E} {h₂ : Z ⇒ E} {eq : h₁ ∘ f ≈ h₂ ∘ g} →
                          universal eq ∘ i₂ ≈ h₂
+
+  unique-diagram : h ∘ i₁ ≈ j ∘ i₁ →
+                   h ∘ i₂ ≈ j ∘ i₂ →
+                   h ≈ j
+  unique-diagram {h = h} {j = j} eq₁ eq₂ = begin
+    h            ≈⟨ unique eq₁ eq₂ ⟩
+    universal eq ≈˘⟨ unique refl refl ⟩
+    j            ∎
+    where eq = extendˡ commute

--- a/src/Categories/Morphism.agda
+++ b/src/Categories/Morphism.agda
@@ -50,6 +50,12 @@ g SectionOf f = f ∘ g ≈ id
 _RetractOf_ : (g : B ⇒ A) (f : A ⇒ B) → Set e
 g RetractOf f = g ∘ f ≈ id
 
+record Retract (X U : Obj) : Set (ℓ ⊔ e) where
+  field
+    section : X ⇒ U
+    retract : U ⇒ X
+    is-retract : retract ∘ section ≈ id
+
 record Iso (from : A ⇒ B) (to : B ⇒ A) : Set e where
   field
     isoˡ : to ∘ from ≈ id

--- a/src/Categories/Morphism.agda
+++ b/src/Categories/Morphism.agda
@@ -61,6 +61,16 @@ record Iso (from : A ⇒ B) (to : B ⇒ A) : Set e where
     isoˡ : to ∘ from ≈ id
     isoʳ : from ∘ to ≈ id
 
+-- We often say that a morphism "is an iso" if there exists some inverse to it.
+-- This does buck the naming convention we use somewhat, but it lines up
+-- better with the literature.
+record IsIso (from : A ⇒ B) : Set (ℓ ⊔ e) where
+  field
+    inv : B ⇒ A
+    iso : Iso from inv 
+
+  open Iso iso public
+
 infix 4 _≅_
 record _≅_ (A B : Obj) : Set (ℓ ⊔ e) where
   field

--- a/src/Categories/Morphism/Lifts.agda
+++ b/src/Categories/Morphism/Lifts.agda
@@ -26,29 +26,44 @@ open Definitions 𝒞
 --   V ╱     V
 --   B ────> Y
 --      g
+--
+-- Note that the filler is /not/ required to be unique.
+--
+-- For ease of use, we define lifts in two steps:
+-- * 'Filler' describes the data required to fill a /particular/ commutative square.
+-- * 'Lifts' then quantifies over all commutative squares.
 
-record Lifts {A B X Y} (i : A ⇒ B) (p : X ⇒ Y) : Set (ℓ ⊔ e) where
+record Filler {A B X Y} {i : A ⇒ B} {f : A ⇒ X} {g : B ⇒ Y} {p : X ⇒ Y}
+              (comm : CommutativeSquare i f g p) : Set (ℓ ⊔ e) where
   field
-    -- The diagonal filler of a given commutative square. Note that this
-    -- isn't required to be unique.
-    filler : ∀ {f : A ⇒ X} {g : B ⇒ Y} → CommutativeSquare i f g p → B ⇒ X
-    -- The "left" triangle of the diagram must commute.
-    fill-commˡ : ∀ {f g} → (sq : CommutativeSquare i f g p) → filler sq ∘ i ≈ f
-    -- The "right" triangle of the diagram must commute.
-    fill-commʳ : ∀ {f g} → (sq : CommutativeSquare i f g p) → p ∘ filler sq ≈ g
+    filler : B ⇒ X
+    fill-commˡ : filler ∘ i ≈ f
+    fill-commʳ : p ∘ filler ≈ g
 
--- We often want to discuss lifting properties with respect to /classes/ of morphisms,
--- not just individual morphisms.
+Lifts : ∀ {A B X Y} → (i : A ⇒ B) → (p : X ⇒ Y) → Set (ℓ ⊔ e)
+Lifts i p = ∀ {f g} → (comm : CommutativeSquare i f g p) → Filler comm
+
+--------------------------------------------------------------------------------
+-- Lifings of Morphism Classes
 
 -- Shorthand for denoting a class of morphisms.
 MorphismClass : (p : Level) → Set (o ⊔ ℓ ⊔ suc p)
 MorphismClass p = ∀ {X Y} → X ⇒ Y → Set p
 
--- A morphisms has the left lifting property with respect to a class of morphisms 'P'
--- if it has the left lifting property with each element of 'P'.
-LeftLifts : ∀ {p} {A B} → (i : A ⇒ B) → MorphismClass p → Set (o ⊔ ℓ ⊔ e ⊔ p)
-LeftLifts i P = ∀ {X Y} → (f : X ⇒ Y) → P f → Lifts i f
+-- A morphism 'i' is called "projective" with respect to some morphism class 'J'
+-- if it has the left-lifting property against every element of 'J'.
+Projective : ∀ {j} {A B} → MorphismClass j → (i : A ⇒ B) → Set (o ⊔ ℓ ⊔ e ⊔ j)
+Projective J i = ∀ {X Y} → (f : X ⇒ Y) → J f → Lifts i f
 
--- The situation is analogous for right lifting properties.
-RightLifts : ∀ {p} {A B} → (i : A ⇒ B) → MorphismClass p → Set (o ⊔ ℓ ⊔ e ⊔ p)
-RightLifts i P = ∀ {X Y} → (f : X ⇒ Y) → P f → Lifts f i
+-- Dually, a morphism 'i' is called "injective" with repsect to a morphism class 'J'
+-- if it has the right-lifting property against every element of 'J'.
+Injective : ∀ {j} {A B} → MorphismClass j → (i : A ⇒ B) → Set (o ⊔ ℓ ⊔ e ⊔ j)
+Injective J i = ∀ {X Y} → (f : X ⇒ Y) → J f → Lifts f i
+
+-- The class of J-Projective morphisms.
+Proj : ∀ {j} (J : MorphismClass j) → MorphismClass (o ⊔ ℓ ⊔ e ⊔ j)
+Proj J = Projective J
+
+-- The class of J-Injective morphisms.
+Inj : ∀ {j} (J : MorphismClass j) → MorphismClass (o ⊔ ℓ ⊔ e ⊔ j)
+Inj J = Injective J

--- a/src/Categories/Morphism/Lifts.agda
+++ b/src/Categories/Morphism/Lifts.agda
@@ -1,0 +1,54 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category
+
+-- Lifting Properties
+module Categories.Morphism.Lifts {o ℓ e} (𝒞 : Category o ℓ e) where
+
+open import Level
+
+open Category 𝒞
+open Definitions 𝒞
+
+-- A pair of morphisms has the lifting property if every commutative
+-- square admits a diagonal filler. We say that 'i' has the left lifting
+-- property with respect to 'p', and that 'p' has the right lifting property
+-- with respect to 'i'.
+--
+-- Graphically, the situation is as follows:
+--
+--      f
+--   A ────> X
+--   │     ^ │
+--   │  ∃ ╱  │
+-- i │   ╱   │ p
+--   │  ╱    │
+--   V ╱     V
+--   B ────> Y
+--      g
+
+record Lifts {A B X Y} (i : A ⇒ B) (p : X ⇒ Y) : Set (ℓ ⊔ e) where
+  field
+    -- The diagonal filler of a given commutative square. Note that this
+    -- isn't required to be unique.
+    filler : ∀ {f : A ⇒ X} {g : B ⇒ Y} → CommutativeSquare i f g p → B ⇒ X
+    -- The "left" triangle of the diagram must commute.
+    fill-commˡ : ∀ {f g} → (sq : CommutativeSquare i f g p) → filler sq ∘ i ≈ f
+    -- The "right" triangle of the diagram must commute.
+    fill-commʳ : ∀ {f g} → (sq : CommutativeSquare i f g p) → p ∘ filler sq ≈ g
+
+-- We often want to discuss lifting properties with respect to /classes/ of morphisms,
+-- not just individual morphisms.
+
+-- Shorthand for denoting a class of morphisms.
+MorphismClass : (p : Level) → Set (o ⊔ ℓ ⊔ suc p)
+MorphismClass p = ∀ {X Y} → X ⇒ Y → Set p
+
+-- A morphisms has the left lifting property with respect to a class of morphisms 'P'
+-- if it has the left lifting property with each element of 'P'.
+LeftLifts : ∀ {p} {A B} → (i : A ⇒ B) → MorphismClass p → Set (o ⊔ ℓ ⊔ e ⊔ p)
+LeftLifts i P = ∀ {X Y} → (f : X ⇒ Y) → P f → Lifts i f
+
+-- The situation is analogous for right lifting properties.
+RightLifts : ∀ {p} {A B} → (i : A ⇒ B) → MorphismClass p → Set (o ⊔ ℓ ⊔ e ⊔ p)
+RightLifts i P = ∀ {X Y} → (f : X ⇒ Y) → P f → Lifts f i

--- a/src/Categories/Morphism/Lifts/Properties.agda
+++ b/src/Categories/Morphism/Lifts/Properties.agda
@@ -1,0 +1,191 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category
+
+module Categories.Morphism.Lifts.Properties {o ℓ e} (𝒞 : Category o ℓ e) where
+
+open import Level
+open import Data.Product using (_,_; proj₁; proj₂)
+
+open import Categories.Category.Construction.Arrow 𝒞
+
+open import Categories.Diagram.Pullback 𝒞
+open import Categories.Diagram.Pushout 𝒞
+
+open import Categories.Morphism.Lifts 𝒞
+
+open import Categories.Morphism.Reasoning 𝒞 renaming (glue to glue-■)
+import Categories.Morphism as Mor
+
+open Category 𝒞
+open Definitions 𝒞
+open HomReasoning
+
+-- We want to talk about retracts of morphisms, so
+-- we don't use the definition of 'Retract' applied to '𝒞'
+open Mor 𝒞 hiding (Retract)
+open Mor using (Retract)
+open Morphism⇒
+
+--------------------------------------------------------------------------------
+-- Lifting and Retractions
+
+module _ {X Y T} {f : X ⇒ Y} {i : X ⇒ T} {p : T ⇒ Y} (factors : f ≈ p ∘ i) where
+
+  -- If 'f' factors into 'p ∘ i' and 'f' has the left lifting property
+  -- with respect to 'p', then 'f' is a retraction of 'i' in the arrow
+  -- category of 𝒞.
+  retract-liftˡ : Lifts f p → Retract Arrow (mor f) (mor i)
+  retract-liftˡ lifts = record
+    { section = mor⇒ (fill-commˡ ○ ⟺ identityʳ)
+    ; retract = mor⇒ (⟺ factors ○ ⟺ identityʳ)
+    ; is-retract = identity² , fill-commʳ
+    }
+    where
+      open Filler (lifts (identityˡ ○ factors))
+
+  -- We have an analogous situation for right lifts.
+  retract-liftʳ : Lifts i f → Retract Arrow (mor f) (mor p)
+  retract-liftʳ lifts = record
+    { section = mor⇒ (identityˡ ○ factors)
+    ; retract = mor⇒ (identityˡ ○ ⟺ fill-commʳ)
+    ; is-retract = fill-commˡ , identity²
+    }
+    where
+      open Filler (lifts (⟺ factors ○ ⟺ identityʳ))
+
+--------------------------------------------------------------------------------
+-- Closure Properties of Injective and Projective morphisms.
+
+module _ {j} (J : MorphismClass j) where
+  private
+    variable
+      X Y Z : Obj
+      f g h i p : X ⇒ Y
+
+  -- If 'f' is an isomorphism, then it must be J-Projective.
+  iso-proj : ∀ {X Y} (f : X ⇒ Y) → IsIso f → Proj J f
+  iso-proj f f-iso g g∈J {h} {i} comm = record
+    { filler = h ∘ inv
+    ; fill-commˡ = cancelʳ isoˡ
+    ; fill-commʳ = extendʳ (⟺ comm) ○ elimʳ isoʳ
+    }
+    where
+      open IsIso f-iso
+
+  -- Dually, If 'f' is an isomorphism, then it must be J-Injective.
+  iso-inj : ∀ {X Y} (f : X ⇒ Y) → IsIso f → Inj J f
+  iso-inj f f-iso g g∈J {h} {i} comm = record
+    { filler = inv ∘ i
+    ; fill-commˡ = extendˡ comm ○ elimˡ isoˡ
+    ; fill-commʳ = cancelˡ isoʳ
+    }
+    where
+      open IsIso f-iso
+
+  -- J-Projective morphisms are closed under composition.
+  proj-∘ : ∀ {X Y Z} {f : Y ⇒ Z} {g : X ⇒ Y} → Proj J f → Proj J g → Proj J (f ∘ g)
+  proj-∘ {f = f} {g = g} f-proj g-proj h h∈J {k} {i} comm = record
+    { filler = UpperFiller.filler
+    ; fill-commˡ = begin
+        UpperFiller.filler ∘ f ∘ g
+      ≈⟨ pullˡ UpperFiller.fill-commˡ ⟩
+        LowerFiller.filler ∘ g
+      ≈⟨ LowerFiller.fill-commˡ ⟩
+        k
+      ∎
+
+    ; fill-commʳ = UpperFiller.fill-commʳ
+    }
+    where
+      module LowerFiller = Filler (g-proj h h∈J (assoc ○ comm))
+      module UpperFiller = Filler (f-proj h h∈J (⟺ LowerFiller.fill-commʳ))
+
+  -- J-Injective morphisms are closed under composition.
+  inj-∘ : ∀ {X Y Z} {f : Y ⇒ Z} {g : X ⇒ Y} → Inj J f → Inj J g → Inj J (f ∘ g)
+  inj-∘ {f = f} {g = g} f-inj g-inj h h∈J {k} {i} comm = record
+    { filler = LowerFiller.filler
+    ; fill-commˡ = LowerFiller.fill-commˡ
+    ; fill-commʳ = begin
+        (f ∘ g) ∘ LowerFiller.filler
+      ≈⟨ pullʳ LowerFiller.fill-commʳ ⟩
+        f ∘ UpperFiller.filler
+      ≈⟨ UpperFiller.fill-commʳ ⟩
+        i
+      ∎
+    }
+    where
+      module UpperFiller = Filler (f-inj h h∈J (comm ○ assoc))
+      module LowerFiller = Filler (g-inj h h∈J UpperFiller.fill-commˡ)
+
+  -- J-Projective morphisms are stable under pushout.
+  proj-pushout : ∀ {X Y Z} {p : X ⇒ Y} {f : X ⇒ Z} → (P : Pushout p f) → Proj J p → Proj J (Pushout.i₂ P)
+  proj-pushout {p = p} {f = f} po p-proj h h∈J sq = record
+    { filler = universal fill-commˡ
+    ; fill-commˡ = universal∘i₂≈h₂
+    ; fill-commʳ = unique-diagram (pullʳ universal∘i₁≈h₁ ○ fill-commʳ) (pullʳ universal∘i₂≈h₂ ○ ⟺ sq)
+    }
+    where
+      open Pushout po
+      open Filler (p-proj h h∈J (glue-■ sq commute))
+  
+  -- J-Injective morphisms are stable under pullback.
+  inj-pullback : ∀ {X Y Z} {i : X ⇒ Z} {f : Y ⇒ Z} → (P : Pullback i f) → Inj J i → Inj J (Pullback.p₂ P)
+  inj-pullback {i = i} {f = f} pb i-inj h h∈J sq = record
+    { filler = universal fill-commʳ
+    ; fill-commˡ = unique-diagram (pullˡ p₁∘universal≈h₁ ○ fill-commˡ) (pullˡ p₂∘universal≈h₂ ○ sq)
+    ; fill-commʳ = p₂∘universal≈h₂
+    }
+    where
+      open Pullback pb
+      open Filler (i-inj h h∈J (glue-■ (⟺ commute) sq))
+
+  -- J-Projective morphisms are stable under retractions.
+  proj-retract : Proj J p → Retract Arrow (mor f) (mor p) → Proj J f
+  proj-retract {p = p} {f = f} p-proj f-retracts h h∈J {g} {k} sq = record
+    { filler = filler ∘ cod⇒ section
+    ; fill-commˡ = begin
+        (filler ∘ cod⇒ section) ∘ f
+      ≈⟨ extendˡ (square section) ⟩
+        (filler ∘ p) ∘ dom⇒ section
+      ≈⟨ fill-commˡ ⟩∘⟨refl ⟩
+        (g ∘ dom⇒ retract) ∘ dom⇒ section
+      ≈⟨ cancelʳ (proj₁ is-retract) ⟩
+        g
+      ∎
+    ; fill-commʳ = begin
+        h ∘ filler ∘ cod⇒ section
+      ≈⟨ extendʳ fill-commʳ ⟩
+        k ∘ (cod⇒ retract ∘ cod⇒ section)
+      ≈⟨ elimʳ (proj₂ is-retract) ⟩
+        k
+      ∎
+    }
+    where
+      open Retract f-retracts
+      open Filler (p-proj h h∈J (glue-■ sq (square retract)))
+
+  -- J-Injective morphisms are stable under retractions.
+  inj-retract : Inj J i → Retract Arrow (mor f) (mor i) → Inj J f
+  inj-retract {i = i} {f = f} i-inj f-retracts h h∈J {g} {k} sq = record
+    { filler = dom⇒ retract ∘ filler
+    ; fill-commˡ = begin
+        (dom⇒ retract ∘ filler) ∘ h
+      ≈⟨ extendˡ fill-commˡ ⟩
+        (dom⇒ retract ∘ dom⇒ section) ∘ g
+      ≈⟨ elimˡ (proj₁ is-retract) ⟩
+        g
+      ∎
+    ; fill-commʳ = begin
+        f ∘ dom⇒ retract ∘ filler
+      ≈⟨ extendʳ (⟺ (square retract)) ⟩
+        cod⇒ retract ∘ i ∘ filler
+      ≈⟨ refl⟩∘⟨ fill-commʳ ⟩
+        cod⇒ retract ∘ cod⇒ section ∘ k
+      ≈⟨ cancelˡ (proj₂ is-retract) ⟩
+        k
+      ∎
+    }
+    where
+      open Retract f-retracts
+      open Filler (i-inj h h∈J (glue-■ (square section) sq))


### PR DESCRIPTION
## Patch Description

This PR defines [Lifting Properties](http://nlab-pages.s3.us-east-2.amazonaws.com/nlab/show/lift), [Injective and Projective Morphisms](nlab-pages.s3.us-east-2.amazonaws.com/nlab/show/injective+or+projective+morphism), and also proves a pile of lemmas about them.

## Notes
I often find myself looking for the following definition, so I've added it:
```agda
record IsIso (from : A ⇒ B) : Set (ℓ ⊔ e) where
  field
    inv : B ⇒ A
    iso : Iso from inv 

  open Iso iso public
  ```
  
This does _somewhat_ violate the naming scheme we use in the library, but it lines up with the literature so I think it's a reasonable name.

I've also been using `Retract Arrow` for retracts of morphisms, which feels a bit klunky? Perhaps it might make sense to define that notion on it's own.