### PR TITLE
Implementation of Lax Slice bicategory

### DIFF
--- a/src/Categories/Bicategory/Construction/LaxSlice.agda
+++ b/src/Categories/Bicategory/Construction/LaxSlice.agda
@@ -53,13 +53,11 @@ module SliceHom (A : Obj) where
       {ϕ} : J.h ⇒₂ K.h
       E   : K.Δ ≈ (Y.arr ▷ ϕ ∘ᵥ J.Δ)
 
-
   _∘ᵥ/_ : ∀ {X Y : SliceObj A}{J K L : Slice⇒₁ X Y} → Slice⇒₂ K L → Slice⇒₂ J K → Slice⇒₂ J L
   _∘ᵥ/_ {X}{Y}{J}{K}{L} (slicearr₂ {ϕ = ϕ} E) (slicearr₂ {ϕ = ψ} F) = slicearr₂ {ϕ = ϕ ∘ᵥ ψ} $ begin
       L.Δ                             ≈⟨ E ⟩
       (Y.arr ▷ ϕ ∘ᵥ K.Δ)              ≈⟨ refl⟩∘⟨ F ⟩
-      Y.arr ▷ ϕ ∘ᵥ (Y.arr ▷ ψ ∘ᵥ J.Δ) ≈˘⟨ assoc ⟩
-      (Y.arr ▷ ϕ ∘ᵥ Y.arr ▷ ψ) ∘ᵥ J.Δ ≈⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+      Y.arr ▷ ϕ ∘ᵥ (Y.arr ▷ ψ ∘ᵥ J.Δ) ≈⟨ pullˡ ∘ᵥ-distr-▷ ⟩
       Y.arr ▷ (ϕ ∘ᵥ ψ) ∘ᵥ J.Δ         ∎
     where module X = SliceObj X
           module Y = SliceObj Y
@@ -110,27 +108,15 @@ module SliceHom (A : Obj) where
   
   _⊚₁/_ : ∀ {X Y Z : SliceObj A} → {J J' : Slice⇒₁ Y Z} → {K K' : Slice⇒₁ X Y} → Slice⇒₂ J J' → Slice⇒₂ K K' → Slice⇒₂ (J ⊚₀/ K) (J' ⊚₀/ K')
   _⊚₁/_ {X}{Y}{Z}{J'}{J}{K'}{K} δ γ = slicearr₂ $ begin
-    (α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ                                                      ≈⟨ (refl⟩∘⟨ γ.E) ⟩
-    (α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ (Y.arr ▷ γ.ϕ ∘ᵥ K'.Δ)                                    ≈⟨ ((refl⟩∘⟨ δ.E ⟩⊚⟨refl) ⟩∘⟨refl) ⟩
-    (α⇒ ∘ᵥ (Z.arr ▷ δ.ϕ ∘ᵥ J'.Δ) ◁ K.h) ∘ᵥ (Y.arr ▷ γ.ϕ ∘ᵥ K'.Δ)                  ≈˘⟨ (((refl⟩∘⟨ ∘ᵥ-distr-◁ ) ⟩∘⟨refl)) ⟩
-
-    -- generalized assoc
-    (α⇒ ∘ᵥ ((Z.arr ▷ δ.ϕ) ◁ K.h ∘ᵥ J'.Δ ◁ K.h)) ∘ᵥ (Y.arr ▷ γ.ϕ ∘ᵥ K'.Δ)          ≈˘⟨ assoc ⟩
-    ((α⇒ ∘ᵥ ((Z.arr ▷ δ.ϕ) ◁ K.h ∘ᵥ J'.Δ ◁ K.h)) ∘ᵥ Y.arr ▷ γ.ϕ) ∘ᵥ K'.Δ          ≈⟨ (assoc ⟩∘⟨refl) ⟩
-    (α⇒ ∘ᵥ ((Z.arr ▷ δ.ϕ) ◁ K.h ∘ᵥ J'.Δ ◁ K.h) ∘ᵥ Y.arr ▷ γ.ϕ) ∘ᵥ K'.Δ            ≈⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
-                   
-    (α⇒ ∘ᵥ (Z.arr ▷ δ.ϕ) ◁ K.h ∘ᵥ (J'.Δ ◁ K.h ∘ᵥ Y.arr ▷ γ.ϕ)) ∘ᵥ K'.Δ            ≈˘⟨ ((refl⟩∘⟨ (refl⟩∘⟨ ◁-▷-exchg)) ⟩∘⟨refl) ⟩
-    -- generalized assoc
-    (α⇒ ∘ᵥ (Z.arr ▷ δ.ϕ) ◁ K.h ∘ᵥ (Z.arr ⊚₀ J'.h ▷ γ.ϕ ∘ᵥ J'.Δ ◁ K'.h)) ∘ᵥ K'.Δ   ≈˘⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
-    (α⇒ ∘ᵥ ((Z.arr ▷ δ.ϕ) ◁ K.h ∘ᵥ Z.arr ⊚₀ J'.h ▷ γ.ϕ) ∘ᵥ J'.Δ ◁ K'.h) ∘ᵥ K'.Δ   ≈˘⟨ (assoc ⟩∘⟨refl) ⟩
-    (((α⇒ ∘ᵥ (Z.arr ▷ δ.ϕ) ◁ K.h ∘ᵥ Z.arr ⊚₀ J'.h ▷ γ.ϕ)) ∘ᵥ J'.Δ ◁ K'.h) ∘ᵥ K'.Δ ≈⟨ assoc ⟩
-
-    (α⇒ ∘ᵥ (Z.arr ▷ δ.ϕ) ◁ K.h ∘ᵥ Z.arr ⊚₀ J'.h ▷ γ.ϕ) ∘ᵥ J'.Δ ◁ K'.h ∘ᵥ K'.Δ     ≈˘⟨ ((refl⟩∘⟨ ⊚.homomorphism) ⟩∘⟨refl) ⟩
-    (α⇒ ∘ᵥ (Z.arr ▷ δ.ϕ ∘ᵥ id₂) ⊚₁ (id₂ ∘ᵥ γ.ϕ)) ∘ᵥ J'.Δ ◁ K'.h ∘ᵥ K'.Δ           ≈⟨ ((refl⟩∘⟨ identity₂ʳ ⟩⊚⟨ identity₂ˡ) ⟩∘⟨refl) ⟩
-    (α⇒ ∘ᵥ (Z.arr ▷ δ.ϕ) ⊚₁ γ.ϕ) ∘ᵥ J'.Δ ◁ K'.h ∘ᵥ K'.Δ                           ≈⟨ (⊚-assoc.⇒.commute ((id₂ , δ.ϕ) , γ.ϕ) ⟩∘⟨refl) ⟩
-    ((Z.arr ▷ δ.ϕ ⊚₁ γ.ϕ) ∘ᵥ α⇒) ∘ᵥ J'.Δ ◁ K'.h ∘ᵥ K'.Δ                           ≈⟨ assoc ⟩
-    (Z.arr ▷ δ.ϕ ⊚₁ γ.ϕ) ∘ᵥ α⇒ ∘ᵥ J'.Δ ◁ K'.h ∘ᵥ K'.Δ                             ≈˘⟨ refl⟩∘⟨ assoc ⟩
-    (Z.arr ▷ δ.ϕ ⊚₁ γ.ϕ) ∘ᵥ ((α⇒ ∘ᵥ J'.Δ ◁ K'.h) ∘ᵥ K'.Δ)                         ∎
+    (α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ                                                  ≈⟨ (refl⟩∘⟨ γ.E) ⟩
+    (α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ (Y.arr ▷ γ.ϕ ∘ᵥ K'.Δ)                                ≈⟨ ((refl⟩∘⟨ δ.E ⟩⊚⟨refl) ⟩∘⟨refl) ⟩
+    (α⇒ ∘ᵥ (Z.arr ▷ δ.ϕ ∘ᵥ J'.Δ) ◁ K.h) ∘ᵥ (Y.arr ▷ γ.ϕ ∘ᵥ K'.Δ)              ≈˘⟨ (((refl⟩∘⟨ ∘ᵥ-distr-◁ ) ⟩∘⟨refl)) ⟩
+    (α⇒ ∘ᵥ ((Z.arr ▷ δ.ϕ) ◁ K.h ∘ᵥ J'.Δ ◁ K.h)) ∘ᵥ (Y.arr ▷ γ.ϕ ∘ᵥ K'.Δ)      ≈⟨ pullʳ (center (sym ◁-▷-exchg)) ⟩
+    α⇒ ∘ᵥ (Z.arr ▷ δ.ϕ) ◁ K.h ∘ᵥ (Z.arr ⊚₀ J'.h ▷ γ.ϕ ∘ᵥ J'.Δ ◁ K'.h) ∘ᵥ K'.Δ ≈⟨ pushʳ ( pullˡ (pullˡ (sym ⊚.homomorphism)) ) ⟩
+    (α⇒ ∘ᵥ (Z.arr ▷ δ.ϕ ∘ᵥ id₂) ⊚₁ (id₂ ∘ᵥ γ.ϕ) ∘ᵥ J'.Δ ◁ K'.h) ∘ᵥ K'.Δ       ≈⟨ ((refl⟩∘⟨ (identity₂ʳ ⟩⊚⟨ identity₂ˡ ⟩∘⟨refl)) ⟩∘⟨refl) ⟩
+    (α⇒ ∘ᵥ ((Z.arr ▷ δ.ϕ) ⊚₁ γ.ϕ) ∘ᵥ J'.Δ ◁ K'.h) ∘ᵥ K'.Δ                     ≈⟨ pushˡ (pullˡ (⊚-assoc.⇒.commute ((id₂ , δ.ϕ) , γ.ϕ))) ⟩
+    (Z.arr ▷ δ.ϕ ⊚₁ γ.ϕ ∘ᵥ α⇒) ∘ᵥ J'.Δ ◁ K'.h ∘ᵥ K'.Δ                         ≈⟨ pullʳ (sym assoc) ⟩
+    (Z.arr ▷ δ.ϕ ⊚₁ γ.ϕ) ∘ᵥ ((α⇒ ∘ᵥ J'.Δ ◁ K'.h) ∘ᵥ K'.Δ)                     ∎
     where module X = SliceObj X
           module Y = SliceObj Y
           module Z = SliceObj Z
@@ -142,6 +128,8 @@ module SliceHom (A : Obj) where
           module δ = Slice⇒₂ δ          
           open 1Category (hom X.Y A)
           open HomReasoning
+          open MR (hom X.Y A)
+          open Equiv
 
   id/ : ∀ {X : SliceObj A} → Slice⇒₁ X X
   id/ = slicearr₁ ρ⇐
@@ -160,28 +148,12 @@ module SliceHom (A : Obj) where
   
   α⇒/ : ∀ {W X Y Z}(H : Slice⇒₁ Y Z) (J : Slice⇒₁ X Y) (K : Slice⇒₁ W X) → Slice⇒₂ ((H ⊚₀/ J) ⊚₀/ K) (H ⊚₀/ (J ⊚₀/ K))
   α⇒/ {W}{X}{Y}{Z} H J K = slicearr₂ $ begin
-    (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ ((α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ)                  ≈⟨ (refl⟩∘⟨ assoc) ⟩
-    (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ α⇒ ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                    ≈˘⟨ assoc ⟩
-    ((α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ α⇒) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                  ≈⟨ (assoc ⟩∘⟨refl) ⟩
-    (α⇒ ∘ᵥ (H.Δ ◁ J.h ⊚₀ K.h ∘ᵥ α⇒)) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                  ≈⟨ assoc ⟩
-
-    α⇒ ∘ᵥ (H.Δ ◁ J.h ⊚₀ K.h ∘ᵥ α⇒) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                    ≈˘⟨ (refl⟩∘⟨ (α⇒-◁-∘ₕ  ⟩∘⟨refl)) ⟩
-  
-    α⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                     ≈˘⟨ assoc ⟩
-    (α⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ J.h ◁ K.h)) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                   ≈˘⟨ ( assoc ⟩∘⟨refl) ⟩
-    ((α⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                   ≈⟨ assoc ⟩
-
-    (α⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ J.h ◁ K.h ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                     ≈˘⟨ (pentagon ⟩∘⟨refl) ⟩
-  
-    (Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ K.h) ∘ᵥ H.Δ ◁ J.h ◁ K.h ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ assoc²' ⟩
-    Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ K.h ∘ᵥ H.Δ ◁ J.h ◁ K.h ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)   ≈˘⟨ (refl⟩∘⟨ (refl⟩∘⟨ assoc)) ⟩
-
-    Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ (α⇒ ◁ K.h ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl))) ⟩
-    Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ ((α⇒ ∘ᵥ H.Δ ◁ J.h) ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)     ≈˘⟨ (refl⟩∘⟨ refl⟩∘⟨ assoc) ⟩
-    Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ ((α⇒ ∘ᵥ H.Δ ◁ J.h) ◁ K.h ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ       ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ (∘ᵥ-distr-◁  ⟩∘⟨refl))) ⟩
-    Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ           ≈˘⟨ refl⟩∘⟨ assoc ⟩
-
-    Z.arr ▷ α⇒ ∘ᵥ ((α⇒ ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h)) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ)       ∎
+    (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ ((α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ  )                  ≈⟨ pullʳ (center⁻¹ (sym α⇒-◁-∘ₕ) refl) ⟩
+    α⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ J.Δ ◁ K.h ∘ᵥ K.Δ                         ≈⟨ pullˡ (pullˡ (sym pentagon)) ⟩
+    ((Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ K.h) ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ pullˡ (pushˡ (pull-last ∘ᵥ-distr-◁ )) ⟩
+    (Z.arr ▷ α⇒ ∘ᵥ (α⇒ ∘ᵥ ((α⇒ ∘ᵥ H.Δ ◁ J.h) ◁ K.h)) ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ     ≈⟨ pushˡ (pushʳ (pullʳ ∘ᵥ-distr-◁)) ⟩
+    ((Z.arr ▷ α⇒ ∘ᵥ α⇒)) ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ         ≈⟨ pullʳ (pushʳ refl) ⟩
+    Z.arr ▷ α⇒ ∘ᵥ ((α⇒ ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h)) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ)         ∎
     where module W = SliceObj W
           module X = SliceObj X
           module Y = SliceObj Y
@@ -191,49 +163,46 @@ module SliceHom (A : Obj) where
           module K = Slice⇒₁ K
           open 1Category (hom W.Y A)
           open HomReasoning
-          open MR (hom W.Y A) using (assoc²')
+          open MR (hom W.Y A)
+          open hom.Equiv
 
   λ⇒/ : ∀ {X Y} (H : Slice⇒₁ X Y) → Slice⇒₂ (id/ ⊚₀/ H) H
   λ⇒/ {X}{Y} H = slicearr₂ $ begin
-    H.Δ                                                  ≈˘⟨ identity₂ˡ ⟩
-    id₂ ∘ᵥ H.Δ                                           ≈˘⟨ (id₂◁ ⟩∘⟨refl) ⟩
-    (id₂ ◁ H.h) ∘ᵥ H.Δ                                   ≈˘⟨ (unitʳ.iso.isoʳ (Y.arr , _) ⟩⊚⟨refl ⟩∘⟨refl) ⟩
-    ((ρ⇒ ∘ᵥ ρ⇐) ◁ H.h) ∘ᵥ H.Δ                            ≈˘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl) ⟩
-    (ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ                        ≈⟨ assoc ⟩
-    ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ                          ≈˘⟨ (triangle ⟩∘⟨refl) ⟩
-    (Y.arr ▷ λ⇒ ∘ᵥ α⇒) ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ                ≈⟨ assoc ⟩
-    Y.arr ▷ λ⇒ ∘ᵥ α⇒ ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ                  ≈˘⟨ (refl⟩∘⟨ assoc) ⟩
-    Y.arr ▷ λ⇒ ∘ᵥ (α⇒ ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ                ∎
+    H.Δ                                   ≈⟨ introˡ id₂◁ ⟩
+    (id₂ ◁ H.h) ∘ᵥ H.Δ                    ≈˘⟨ (unitʳ.iso.isoʳ (Y.arr , _) ⟩⊚⟨refl ⟩∘⟨refl) ⟩
+    ((ρ⇒ ∘ᵥ ρ⇐) ◁ H.h) ∘ᵥ H.Δ             ≈˘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl) ⟩
+    (ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ         ≈⟨ pushˡ (sym triangle ⟩∘⟨ refl) ⟩
+    (Y.arr ▷ λ⇒ ∘ᵥ α⇒) ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ ≈⟨ pullʳ (sym assoc) ⟩
+    Y.arr ▷ λ⇒ ∘ᵥ (α⇒ ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ ∎
     where module X = SliceObj X
           module Y = SliceObj Y
           module H = Slice⇒₁ H
           open 1Category (hom X.Y A)
           open HomReasoning
+          open MR (hom X.Y A)
+          open hom.Equiv
 
   ρ⇒/ : ∀{X}{Y} (H : Slice⇒₁ X Y) → Slice⇒₂ (H ⊚₀/ id/) H
   ρ⇒/ {X}{Y} H = slicearr₂ $ begin
-    H.Δ                                                   ≈˘⟨ identity₂ʳ ⟩
-    H.Δ ∘ᵥ id₂                                            ≈˘⟨ refl⟩∘⟨ unitʳ.iso.isoʳ (X.arr , _) ⟩
-    H.Δ ∘ᵥ ρ⇒ ∘ᵥ ρ⇐                                       ≈˘⟨ assoc ⟩
-    (H.Δ ∘ᵥ ρ⇒) ∘ᵥ ρ⇐                                     ≈˘⟨ ρ⇒-∘ᵥ-◁ ⟩∘⟨refl ⟩
-    (ρ⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐                               ≈⟨ unitorʳ-coherence  ⟩∘⟨refl ⟩∘⟨refl ⟩
-    ((Y.arr ▷ ρ⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐               ≈⟨ assoc ⟩∘⟨refl ⟩
-    (Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁)) ∘ᵥ ρ⇐               ≈⟨ assoc ⟩
-    Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐                 ∎
+    H.Δ                                     ≈⟨ introʳ (unitʳ.iso.isoʳ _) ⟩
+    H.Δ ∘ᵥ ρ⇒ ∘ᵥ ρ⇐                         ≈⟨ pullˡ (sym ρ⇒-∘ᵥ-◁) ⟩
+    (ρ⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐                 ≈⟨ unitorʳ-coherence  ⟩∘⟨refl ⟩∘⟨refl ⟩
+    ((Y.arr ▷ ρ⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ pushˡ assoc ⟩
+    Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐   ∎
     where module X = SliceObj X
           module Y = SliceObj Y
           module H = Slice⇒₁ H
           open 1Category (hom X.Y A)
           open HomReasoning
+          open MR (hom X.Y A)
+          open hom.Equiv
 
   slice-inv : ∀ {X}{Y}{H : Slice⇒₁ X Y}{K} (α : Slice⇒₂ H K) → (f : Slice⇒₁.h K ⇒₂ Slice⇒₁.h H) → (f ∘ᵥ (Slice⇒₂.ϕ α) ≈ id₂) → Slice⇒₂ K H
   slice-inv {X}{Y}{H}{K} α f p = slicearr₂ $ begin
-    H.Δ                               ≈˘⟨ identity₂ˡ ⟩
-    id₂ ∘ᵥ H.Δ                        ≈⟨ (Equiv.sym ▷id₂ ⟩∘⟨refl) ⟩
+    H.Δ                               ≈⟨ introˡ ▷id₂ ⟩
     (Y.arr ▷ id₂) ∘ᵥ H.Δ              ≈˘⟨ (refl⟩⊚⟨ p ⟩∘⟨refl) ⟩
     (Y.arr ▷ (f ∘ᵥ α.ϕ)) ∘ᵥ H.Δ       ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
-    (Y.arr ▷ f ∘ᵥ Y.arr ▷ α.ϕ) ∘ᵥ H.Δ ≈⟨ assoc ⟩
-    Y.arr ▷ f ∘ᵥ Y.arr ▷ α.ϕ ∘ᵥ H.Δ   ≈˘⟨ (refl⟩∘⟨ α.E ) ⟩
+    (Y.arr ▷ f ∘ᵥ Y.arr ▷ α.ϕ) ∘ᵥ H.Δ ≈⟨ pullʳ (sym α.E) ⟩
     Y.arr ▷ f ∘ᵥ K.Δ                  ∎
     where module X = SliceObj X
           module Y = SliceObj Y
@@ -242,6 +211,8 @@ module SliceHom (A : Obj) where
           module α = Slice⇒₂ α          
           open 1Category (hom X.Y A)
           open HomReasoning
+          open MR (hom X.Y A)
+          open hom.Equiv
 
 LaxSlice : Obj → Bicategory (o ⊔ ℓ) (ℓ ⊔ e) e (o ⊔ t)
 LaxSlice A   = record

--- a/src/Categories/Bicategory/Construction/LaxSlice.agda
+++ b/src/Categories/Bicategory/Construction/LaxSlice.agda
@@ -11,9 +11,14 @@ module Categories.Bicategory.Construction.LaxSlice
 
 open import Categories.Enriched.Category
 open import Categories.Category renaming (Category to 1Category)
-open import Categories.Morphism.Reasoning
-
+import Categories.Morphism.Reasoning as MR
 open import Categories.Bicategory.Extras 𝒞
+
+open import Categories.Functor.Construction.Constant using (const)
+open import Categories.Functor.Bifunctor using (Bifunctor)
+open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism; niHelper)
+open import Data.Product using (_,_)
+open import Categories.Functor using (Functor)
 
 open import Level
 
@@ -47,7 +52,6 @@ module SliceHom (A : Obj) where
       E   : K.Δ ≈ (Y.arr ▷ ϕ ∘ᵥ H.Δ)
 
   open hom.Equiv
-  open import Categories.Functor using (Functor)
 
   _∘'_ : ∀ {X Y : SliceObj A}{H K L : Slice⇒₁ X Y} → Slice⇒₂ K L → Slice⇒₂ H K → Slice⇒₂ H L
   _∘'_ {X}{Y}{H}{K}{L} (slicearr₂ {ϕ = ϕ} E) (slicearr₂ {ϕ = ψ} F) = slicearr₂ {ϕ = ϕ ∘ᵥ ψ} 
@@ -66,9 +70,7 @@ module SliceHom (A : Obj) where
           open 1Category (hom X.Y A)
           open HomReasoning
           open Equiv
-          open import Categories.Morphism.Reasoning (hom X.Y A)
-          open import Relation.Binary.Core using (Rel)
-          open import Function.Base using (_$_)
+          open MR (hom X.Y A)
           
   open SliceObj
   SliceHomCat : SliceObj A → SliceObj A → 1Category (o ⊔ ℓ) (ℓ ⊔ e) e
@@ -102,6 +104,8 @@ module SliceHom (A : Obj) where
               open 1Category (hom X.Y A)
               open HomReasoning
 
+  
+
 LaxSlice : Obj → Bicategory (o ⊔ ℓ) (ℓ ⊔ e) e (o ⊔ t)
 LaxSlice A   = record
   { enriched = record
@@ -121,7 +125,7 @@ LaxSlice A   = record
                 module K = Slice⇒₁ K
                 open 1Category (hom W.Y A)
                 open HomReasoning
-                module Help = Categories.Morphism.Reasoning (hom W.Y A)
+                module Help = MR (hom W.Y A)
             in SliceHom.slicearr₂ (begin (
               Slice⇒₁.Δ (F₀ _⊚'_ (H  , F₀ _⊚'_ (J , K))) ≈⟨ Equiv.refl ⟩
               (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ ((α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ) ≈⟨ (refl⟩∘⟨ assoc) ⟩
@@ -276,17 +280,9 @@ LaxSlice A   = record
   ; pentagon = λ {V} {W} {X} {Y} {Z} {H} {J} {K} {L} → pentagon
   }
   where
-    open import Categories.NaturalTransformation.NaturalIsomorphism
-      using (NaturalIsomorphism; niHelper)
     open SliceHom A
     open Shorthands
-    open import Categories.Functor
     open Functor
-    open import Categories.Functor.Construction.Constant
-    
-    open import Categories.Functor.Bifunctor
-
-    open import Data.Product
     _⊚'_ : ∀ {X Y Z : SliceObj A} → Bifunctor (SliceHomCat Y Z) (SliceHomCat X Y) (SliceHomCat X Z)
     _⊚'_ {X}{Y}{Z} = record
              { F₀ = λ where

--- a/src/Categories/Bicategory/Construction/LaxSlice.agda
+++ b/src/Categories/Bicategory/Construction/LaxSlice.agda
@@ -1,0 +1,337 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Mentioned in passing https://ncatlab.org/nlab/show/slice+2-category
+
+open import Categories.Bicategory
+
+module Categories.Bicategory.Construction.LaxSlice
+       {o ℓ e t}
+       (𝒞 : Bicategory o ℓ e t)
+       where
+
+open import Categories.Enriched.Category
+open import Categories.Category renaming (Category to 1Category)
+open import Categories.Morphism.Reasoning
+
+open import Categories.Bicategory.Extras 𝒞
+
+open import Level
+
+record SliceObj (X : Obj) : Set (t ⊔ o) where
+  constructor sliceobj
+  field
+    {Y} : Obj
+    arr : Y ⇒₁ X
+
+module SliceHom (A : Obj) where
+
+  record Slice⇒₁ (X Y : SliceObj A) : Set (o ⊔ ℓ) where
+    constructor slicearr₁
+    private
+      module X = SliceObj X
+      module Y = SliceObj Y
+
+    field
+      {h} : X.Y ⇒₁ Y.Y
+      Δ   : X.arr ⇒₂ (Y.arr ∘ₕ h)
+
+  record Slice⇒₂ {X Y : SliceObj A} (H K : Slice⇒₁ X Y) : Set (ℓ ⊔ e) where
+    constructor slicearr₂
+    private
+      module Y = SliceObj Y
+      module H = Slice⇒₁ H
+      module K = Slice⇒₁ K
+
+    field
+      {ϕ} : H.h ⇒₂ K.h
+      E   : K.Δ ≈ (Y.arr ▷ ϕ ∘ᵥ H.Δ)
+
+  open hom.Equiv
+  open import Categories.Functor using (Functor)
+
+  _∘'_ : ∀ {X Y : SliceObj A}{H K L : Slice⇒₁ X Y} → Slice⇒₂ K L → Slice⇒₂ H K → Slice⇒₂ H L
+  _∘'_ {X}{Y}{H}{K}{L} (slicearr₂ {ϕ = ϕ} E) (slicearr₂ {ϕ = ψ} F) = slicearr₂ {ϕ = ϕ ∘ᵥ ψ} 
+     (begin
+      L.Δ ≈⟨ E ⟩
+      (Y.arr ▷ ϕ ∘ᵥ K.Δ) ≈⟨ refl⟩∘⟨ F ⟩
+      Y.arr ▷ ϕ ∘ᵥ (Y.arr ▷ ψ ∘ᵥ H.Δ) ≈˘⟨ hom.assoc ⟩
+      (Y.arr ▷ ϕ ∘ᵥ Y.arr ▷ ψ) ∘ᵥ H.Δ ≈⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+      Y.arr ▷ (ϕ ∘ᵥ ψ) ∘ᵥ H.Δ ∎
+        )
+    where module X = SliceObj X
+          module Y = SliceObj Y
+          module H = Slice⇒₁ H
+          module K = Slice⇒₁ K
+          module L = Slice⇒₁ L
+          open 1Category (hom X.Y A)
+          open HomReasoning
+          open Equiv
+          open import Categories.Morphism.Reasoning (hom X.Y A)
+          open import Relation.Binary.Core using (Rel)
+          open import Function.Base using (_$_)
+          
+  open SliceObj
+  SliceHomCat : SliceObj A → SliceObj A → 1Category (o ⊔ ℓ) (ℓ ⊔ e) e
+  SliceHomCat X Y = record
+    { Obj = Slice⇒₁ X Y
+    ; _⇒_ = Slice⇒₂
+    ; _≈_ = λ where
+      (slicearr₂ {ϕ} _) (slicearr₂ {ψ} _) → ϕ ≈ ψ 
+    ; id = slice-id _
+    ; _∘_ = _∘'_
+    ; assoc = hom.assoc
+    ; sym-assoc = hom.sym-assoc
+    ; identityˡ = hom.identityˡ
+    ; identityʳ = hom.identityʳ
+    ; identity² = hom.identity²
+    ; equiv = record
+      { refl = refl
+      ; sym = sym
+      ; trans = trans }
+    ; ∘-resp-≈ = hom.∘-resp-≈
+    }
+    where
+      slice-id : ∀ (H : Slice⇒₁ X Y) → Slice⇒₂ H H
+      slice-id H = slicearr₂ (begin
+        (H.Δ        ≈˘⟨ identity₂ˡ ⟩
+         id₂ ∘ᵥ H.Δ ≈⟨ (sym ▷id₂ ⟩∘⟨refl) ⟩
+         (arr Y ▷ id₂) ∘ H.Δ
+         ∎))
+        where module X = SliceObj X
+              module H = Slice⇒₁ H
+              open 1Category (hom X.Y A)
+              open HomReasoning
+
+LaxSlice : Obj → Bicategory (o ⊔ ℓ) (ℓ ⊔ e) e (o ⊔ t)
+LaxSlice A   = record
+  { enriched = record
+    { Obj = SliceObj A
+    ; hom = SliceHomCat
+    ; id = const (SliceHom.slicearr₁ ρ⇐)
+    ; ⊚ = _⊚'_
+    ; ⊚-assoc = λ {W X Y Z} →
+      let module W = SliceObj W
+          module X = SliceObj X
+          module Y = SliceObj Y
+          module Z = SliceObj Z
+          η' : ∀ (H : Slice⇒₁ Y Z) (J : Slice⇒₁ X Y) (K : Slice⇒₁ W X) → Slice⇒₂ ((F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) (F₀ _⊚'_ (H  , F₀ _⊚'_ (J , K)))
+          η' H J K =
+            let module H = Slice⇒₁ H
+                module J = Slice⇒₁ J
+                module K = Slice⇒₁ K
+                open 1Category (hom W.Y A)
+                open HomReasoning
+                module Help = Categories.Morphism.Reasoning (hom W.Y A)
+            in SliceHom.slicearr₂ (begin (
+              Slice⇒₁.Δ (F₀ _⊚'_ (H  , F₀ _⊚'_ (J , K))) ≈⟨ Equiv.refl ⟩
+              (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ ((α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ) ≈⟨ (refl⟩∘⟨ assoc) ⟩
+              (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ α⇒ ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)   ≈˘⟨ assoc ⟩
+              ((α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ α⇒) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ (assoc ⟩∘⟨refl) ⟩
+              (α⇒ ∘ᵥ (H.Δ ◁ J.h ⊚₀ K.h ∘ᵥ α⇒)) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ assoc ⟩
+
+              α⇒ ∘ᵥ (H.Δ ◁ J.h ⊚₀ K.h ∘ᵥ α⇒) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                    ≈˘⟨ (refl⟩∘⟨ (α⇒-◁-∘ₕ  ⟩∘⟨refl)) ⟩
+  
+              α⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                     ≈⟨ Equiv.sym assoc ⟩
+              (α⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ J.h ◁ K.h)) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                   ≈˘⟨ ( assoc ⟩∘⟨refl) ⟩
+              ((α⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                   ≈⟨ assoc ⟩
+
+              (α⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ J.h ◁ K.h ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                     ≈˘⟨ (pentagon ⟩∘⟨refl) ⟩
+  
+              (Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ K.h) ∘ᵥ H.Δ ◁ J.h ◁ K.h ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ Help.assoc²' ⟩
+              Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ K.h ∘ᵥ H.Δ ◁ J.h ◁ K.h ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)   ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ Equiv.sym assoc)) ⟩
+
+              Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ (α⇒ ◁ K.h ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl))) ⟩
+              Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ ((α⇒ ∘ᵥ H.Δ ◁ J.h) ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)     ≈⟨ (refl⟩∘⟨ refl⟩∘⟨ Equiv.sym assoc) ⟩
+              Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ ((α⇒ ∘ᵥ H.Δ ◁ J.h) ◁ K.h ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ       ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ (∘ᵥ-distr-◁  ⟩∘⟨refl))) ⟩
+              -- assoc/lifted assoc
+              Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ           ≈⟨ (refl⟩∘⟨ Equiv.sym assoc) ⟩
+
+              Z.arr ▷ α⇒ ∘ᵥ ((α⇒ ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h)) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ)       ≈⟨ Equiv.refl ⟩
+              Z.arr ▷ α⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))
+              ∎))
+      in 
+      niHelper (record
+      { η       = λ ((H , J) , K) → η' H J K
+      ; η⁻¹     = λ where
+        ((H , J) , K) →
+          let module H = Slice⇒₁ H
+              module J = Slice⇒₁ J
+              module K = Slice⇒₁ K
+              open 1Category (hom W.Y A)
+              open HomReasoning
+          in
+          SliceHom.slicearr₂ 
+            (begin (
+            Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))         ≈˘⟨ identity₂ˡ ⟩
+            id₂ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) ≈⟨ (Equiv.sym ▷id₂ ⟩∘⟨refl) ⟩
+            (Z.arr ▷ id₂) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) ≈˘⟨ (refl⟩⊚⟨ ⊚-assoc.iso.isoˡ ((H.h , J.h) , K.h) ⟩∘⟨refl) ⟩
+            (Z.arr ▷ (α⇐ ∘ᵥ α⇒)) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+            (Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) ≈⟨ assoc ⟩
+            Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (η' H J K)) ⟩
+            Z.arr ▷ α⇐ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H  , F₀ _⊚'_ (J , K)))
+            ∎))
+
+      ; commute = λ where
+        {(H , J) , K} {(H' , J') , K'} (( β , γ ) , δ) →
+          let module β = Slice⇒₂ β
+              module γ = Slice⇒₂ γ
+              module δ = Slice⇒₂ δ
+          in ⊚-assoc.⇒.commute (((β.ϕ , γ.ϕ) , δ.ϕ))
+      ; iso = λ where
+         ((H , J) , K) →
+          let module H = Slice⇒₁ H
+              module J = Slice⇒₁ J
+              module K = Slice⇒₁ K
+          in record { isoˡ = ⊚-assoc.iso.isoˡ ((H.h , J.h) , K.h) ; isoʳ = ⊚-assoc.iso.isoʳ ( (H.h , J.h) , K.h) }
+      })
+    ; unitˡ = λ {X}{Y} →
+      let module X = SliceObj X
+          module Y = SliceObj Y
+          λ⇒/ : ∀ (H : Slice⇒₁ X Y) → Slice⇒₂ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H)) H
+          λ⇒/ H =
+            let module H = Slice⇒₁ H
+                open 1Category (hom X.Y A)
+                open HomReasoning
+                open Equiv
+            in SliceHom.slicearr₂ (begin (
+              H.Δ                                   ≈˘⟨ identity₂ˡ ⟩
+              id₂ ∘ᵥ H.Δ                            ≈˘⟨ (id₂◁ ⟩∘⟨refl) ⟩
+              (id₂ ◁ H.h) ∘ᵥ H.Δ                    ≈˘⟨ (unitʳ.iso.isoʳ (Y.arr , (lift _)) ⟩⊚⟨refl ⟩∘⟨refl) ⟩
+              ((ρ⇒ ∘ᵥ ρ⇐) ◁ H.h) ∘ᵥ H.Δ             ≈˘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl) ⟩
+              (ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ         ≈⟨ assoc ⟩
+              ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ           ≈˘⟨ (triangle ⟩∘⟨refl) ⟩
+              (Y.arr ▷ λ⇒ ∘ᵥ α⇒) ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ ≈⟨ assoc ⟩
+              Y.arr ▷ λ⇒ ∘ᵥ α⇒ ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ   ≈˘⟨ (refl⟩∘⟨ assoc) ⟩
+              Y.arr ▷ λ⇒ ∘ᵥ (α⇒ ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ ≈⟨ refl ⟩
+              Y.arr ▷ λ⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H))
+              ∎))
+      in niHelper (record
+      { η = λ where
+          (i , H) → λ⇒/ H
+      ; η⁻¹ = λ where
+          (i , H) →
+            let module H = Slice⇒₁ H
+                open 1Category (hom X.Y A)
+                open HomReasoning
+                open Equiv
+            in SliceHom.slicearr₂ (begin (
+               Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H))                                   ≈˘⟨ identity₂ˡ ⟩
+               (id₂ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H)))                          ≈˘⟨ (▷id₂ ⟩∘⟨refl ) ⟩
+               (Y.arr ▷ id₂) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H))                  ≈˘⟨ (refl⟩⊚⟨ unitˡ.iso.isoˡ _ ⟩∘⟨refl) ⟩
+               (Y.arr ▷ (λ⇐ ∘ᵥ λ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H))           ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+               ((Y.arr ▷ λ⇐) ∘ᵥ (Y.arr ▷ λ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H)) ≈⟨ assoc ⟩
+               (Y.arr ▷ λ⇐) ∘ᵥ (Y.arr ▷ λ⇒) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H))   ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (λ⇒/ H)) ⟩
+               Y.arr ▷ λ⇐ ∘ᵥ H.Δ
+               ∎))
+      ; commute = λ where
+          {lift _ , SliceHom.slicearr₁ {Hh} HΔ} {lift _ , SliceHom.slicearr₁ {Jh} JΔ} (lift _ , SliceHom.slicearr₂ {ϕ} E) → λ⇒-∘ᵥ-▷
+      ; iso = λ where
+          (i , SliceHom.slicearr₁ {h} Δ) →
+            record { isoˡ = unitˡ.iso.isoˡ (_ , h)
+                   ; isoʳ = unitˡ.iso.isoʳ (_ , h) }
+      })
+    ; unitʳ = λ {X}{Y} →
+      let module X = SliceObj X
+          module Y = SliceObj Y
+          ρ⇒/ : ∀ (H : Slice⇒₁ X Y) → Slice⇒₂ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐)) H
+          ρ⇒/ H =
+            let module H = Slice⇒₁ H
+                open 1Category (hom X.Y A)
+                open HomReasoning
+                open Equiv
+            in SliceHom.slicearr₂ (begin (
+               H.Δ ≈˘⟨ identity₂ʳ ⟩
+               H.Δ ∘ᵥ id₂ ≈˘⟨ refl⟩∘⟨ unitʳ.iso.isoʳ (X.arr , _) ⟩
+               H.Δ ∘ᵥ ρ⇒ ∘ᵥ ρ⇐ ≈˘⟨ assoc ⟩
+               (H.Δ ∘ᵥ ρ⇒) ∘ᵥ ρ⇐ ≈˘⟨ ρ⇒-∘ᵥ-◁ ⟩∘⟨refl ⟩
+               (ρ⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ unitorʳ-coherence  ⟩∘⟨refl ⟩∘⟨refl ⟩
+               ((Y.arr ▷ ρ⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ assoc ⟩∘⟨refl ⟩
+               (Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁)) ∘ᵥ ρ⇐ ≈⟨ assoc ⟩
+               Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ refl ⟩
+               Y.arr ▷ ρ⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐ ))
+               ∎))
+      in niHelper (record
+         { η = λ (H , i) → ρ⇒/ H
+         ; η⁻¹ = λ (H , i) →
+            let module H = Slice⇒₁ H
+                open 1Category (hom X.Y A)
+                open HomReasoning
+                open Equiv
+            in SliceHom.slicearr₂ (begin (
+               Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐ )) ≈˘⟨ identity₂ˡ ⟩
+               (id₂ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐ )))                          ≈˘⟨ (▷id₂ ⟩∘⟨refl ) ⟩
+               (Y.arr ▷ id₂) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐))                   ≈˘⟨ (refl⟩⊚⟨ unitʳ.iso.isoˡ _ ⟩∘⟨refl) ⟩
+               (Y.arr ▷ (ρ⇐ ∘ᵥ ρ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐))            ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+               ((Y.arr ▷ ρ⇐) ∘ᵥ (Y.arr ▷ ρ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐ )) ≈⟨ assoc ⟩
+               (Y.arr ▷ ρ⇐) ∘ᵥ (Y.arr ▷ ρ⇒) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐))    ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (ρ⇒/ H)) ⟩
+               Y.arr ▷ ρ⇐ ∘ᵥ H.Δ
+               ∎))
+         ; commute = λ f → ρ⇒-∘ᵥ-◁
+         ; iso = λ where
+          ((SliceHom.slicearr₁ {h} Δ) , i) →
+            record { isoˡ = unitʳ.iso.isoˡ (h , _)
+                   ; isoʳ = unitʳ.iso.isoʳ (h , _) } })
+    }
+  ; triangle = λ {X}{Y}{Z}{H}{K} → triangle
+  ; pentagon = λ {V} {W} {X} {Y} {Z} {H} {J} {K} {L} → pentagon
+  }
+  where
+    open import Categories.NaturalTransformation.NaturalIsomorphism
+      using (NaturalIsomorphism; niHelper)
+    open SliceHom A
+    open Shorthands
+    open import Categories.Functor
+    open Functor
+    open import Categories.Functor.Construction.Constant
+    
+    open import Categories.Functor.Bifunctor
+
+    open import Data.Product
+    _⊚'_ : ∀ {X Y Z : SliceObj A} → Bifunctor (SliceHomCat Y Z) (SliceHomCat X Y) (SliceHomCat X Z)
+    _⊚'_ {X}{Y}{Z} = record
+             { F₀ = λ where
+               (H' , H) →
+                 let module H' = Slice⇒₁ H'
+                     module H = Slice⇒₁ H
+                 in SliceHom.slicearr₁ ((α⇒ ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ)
+             ; F₁ = λ where
+               {H' , H} {J' , J} (γ , δ) →
+                 let module H' = Slice⇒₁ H'
+                     module H = Slice⇒₁ H
+                     module J' = Slice⇒₁ J'
+                     module J = Slice⇒₁ J
+                     module γ = Slice⇒₂ γ
+                     module δ = Slice⇒₂ δ
+                     open 1Category (hom X.Y A)
+                     open HomReasoning
+                 in SliceHom.slicearr₂ (begin
+                   (α⇒ ∘ᵥ J'.Δ ◁ J.h) ∘ᵥ J.Δ ≈⟨ (refl⟩∘⟨ δ.E) ⟩
+                   (α⇒ ∘ᵥ J'.Δ ◁ J.h) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈⟨ ((refl⟩∘⟨ γ.E ⟩⊚⟨refl) ⟩∘⟨refl) ⟩
+                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ ∘ᵥ H'.Δ) ◁ J.h) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈˘⟨ (((refl⟩∘⟨ ∘ᵥ-distr-◁ ) ⟩∘⟨refl)) ⟩
+
+                    -- generalized assoc
+                   (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h)) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈˘⟨ assoc ⟩
+                   ((α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h)) ∘ᵥ Y.arr ▷ δ.ϕ) ∘ᵥ H.Δ ≈⟨ (assoc ⟩∘⟨refl) ⟩
+                   (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h) ∘ᵥ Y.arr ▷ δ.ϕ) ∘ᵥ H.Δ ≈⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
+                   
+                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ (H'.Δ ◁ J.h ∘ᵥ Y.arr ▷ δ.ϕ)) ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ (refl⟩∘⟨ ◁-▷-exchg)) ⟩∘⟨refl) ⟩
+
+                    -- generalized assoc
+                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ (Z.arr ⊚₀ H'.h ▷ δ.ϕ ∘ᵥ H'.Δ ◁ H.h)) ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
+                   (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ ≈˘⟨ (assoc ⟩∘⟨refl) ⟩
+                   (((α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ)) ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ ≈⟨ assoc ⟩
+
+                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ ⊚.homomorphism) ⟩∘⟨refl) ⟩
+                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ ∘ᵥ id₂) ⊚₁ (id₂ ∘ᵥ δ.ϕ)) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ ((refl⟩∘⟨ identity₂ʳ ⟩⊚⟨ identity₂ˡ) ⟩∘⟨refl) ⟩
+                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ⊚₁ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ (⊚-assoc.⇒.commute ((id₂ , γ.ϕ) , δ.ϕ) ⟩∘⟨refl) ⟩
+                   ((Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ α⇒) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ assoc ⟩
+                   (Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ α⇒ ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈˘⟨ refl⟩∘⟨ assoc ⟩
+                   (Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ ((α⇒ ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ)
+                   ∎)
+             ; identity = ⊚.identity
+             ; homomorphism = ⊚.homomorphism
+             ; F-resp-≈ = ⊚.F-resp-≈
+             }
+         where module X = SliceObj X
+               module Y = SliceObj Y
+               module Z = SliceObj Z

--- a/src/Categories/Bicategory/Construction/LaxSlice.agda
+++ b/src/Categories/Bicategory/Construction/LaxSlice.agda
@@ -146,67 +146,67 @@ module SliceHom (A : Obj) where
             module Y = SliceObj Y
             module Z = SliceObj Z
   
-  α⇒/ : ∀ {W X Y Z}(H : Slice⇒₁ Y Z) (J : Slice⇒₁ X Y) (K : Slice⇒₁ W X) → Slice⇒₂ ((H ⊚₀/ J) ⊚₀/ K) (H ⊚₀/ (J ⊚₀/ K))
-  α⇒/ {W}{X}{Y}{Z} H J K = slicearr₂ $ begin
-    (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ ((α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ  )                  ≈⟨ pullʳ (center⁻¹ (sym α⇒-◁-∘ₕ) refl) ⟩
-    α⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ J.Δ ◁ K.h ∘ᵥ K.Δ                         ≈⟨ pullˡ (pullˡ (sym pentagon)) ⟩
-    ((Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ K.h) ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ pullˡ (pushˡ (pull-last ∘ᵥ-distr-◁ )) ⟩
-    (Z.arr ▷ α⇒ ∘ᵥ (α⇒ ∘ᵥ ((α⇒ ∘ᵥ H.Δ ◁ J.h) ◁ K.h)) ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ     ≈⟨ pushˡ (pushʳ (pullʳ ∘ᵥ-distr-◁)) ⟩
-    ((Z.arr ▷ α⇒ ∘ᵥ α⇒)) ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ         ≈⟨ pullʳ (pushʳ refl) ⟩
-    Z.arr ▷ α⇒ ∘ᵥ ((α⇒ ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h)) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ)         ∎
+  α⇒/ : ∀ {W X Y Z}(J : Slice⇒₁ Y Z) (K : Slice⇒₁ X Y) (L : Slice⇒₁ W X) → Slice⇒₂ ((J ⊚₀/ K) ⊚₀/ L) (J ⊚₀/ (K ⊚₀/ L))
+  α⇒/ {W}{X}{Y}{Z} J K L = slicearr₂ $ begin
+    (α⇒ ∘ᵥ J.Δ ◁ K.h ⊚₀ L.h) ∘ᵥ ((α⇒ ∘ᵥ K.Δ ◁ L.h) ∘ᵥ L.Δ  )                  ≈⟨ pullʳ (center⁻¹ (sym α⇒-◁-∘ₕ) refl) ⟩
+    α⇒ ∘ᵥ (α⇒ ∘ᵥ J.Δ ◁ K.h ◁ L.h) ∘ᵥ K.Δ ◁ L.h ∘ᵥ L.Δ                         ≈⟨ pullˡ (pullˡ (sym pentagon)) ⟩
+    ((Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ L.h) ∘ᵥ J.Δ ◁ K.h ◁ L.h) ∘ᵥ (K.Δ ◁ L.h ∘ᵥ L.Δ) ≈⟨ pullˡ (pushˡ (pull-last ∘ᵥ-distr-◁ )) ⟩
+    (Z.arr ▷ α⇒ ∘ᵥ (α⇒ ∘ᵥ ((α⇒ ∘ᵥ J.Δ ◁ K.h) ◁ L.h)) ∘ᵥ K.Δ ◁ L.h) ∘ᵥ L.Δ     ≈⟨ pushˡ (pushʳ (pullʳ ∘ᵥ-distr-◁)) ⟩
+    ((Z.arr ▷ α⇒ ∘ᵥ α⇒)) ∘ᵥ (((α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ) ◁ L.h) ∘ᵥ L.Δ         ≈⟨ pullʳ (pushʳ refl) ⟩
+    Z.arr ▷ α⇒ ∘ᵥ ((α⇒ ∘ᵥ (((α⇒ ∘ᵥ J.Δ ◁ K.h)) ∘ᵥ K.Δ) ◁ L.h) ∘ᵥ L.Δ)         ∎
     where module W = SliceObj W
           module X = SliceObj X
           module Y = SliceObj Y
           module Z = SliceObj Z
-          module H = Slice⇒₁ H
           module J = Slice⇒₁ J
           module K = Slice⇒₁ K
+          module L = Slice⇒₁ L
           open 1Category (hom W.Y A)
           open HomReasoning
           open MR (hom W.Y A)
           open hom.Equiv
 
-  λ⇒/ : ∀ {X Y} (H : Slice⇒₁ X Y) → Slice⇒₂ (id/ ⊚₀/ H) H
-  λ⇒/ {X}{Y} H = slicearr₂ $ begin
-    H.Δ                                   ≈⟨ introˡ id₂◁ ⟩
-    (id₂ ◁ H.h) ∘ᵥ H.Δ                    ≈˘⟨ (unitʳ.iso.isoʳ (Y.arr , _) ⟩⊚⟨refl ⟩∘⟨refl) ⟩
-    ((ρ⇒ ∘ᵥ ρ⇐) ◁ H.h) ∘ᵥ H.Δ             ≈˘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl) ⟩
-    (ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ         ≈⟨ pushˡ (sym triangle ⟩∘⟨ refl) ⟩
-    (Y.arr ▷ λ⇒ ∘ᵥ α⇒) ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ ≈⟨ pullʳ (sym assoc) ⟩
-    Y.arr ▷ λ⇒ ∘ᵥ (α⇒ ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ ∎
+  λ⇒/ : ∀ {X Y} (J : Slice⇒₁ X Y) → Slice⇒₂ (id/ ⊚₀/ J) J
+  λ⇒/ {X}{Y} J = slicearr₂ $ begin
+    J.Δ                                   ≈⟨ introˡ id₂◁ ⟩
+    (id₂ ◁ J.h) ∘ᵥ J.Δ                    ≈˘⟨ (unitʳ.iso.isoʳ (Y.arr , _) ⟩⊚⟨refl ⟩∘⟨refl) ⟩
+    ((ρ⇒ ∘ᵥ ρ⇐) ◁ J.h) ∘ᵥ J.Δ             ≈˘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl) ⟩
+    (ρ⇒ ◁ J.h ∘ᵥ ρ⇐ ◁ J.h) ∘ᵥ J.Δ         ≈⟨ pushˡ (sym triangle ⟩∘⟨ refl) ⟩
+    (Y.arr ▷ λ⇒ ∘ᵥ α⇒) ∘ᵥ ρ⇐ ◁ J.h ∘ᵥ J.Δ ≈⟨ pullʳ (sym assoc) ⟩
+    Y.arr ▷ λ⇒ ∘ᵥ (α⇒ ∘ᵥ ρ⇐ ◁ J.h) ∘ᵥ J.Δ ∎
     where module X = SliceObj X
           module Y = SliceObj Y
-          module H = Slice⇒₁ H
+          module J = Slice⇒₁ J
           open 1Category (hom X.Y A)
           open HomReasoning
           open MR (hom X.Y A)
           open hom.Equiv
 
-  ρ⇒/ : ∀{X}{Y} (H : Slice⇒₁ X Y) → Slice⇒₂ (H ⊚₀/ id/) H
-  ρ⇒/ {X}{Y} H = slicearr₂ $ begin
-    H.Δ                                     ≈⟨ introʳ (unitʳ.iso.isoʳ _) ⟩
-    H.Δ ∘ᵥ ρ⇒ ∘ᵥ ρ⇐                         ≈⟨ pullˡ (sym ρ⇒-∘ᵥ-◁) ⟩
-    (ρ⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐                 ≈⟨ unitorʳ-coherence  ⟩∘⟨refl ⟩∘⟨refl ⟩
-    ((Y.arr ▷ ρ⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ pushˡ assoc ⟩
-    Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐   ∎
+  ρ⇒/ : ∀{X}{Y} (J : Slice⇒₁ X Y) → Slice⇒₂ (J ⊚₀/ id/) J
+  ρ⇒/ {X}{Y} J = slicearr₂ $ begin
+    J.Δ                                     ≈⟨ introʳ (unitʳ.iso.isoʳ _) ⟩
+    J.Δ ∘ᵥ ρ⇒ ∘ᵥ ρ⇐                         ≈⟨ pullˡ (sym ρ⇒-∘ᵥ-◁) ⟩
+    (ρ⇒ ∘ᵥ J.Δ ◁ id₁) ∘ᵥ ρ⇐                 ≈⟨ unitorʳ-coherence  ⟩∘⟨refl ⟩∘⟨refl ⟩
+    ((Y.arr ▷ ρ⇒ ∘ᵥ α⇒) ∘ᵥ J.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ pushˡ assoc ⟩
+    Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ J.Δ ◁ id₁) ∘ᵥ ρ⇐   ∎
     where module X = SliceObj X
           module Y = SliceObj Y
-          module H = Slice⇒₁ H
+          module J = Slice⇒₁ J
           open 1Category (hom X.Y A)
           open HomReasoning
           open MR (hom X.Y A)
           open hom.Equiv
 
-  slice-inv : ∀ {X}{Y}{H : Slice⇒₁ X Y}{K} (α : Slice⇒₂ H K) → (f : Slice⇒₁.h K ⇒₂ Slice⇒₁.h H) → (f ∘ᵥ (Slice⇒₂.ϕ α) ≈ id₂) → Slice⇒₂ K H
-  slice-inv {X}{Y}{H}{K} α f p = slicearr₂ $ begin
-    H.Δ                               ≈⟨ introˡ ▷id₂ ⟩
-    (Y.arr ▷ id₂) ∘ᵥ H.Δ              ≈˘⟨ (refl⟩⊚⟨ p ⟩∘⟨refl) ⟩
-    (Y.arr ▷ (f ∘ᵥ α.ϕ)) ∘ᵥ H.Δ       ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
-    (Y.arr ▷ f ∘ᵥ Y.arr ▷ α.ϕ) ∘ᵥ H.Δ ≈⟨ pullʳ (sym α.E) ⟩
+  slice-inv : ∀ {X}{Y}{J : Slice⇒₁ X Y}{K} (α : Slice⇒₂ J K) → (f : Slice⇒₁.h K ⇒₂ Slice⇒₁.h J) → (f ∘ᵥ (Slice⇒₂.ϕ α) ≈ id₂) → Slice⇒₂ K J
+  slice-inv {X}{Y}{J}{K} α f p = slicearr₂ $ begin
+    J.Δ                               ≈⟨ introˡ ▷id₂ ⟩
+    (Y.arr ▷ id₂) ∘ᵥ J.Δ              ≈˘⟨ (refl⟩⊚⟨ p ⟩∘⟨refl) ⟩
+    (Y.arr ▷ (f ∘ᵥ α.ϕ)) ∘ᵥ J.Δ       ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+    (Y.arr ▷ f ∘ᵥ Y.arr ▷ α.ϕ) ∘ᵥ J.Δ ≈⟨ pullʳ (sym α.E) ⟩
     Y.arr ▷ f ∘ᵥ K.Δ                  ∎
     where module X = SliceObj X
           module Y = SliceObj Y
-          module H = Slice⇒₁ H
+          module J = Slice⇒₁ J
           module K = Slice⇒₁ K
           module α = Slice⇒₂ α          
           open 1Category (hom X.Y A)
@@ -222,22 +222,22 @@ LaxSlice A   = record
     ; id = const id/
     ; ⊚ = _⊚/_
     ; ⊚-assoc = niHelper (record
-      { η       = λ ((H , J) , K) → α⇒/ H J K
-      ; η⁻¹     = λ ((H , J) , K) → slice-inv (α⇒/ H J K) α⇐ (⊚-assoc.iso.isoˡ _)
+      { η       = λ ((J , K) , L) → α⇒/ J K L
+      ; η⁻¹     = λ ((J , K) , L) → slice-inv (α⇒/ J K L) α⇐ (⊚-assoc.iso.isoˡ _)
       ; commute = λ f → ⊚-assoc.⇒.commute _
-      ; iso = λ HJK → record { isoˡ = ⊚-assoc.iso.isoˡ _ ; isoʳ = ⊚-assoc.iso.isoʳ _ }
+      ; iso = λ _ → record { isoˡ = ⊚-assoc.iso.isoˡ _ ; isoʳ = ⊚-assoc.iso.isoʳ _ }
       })
     ; unitˡ = niHelper (record
-      { η       = λ (i , H) → λ⇒/ H
-      ; η⁻¹     = λ (i , H) → slice-inv (λ⇒/ H) λ⇐ (unitˡ.iso.isoˡ _)
-      ; commute = λ f → λ⇒-∘ᵥ-▷
-      ; iso     = λ iH → record { isoˡ = unitˡ.iso.isoˡ _ ; isoʳ = unitˡ.iso.isoʳ _ }
+      { η       = λ (_ , J) → λ⇒/ J
+      ; η⁻¹     = λ (_ , J) → slice-inv (λ⇒/ J) λ⇐ (unitˡ.iso.isoˡ _)
+      ; commute = λ _ → λ⇒-∘ᵥ-▷
+      ; iso     = λ _ → record { isoˡ = unitˡ.iso.isoˡ _ ; isoʳ = unitˡ.iso.isoʳ _ }
       })
     ; unitʳ = niHelper (record
-         { η       = λ (H , i) → ρ⇒/ H
-         ; η⁻¹     = λ (H , i) → slice-inv (ρ⇒/ H) ρ⇐ (unitʳ.iso.isoˡ _)
-         ; commute = λ f → ρ⇒-∘ᵥ-◁
-         ; iso     = λ Hi → record { isoˡ = unitʳ.iso.isoˡ _ ; isoʳ = unitʳ.iso.isoʳ _ } })
+         { η       = λ (J , _) → ρ⇒/ J
+         ; η⁻¹     = λ (J , _) → slice-inv (ρ⇒/ J) ρ⇐ (unitʳ.iso.isoˡ _)
+         ; commute = λ _ → ρ⇒-∘ᵥ-◁
+         ; iso     = λ _ → record { isoˡ = unitʳ.iso.isoˡ _ ; isoʳ = unitʳ.iso.isoʳ _ } })
     }
   ; triangle = triangle
   ; pentagon = pentagon

--- a/src/Categories/Bicategory/Construction/LaxSlice.agda
+++ b/src/Categories/Bicategory/Construction/LaxSlice.agda
@@ -2,17 +2,17 @@
 
 -- Mentioned in passing https://ncatlab.org/nlab/show/slice+2-category
 
-open import Categories.Bicategory
+open import Categories.Bicategory using (Bicategory)
 
 module Categories.Bicategory.Construction.LaxSlice
        {o ℓ e t}
        (𝒞 : Bicategory o ℓ e t)
        where
 
-open import Categories.Enriched.Category
-open import Categories.Category renaming (Category to 1Category)
+open import Categories.Category using () renaming (Category to 1Category)
 import Categories.Morphism.Reasoning as MR
 open import Categories.Bicategory.Extras 𝒞
+open Shorthands
 
 open import Categories.Functor.Construction.Constant using (const)
 open import Categories.Functor.Bifunctor using (Bifunctor)
@@ -104,30 +104,61 @@ module SliceHom (A : Obj) where
               open 1Category (hom X.Y A)
               open HomReasoning
 
-  
-
-LaxSlice : Obj → Bicategory (o ⊔ ℓ) (ℓ ⊔ e) e (o ⊔ t)
-LaxSlice A   = record
-  { enriched = record
-    { Obj = SliceObj A
-    ; hom = SliceHomCat
-    ; id = const (SliceHom.slicearr₁ ρ⇐)
-    ; ⊚ = _⊚'_
-    ; ⊚-assoc = λ {W X Y Z} →
-      let module W = SliceObj W
-          module X = SliceObj X
-          module Y = SliceObj Y
-          module Z = SliceObj Z
-          η' : ∀ (H : Slice⇒₁ Y Z) (J : Slice⇒₁ X Y) (K : Slice⇒₁ W X) → Slice⇒₂ ((F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) (F₀ _⊚'_ (H  , F₀ _⊚'_ (J , K)))
-          η' H J K =
-            let module H = Slice⇒₁ H
+  open Shorthands
+  open Functor
+  _⊚/_ : ∀ {X Y Z : SliceObj A} → Bifunctor (SliceHomCat Y Z) (SliceHomCat X Y) (SliceHomCat X Z)
+  _⊚/_ {X}{Y}{Z} = record
+    { F₀ = λ (H' , H) →
+           let module H' = Slice⇒₁ H'
+               module H = Slice⇒₁ H
+           in slicearr₁ ((α⇒ ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ)
+    ; F₁ = λ where
+          {H' , H} {J' , J} (γ , δ) →
+            let module H' = Slice⇒₁ H'
+                module H = Slice⇒₁ H
+                module J' = Slice⇒₁ J'
                 module J = Slice⇒₁ J
-                module K = Slice⇒₁ K
-                open 1Category (hom W.Y A)
+                module γ = Slice⇒₂ γ
+                module δ = Slice⇒₂ δ
+                open 1Category (hom X.Y A)
                 open HomReasoning
-                module Help = MR (hom W.Y A)
-            in SliceHom.slicearr₂ (begin (
-              Slice⇒₁.Δ (F₀ _⊚'_ (H  , F₀ _⊚'_ (J , K))) ≈⟨ Equiv.refl ⟩
+            in slicearr₂ (begin
+               (α⇒ ∘ᵥ J'.Δ ◁ J.h) ∘ᵥ J.Δ ≈⟨ (refl⟩∘⟨ δ.E) ⟩
+               (α⇒ ∘ᵥ J'.Δ ◁ J.h) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈⟨ ((refl⟩∘⟨ γ.E ⟩⊚⟨refl) ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ ∘ᵥ H'.Δ) ◁ J.h) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈˘⟨ (((refl⟩∘⟨ ∘ᵥ-distr-◁ ) ⟩∘⟨refl)) ⟩
+
+                -- generalized assoc
+               (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h)) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈˘⟨ assoc ⟩
+               ((α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h)) ∘ᵥ Y.arr ▷ δ.ϕ) ∘ᵥ H.Δ ≈⟨ (assoc ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h) ∘ᵥ Y.arr ▷ δ.ϕ) ∘ᵥ H.Δ ≈⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
+                   
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ (H'.Δ ◁ J.h ∘ᵥ Y.arr ▷ δ.ϕ)) ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ (refl⟩∘⟨ ◁-▷-exchg)) ⟩∘⟨refl) ⟩
+
+               -- generalized assoc
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ (Z.arr ⊚₀ H'.h ▷ δ.ϕ ∘ᵥ H'.Δ ◁ H.h)) ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ ≈˘⟨ (assoc ⟩∘⟨refl) ⟩
+               (((α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ)) ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ ≈⟨ assoc ⟩
+
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ ⊚.homomorphism) ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ ∘ᵥ id₂) ⊚₁ (id₂ ∘ᵥ δ.ϕ)) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ ((refl⟩∘⟨ identity₂ʳ ⟩⊚⟨ identity₂ˡ) ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ⊚₁ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ (⊚-assoc.⇒.commute ((id₂ , γ.ϕ) , δ.ϕ) ⟩∘⟨refl) ⟩
+               ((Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ α⇒) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ assoc ⟩
+               (Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ α⇒ ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈˘⟨ refl⟩∘⟨ assoc ⟩
+               (Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ ((α⇒ ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ)
+               ∎)
+      ; identity = ⊚.identity
+      ; homomorphism = ⊚.homomorphism
+      ; F-resp-≈ = ⊚.F-resp-≈
+      }
+      where module X = SliceObj X
+            module Y = SliceObj Y
+            module Z = SliceObj Z
+
+  
+  α⇒/ : ∀ {W X Y Z}(H : Slice⇒₁ Y Z) (J : Slice⇒₁ X Y) (K : Slice⇒₁ W X) → Slice⇒₂ ((F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) (F₀ _⊚/_ (H  , F₀ _⊚/_ (J , K)))
+  α⇒/ {W}{X}{Y}{Z} H J K =
+            slicearr₂ (begin (
+              Slice⇒₁.Δ (F₀ _⊚/_ (H  , F₀ _⊚/_ (J , K))) ≈⟨ Equiv.refl ⟩
               (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ ((α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ) ≈⟨ (refl⟩∘⟨ assoc) ⟩
               (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ α⇒ ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)   ≈˘⟨ assoc ⟩
               ((α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ α⇒) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ (assoc ⟩∘⟨refl) ⟩
@@ -141,7 +172,7 @@ LaxSlice A   = record
 
               (α⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ J.h ◁ K.h ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                     ≈˘⟨ (pentagon ⟩∘⟨refl) ⟩
   
-              (Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ K.h) ∘ᵥ H.Δ ◁ J.h ◁ K.h ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ Help.assoc²' ⟩
+              (Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ K.h) ∘ᵥ H.Δ ◁ J.h ◁ K.h ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ assoc²' ⟩
               Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ α⇒ ◁ K.h ∘ᵥ H.Δ ◁ J.h ◁ K.h ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)   ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ Equiv.sym assoc)) ⟩
 
               Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ (α⇒ ◁ K.h ∘ᵥ H.Δ ◁ J.h ◁ K.h) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ (refl⟩∘⟨ (refl⟩∘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl))) ⟩
@@ -151,11 +182,73 @@ LaxSlice A   = record
               Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ           ≈⟨ (refl⟩∘⟨ Equiv.sym assoc) ⟩
 
               Z.arr ▷ α⇒ ∘ᵥ ((α⇒ ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h)) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ)       ≈⟨ Equiv.refl ⟩
-              Z.arr ▷ α⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))
+              Z.arr ▷ α⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))
               ∎))
+    where module W = SliceObj W
+          module X = SliceObj X
+          module Y = SliceObj Y
+          module Z = SliceObj Z
+          module H = Slice⇒₁ H
+          module J = Slice⇒₁ J
+          module K = Slice⇒₁ K
+          open 1Category (hom W.Y A)
+          open HomReasoning
+          open MR (hom W.Y A) using (assoc²')
+
+  λ⇒/ : ∀ {X Y} (H : Slice⇒₁ X Y) → Slice⇒₂ (F₀ _⊚/_ (slicearr₁ ρ⇐ , H)) H
+  λ⇒/ {X}{Y} H =
+    slicearr₂ (begin (
+              H.Δ                                   ≈˘⟨ identity₂ˡ ⟩
+              id₂ ∘ᵥ H.Δ                            ≈˘⟨ (id₂◁ ⟩∘⟨refl) ⟩
+              (id₂ ◁ H.h) ∘ᵥ H.Δ                    ≈˘⟨ (unitʳ.iso.isoʳ (Y.arr , (lift _)) ⟩⊚⟨refl ⟩∘⟨refl) ⟩
+              ((ρ⇒ ∘ᵥ ρ⇐) ◁ H.h) ∘ᵥ H.Δ             ≈˘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl) ⟩
+              (ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ         ≈⟨ assoc ⟩
+              ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ           ≈˘⟨ (triangle ⟩∘⟨refl) ⟩
+              (Y.arr ▷ λ⇒ ∘ᵥ α⇒) ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ ≈⟨ assoc ⟩
+              Y.arr ▷ λ⇒ ∘ᵥ α⇒ ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ   ≈˘⟨ (refl⟩∘⟨ assoc) ⟩
+              Y.arr ▷ λ⇒ ∘ᵥ (α⇒ ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ ≈⟨ refl ⟩
+              Y.arr ▷ λ⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (slicearr₁ ρ⇐ , H))
+              ∎))
+    where module X = SliceObj X
+          module Y = SliceObj Y
+          module H = Slice⇒₁ H
+          open 1Category (hom X.Y A)
+          open HomReasoning
+
+  ρ⇒/ : ∀{X}{Y} (H : Slice⇒₁ X Y) → Slice⇒₂ (F₀ _⊚/_ (H , slicearr₁ ρ⇐)) H
+  ρ⇒/ {X}{Y} H =
+     slicearr₂ (begin (
+               H.Δ ≈˘⟨ identity₂ʳ ⟩
+               H.Δ ∘ᵥ id₂ ≈˘⟨ refl⟩∘⟨ unitʳ.iso.isoʳ (X.arr , _) ⟩
+               H.Δ ∘ᵥ ρ⇒ ∘ᵥ ρ⇐ ≈˘⟨ assoc ⟩
+               (H.Δ ∘ᵥ ρ⇒) ∘ᵥ ρ⇐ ≈˘⟨ ρ⇒-∘ᵥ-◁ ⟩∘⟨refl ⟩
+               (ρ⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ unitorʳ-coherence  ⟩∘⟨refl ⟩∘⟨refl ⟩
+               ((Y.arr ▷ ρ⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ assoc ⟩∘⟨refl ⟩
+               (Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁)) ∘ᵥ ρ⇐ ≈⟨ assoc ⟩
+               Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ refl ⟩
+               Y.arr ▷ ρ⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , slicearr₁ ρ⇐ ))
+               ∎))
+    where module X = SliceObj X
+          module Y = SliceObj Y
+          module H = Slice⇒₁ H
+          open 1Category (hom X.Y A)
+          open HomReasoning
+
+LaxSlice : Obj → Bicategory (o ⊔ ℓ) (ℓ ⊔ e) e (o ⊔ t)
+LaxSlice A   = record
+  { enriched = record
+    { Obj = SliceObj A
+    ; hom = SliceHomCat
+    ; id = const (SliceHom.slicearr₁ ρ⇐)
+    ; ⊚ = _⊚/_
+    ; ⊚-assoc = λ {W X Y Z} →
+      let module W = SliceObj W
+          module X = SliceObj X
+          module Y = SliceObj Y
+          module Z = SliceObj Z
       in 
       niHelper (record
-      { η       = λ ((H , J) , K) → η' H J K
+      { η       = λ ((H , J) , K) → α⇒/ H J K
       ; η⁻¹     = λ where
         ((H , J) , K) →
           let module H = Slice⇒₁ H
@@ -166,13 +259,13 @@ LaxSlice A   = record
           in
           SliceHom.slicearr₂ 
             (begin (
-            Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))         ≈˘⟨ identity₂ˡ ⟩
-            id₂ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) ≈⟨ (Equiv.sym ▷id₂ ⟩∘⟨refl) ⟩
-            (Z.arr ▷ id₂) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) ≈˘⟨ (refl⟩⊚⟨ ⊚-assoc.iso.isoˡ ((H.h , J.h) , K.h) ⟩∘⟨refl) ⟩
-            (Z.arr ▷ (α⇐ ∘ᵥ α⇒)) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
-            (Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) ≈⟨ assoc ⟩
-            Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚'_ (F₀ _⊚'_ (H , J) , K))) ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (η' H J K)) ⟩
-            Z.arr ▷ α⇐ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H  , F₀ _⊚'_ (J , K)))
+            Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))         ≈˘⟨ identity₂ˡ ⟩
+            id₂ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈⟨ (Equiv.sym ▷id₂ ⟩∘⟨refl) ⟩
+            (Z.arr ▷ id₂) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈˘⟨ (refl⟩⊚⟨ ⊚-assoc.iso.isoˡ ((H.h , J.h) , K.h) ⟩∘⟨refl) ⟩
+            (Z.arr ▷ (α⇐ ∘ᵥ α⇒)) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+            (Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈⟨ assoc ⟩
+            Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (α⇒/ H J K)) ⟩
+            Z.arr ▷ α⇐ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H  , F₀ _⊚/_ (J , K)))
             ∎))
 
       ; commute = λ where
@@ -191,24 +284,6 @@ LaxSlice A   = record
     ; unitˡ = λ {X}{Y} →
       let module X = SliceObj X
           module Y = SliceObj Y
-          λ⇒/ : ∀ (H : Slice⇒₁ X Y) → Slice⇒₂ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H)) H
-          λ⇒/ H =
-            let module H = Slice⇒₁ H
-                open 1Category (hom X.Y A)
-                open HomReasoning
-                open Equiv
-            in SliceHom.slicearr₂ (begin (
-              H.Δ                                   ≈˘⟨ identity₂ˡ ⟩
-              id₂ ∘ᵥ H.Δ                            ≈˘⟨ (id₂◁ ⟩∘⟨refl) ⟩
-              (id₂ ◁ H.h) ∘ᵥ H.Δ                    ≈˘⟨ (unitʳ.iso.isoʳ (Y.arr , (lift _)) ⟩⊚⟨refl ⟩∘⟨refl) ⟩
-              ((ρ⇒ ∘ᵥ ρ⇐) ◁ H.h) ∘ᵥ H.Δ             ≈˘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl) ⟩
-              (ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ         ≈⟨ assoc ⟩
-              ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ           ≈˘⟨ (triangle ⟩∘⟨refl) ⟩
-              (Y.arr ▷ λ⇒ ∘ᵥ α⇒) ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ ≈⟨ assoc ⟩
-              Y.arr ▷ λ⇒ ∘ᵥ α⇒ ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ   ≈˘⟨ (refl⟩∘⟨ assoc) ⟩
-              Y.arr ▷ λ⇒ ∘ᵥ (α⇒ ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ ≈⟨ refl ⟩
-              Y.arr ▷ λ⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H))
-              ∎))
       in niHelper (record
       { η = λ where
           (i , H) → λ⇒/ H
@@ -219,12 +294,12 @@ LaxSlice A   = record
                 open HomReasoning
                 open Equiv
             in SliceHom.slicearr₂ (begin (
-               Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H))                                   ≈˘⟨ identity₂ˡ ⟩
-               (id₂ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H)))                          ≈˘⟨ (▷id₂ ⟩∘⟨refl ) ⟩
-               (Y.arr ▷ id₂) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H))                  ≈˘⟨ (refl⟩⊚⟨ unitˡ.iso.isoˡ _ ⟩∘⟨refl) ⟩
-               (Y.arr ▷ (λ⇐ ∘ᵥ λ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H))           ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
-               ((Y.arr ▷ λ⇐) ∘ᵥ (Y.arr ▷ λ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H)) ≈⟨ assoc ⟩
-               (Y.arr ▷ λ⇐) ∘ᵥ (Y.arr ▷ λ⇒) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (SliceHom.slicearr₁ ρ⇐ , H))   ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (λ⇒/ H)) ⟩
+               Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))                                   ≈˘⟨ identity₂ˡ ⟩
+               (id₂ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H)))                          ≈˘⟨ (▷id₂ ⟩∘⟨refl ) ⟩
+               (Y.arr ▷ id₂) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))                  ≈˘⟨ (refl⟩⊚⟨ unitˡ.iso.isoˡ _ ⟩∘⟨refl) ⟩
+               (Y.arr ▷ (λ⇐ ∘ᵥ λ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))           ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+               ((Y.arr ▷ λ⇐) ∘ᵥ (Y.arr ▷ λ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H)) ≈⟨ assoc ⟩
+               (Y.arr ▷ λ⇐) ∘ᵥ (Y.arr ▷ λ⇒) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))   ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (λ⇒/ H)) ⟩
                Y.arr ▷ λ⇐ ∘ᵥ H.Δ
                ∎))
       ; commute = λ where
@@ -237,23 +312,6 @@ LaxSlice A   = record
     ; unitʳ = λ {X}{Y} →
       let module X = SliceObj X
           module Y = SliceObj Y
-          ρ⇒/ : ∀ (H : Slice⇒₁ X Y) → Slice⇒₂ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐)) H
-          ρ⇒/ H =
-            let module H = Slice⇒₁ H
-                open 1Category (hom X.Y A)
-                open HomReasoning
-                open Equiv
-            in SliceHom.slicearr₂ (begin (
-               H.Δ ≈˘⟨ identity₂ʳ ⟩
-               H.Δ ∘ᵥ id₂ ≈˘⟨ refl⟩∘⟨ unitʳ.iso.isoʳ (X.arr , _) ⟩
-               H.Δ ∘ᵥ ρ⇒ ∘ᵥ ρ⇐ ≈˘⟨ assoc ⟩
-               (H.Δ ∘ᵥ ρ⇒) ∘ᵥ ρ⇐ ≈˘⟨ ρ⇒-∘ᵥ-◁ ⟩∘⟨refl ⟩
-               (ρ⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ unitorʳ-coherence  ⟩∘⟨refl ⟩∘⟨refl ⟩
-               ((Y.arr ▷ ρ⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ assoc ⟩∘⟨refl ⟩
-               (Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁)) ∘ᵥ ρ⇐ ≈⟨ assoc ⟩
-               Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ refl ⟩
-               Y.arr ▷ ρ⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐ ))
-               ∎))
       in niHelper (record
          { η = λ (H , i) → ρ⇒/ H
          ; η⁻¹ = λ (H , i) →
@@ -262,12 +320,12 @@ LaxSlice A   = record
                 open HomReasoning
                 open Equiv
             in SliceHom.slicearr₂ (begin (
-               Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐ )) ≈˘⟨ identity₂ˡ ⟩
-               (id₂ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐ )))                          ≈˘⟨ (▷id₂ ⟩∘⟨refl ) ⟩
-               (Y.arr ▷ id₂) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐))                   ≈˘⟨ (refl⟩⊚⟨ unitʳ.iso.isoˡ _ ⟩∘⟨refl) ⟩
-               (Y.arr ▷ (ρ⇐ ∘ᵥ ρ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐))            ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
-               ((Y.arr ▷ ρ⇐) ∘ᵥ (Y.arr ▷ ρ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐ )) ≈⟨ assoc ⟩
-               (Y.arr ▷ ρ⇐) ∘ᵥ (Y.arr ▷ ρ⇒) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚'_ (H , SliceHom.slicearr₁ ρ⇐))    ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (ρ⇒/ H)) ⟩
+               Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐ )) ≈˘⟨ identity₂ˡ ⟩
+               (id₂ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐ )))                          ≈˘⟨ (▷id₂ ⟩∘⟨refl ) ⟩
+               (Y.arr ▷ id₂) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐))                   ≈˘⟨ (refl⟩⊚⟨ unitʳ.iso.isoˡ _ ⟩∘⟨refl) ⟩
+               (Y.arr ▷ (ρ⇐ ∘ᵥ ρ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐))            ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+               ((Y.arr ▷ ρ⇐) ∘ᵥ (Y.arr ▷ ρ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐ )) ≈⟨ assoc ⟩
+               (Y.arr ▷ ρ⇐) ∘ᵥ (Y.arr ▷ ρ⇒) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐))    ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (ρ⇒/ H)) ⟩
                Y.arr ▷ ρ⇐ ∘ᵥ H.Δ
                ∎))
          ; commute = λ f → ρ⇒-∘ᵥ-◁
@@ -283,51 +341,3 @@ LaxSlice A   = record
     open SliceHom A
     open Shorthands
     open Functor
-    _⊚'_ : ∀ {X Y Z : SliceObj A} → Bifunctor (SliceHomCat Y Z) (SliceHomCat X Y) (SliceHomCat X Z)
-    _⊚'_ {X}{Y}{Z} = record
-             { F₀ = λ where
-               (H' , H) →
-                 let module H' = Slice⇒₁ H'
-                     module H = Slice⇒₁ H
-                 in SliceHom.slicearr₁ ((α⇒ ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ)
-             ; F₁ = λ where
-               {H' , H} {J' , J} (γ , δ) →
-                 let module H' = Slice⇒₁ H'
-                     module H = Slice⇒₁ H
-                     module J' = Slice⇒₁ J'
-                     module J = Slice⇒₁ J
-                     module γ = Slice⇒₂ γ
-                     module δ = Slice⇒₂ δ
-                     open 1Category (hom X.Y A)
-                     open HomReasoning
-                 in SliceHom.slicearr₂ (begin
-                   (α⇒ ∘ᵥ J'.Δ ◁ J.h) ∘ᵥ J.Δ ≈⟨ (refl⟩∘⟨ δ.E) ⟩
-                   (α⇒ ∘ᵥ J'.Δ ◁ J.h) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈⟨ ((refl⟩∘⟨ γ.E ⟩⊚⟨refl) ⟩∘⟨refl) ⟩
-                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ ∘ᵥ H'.Δ) ◁ J.h) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈˘⟨ (((refl⟩∘⟨ ∘ᵥ-distr-◁ ) ⟩∘⟨refl)) ⟩
-
-                    -- generalized assoc
-                   (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h)) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈˘⟨ assoc ⟩
-                   ((α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h)) ∘ᵥ Y.arr ▷ δ.ϕ) ∘ᵥ H.Δ ≈⟨ (assoc ⟩∘⟨refl) ⟩
-                   (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h) ∘ᵥ Y.arr ▷ δ.ϕ) ∘ᵥ H.Δ ≈⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
-                   
-                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ (H'.Δ ◁ J.h ∘ᵥ Y.arr ▷ δ.ϕ)) ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ (refl⟩∘⟨ ◁-▷-exchg)) ⟩∘⟨refl) ⟩
-
-                    -- generalized assoc
-                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ (Z.arr ⊚₀ H'.h ▷ δ.ϕ ∘ᵥ H'.Δ ◁ H.h)) ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
-                   (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ ≈˘⟨ (assoc ⟩∘⟨refl) ⟩
-                   (((α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ)) ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ ≈⟨ assoc ⟩
-
-                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ ⊚.homomorphism) ⟩∘⟨refl) ⟩
-                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ ∘ᵥ id₂) ⊚₁ (id₂ ∘ᵥ δ.ϕ)) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ ((refl⟩∘⟨ identity₂ʳ ⟩⊚⟨ identity₂ˡ) ⟩∘⟨refl) ⟩
-                   (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ⊚₁ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ (⊚-assoc.⇒.commute ((id₂ , γ.ϕ) , δ.ϕ) ⟩∘⟨refl) ⟩
-                   ((Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ α⇒) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ assoc ⟩
-                   (Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ α⇒ ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈˘⟨ refl⟩∘⟨ assoc ⟩
-                   (Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ ((α⇒ ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ)
-                   ∎)
-             ; identity = ⊚.identity
-             ; homomorphism = ⊚.homomorphism
-             ; F-resp-≈ = ⊚.F-resp-≈
-             }
-         where module X = SliceObj X
-               module Y = SliceObj Y
-               module Z = SliceObj Z

--- a/src/Categories/Bicategory/Construction/LaxSlice.agda
+++ b/src/Categories/Bicategory/Construction/LaxSlice.agda
@@ -226,6 +226,23 @@ module SliceHom (A : Obj) where
           open 1Category (hom X.Y A)
           open HomReasoning
 
+  slice-inv : ∀ {X}{Y}{H : Slice⇒₁ X Y}{K} (α : Slice⇒₂ H K) → (f : Slice⇒₁.h K ⇒₂ Slice⇒₁.h H) → (f ∘ᵥ (Slice⇒₂.ϕ α) ≈ id₂) → Slice⇒₂ K H
+  slice-inv {X}{Y}{H}{K} α f p = slicearr₂ $ begin
+                  H.Δ                               ≈˘⟨ identity₂ˡ ⟩
+                  id₂ ∘ᵥ H.Δ                        ≈⟨ (Equiv.sym ▷id₂ ⟩∘⟨refl) ⟩
+                  (Y.arr ▷ id₂) ∘ᵥ H.Δ              ≈˘⟨ (refl⟩⊚⟨ p ⟩∘⟨refl) ⟩
+                  (Y.arr ▷ (f ∘ᵥ α.ϕ)) ∘ᵥ H.Δ       ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+                  (Y.arr ▷ f ∘ᵥ Y.arr ▷ α.ϕ) ∘ᵥ H.Δ ≈⟨ assoc ⟩
+                  Y.arr ▷ f ∘ᵥ Y.arr ▷ α.ϕ ∘ᵥ H.Δ   ≈˘⟨ (refl⟩∘⟨ α.E ) ⟩
+                  Y.arr ▷ f ∘ᵥ K.Δ                  ∎
+    where module X = SliceObj X
+          module Y = SliceObj Y
+          module H = Slice⇒₁ H
+          module K = Slice⇒₁ K
+          module α = Slice⇒₂ α          
+          open 1Category (hom X.Y A)
+          open HomReasoning
+
 LaxSlice : Obj → Bicategory (o ⊔ ℓ) (ℓ ⊔ e) e (o ⊔ t)
 LaxSlice A   = record
   { enriched = record
@@ -233,99 +250,25 @@ LaxSlice A   = record
     ; hom = SliceHomCat
     ; id = const (SliceHom.slicearr₁ ρ⇐)
     ; ⊚ = _⊚/_
-    ; ⊚-assoc = λ {W X Y Z} →
-      let module W = SliceObj W
-          module X = SliceObj X
-          module Y = SliceObj Y
-          module Z = SliceObj Z
-      in 
-      niHelper (record
+    ; ⊚-assoc = niHelper (record
       { η       = λ ((H , J) , K) → α⇒/ H J K
-      ; η⁻¹     = λ where
-        ((H , J) , K) →
-          let module H = Slice⇒₁ H
-              module J = Slice⇒₁ J
-              module K = Slice⇒₁ K
-              open 1Category (hom W.Y A)
-              open HomReasoning
-          in
-          SliceHom.slicearr₂ $ begin
-            Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))                                 ≈˘⟨ identity₂ˡ ⟩
-            id₂ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K)))                        ≈⟨ (Equiv.sym ▷id₂ ⟩∘⟨refl) ⟩
-            (Z.arr ▷ id₂) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K)))              ≈˘⟨ (refl⟩⊚⟨ ⊚-assoc.iso.isoˡ ((H.h , J.h) , K.h) ⟩∘⟨refl) ⟩
-            (Z.arr ▷ (α⇐ ∘ᵥ α⇒)) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K)))       ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
-            (Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈⟨ assoc ⟩
-            Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K)))   ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (α⇒/ H J K)) ⟩
-            Z.arr ▷ α⇐ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H  , F₀ _⊚/_ (J , K)))                  ∎
-
-      ; commute = λ where
-        {(H , J) , K} {(H' , J') , K'} (( β , γ ) , δ) →
-          let module β = Slice⇒₂ β
-              module γ = Slice⇒₂ γ
-              module δ = Slice⇒₂ δ
-          in ⊚-assoc.⇒.commute (((β.ϕ , γ.ϕ) , δ.ϕ))
-      ; iso = λ where
-         ((H , J) , K) →
-          let module H = Slice⇒₁ H
-              module J = Slice⇒₁ J
-              module K = Slice⇒₁ K
-          in record { isoˡ = ⊚-assoc.iso.isoˡ ((H.h , J.h) , K.h) ; isoʳ = ⊚-assoc.iso.isoʳ ( (H.h , J.h) , K.h) }
+      ; η⁻¹     = λ ((H , J) , K) → slice-inv (α⇒/ H J K) α⇐ (⊚-assoc.iso.isoˡ _)
+      ; commute = λ f → ⊚-assoc.⇒.commute _
+      ; iso = λ HJK → record { isoˡ = ⊚-assoc.iso.isoˡ _ ; isoʳ = ⊚-assoc.iso.isoʳ _ }
       })
-    ; unitˡ = λ {X}{Y} →
-      let module X = SliceObj X
-          module Y = SliceObj Y
-      in niHelper (record
-      { η = λ where
-          (i , H) → λ⇒/ H
-      ; η⁻¹ = λ where
-          (i , H) →
-            let module H = Slice⇒₁ H
-                open 1Category (hom X.Y A)
-                open HomReasoning
-                open Equiv
-            in SliceHom.slicearr₂ $ begin
-               Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))                                   ≈˘⟨ identity₂ˡ ⟩
-               (id₂ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H)))                          ≈˘⟨ (▷id₂ ⟩∘⟨refl ) ⟩
-               (Y.arr ▷ id₂) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))                  ≈˘⟨ (refl⟩⊚⟨ unitˡ.iso.isoˡ _ ⟩∘⟨refl) ⟩
-               (Y.arr ▷ (λ⇐ ∘ᵥ λ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))           ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
-               ((Y.arr ▷ λ⇐) ∘ᵥ (Y.arr ▷ λ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H)) ≈⟨ assoc ⟩
-               (Y.arr ▷ λ⇐) ∘ᵥ (Y.arr ▷ λ⇒) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))   ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (λ⇒/ H)) ⟩
-               Y.arr ▷ λ⇐ ∘ᵥ H.Δ                                                                 ∎
-      ; commute = λ where
-          {lift _ , SliceHom.slicearr₁ {Hh} HΔ} {lift _ , SliceHom.slicearr₁ {Jh} JΔ} (lift _ , SliceHom.slicearr₂ {ϕ} E) → λ⇒-∘ᵥ-▷
-      ; iso = λ where
-          (i , SliceHom.slicearr₁ {h} Δ) →
-            record { isoˡ = unitˡ.iso.isoˡ (_ , h)
-                   ; isoʳ = unitˡ.iso.isoʳ (_ , h) }
+    ; unitˡ = niHelper (record
+      { η       = λ (i , H) → λ⇒/ H
+      ; η⁻¹     = λ (i , H) → slice-inv (λ⇒/ H) λ⇐ (unitˡ.iso.isoˡ _)
+      ; commute = λ f → λ⇒-∘ᵥ-▷
+      ; iso     = λ iH → record { isoˡ = unitˡ.iso.isoˡ _ ; isoʳ = unitˡ.iso.isoʳ _ }
       })
-    ; unitʳ = λ {X}{Y} →
-      let module X = SliceObj X
-          module Y = SliceObj Y
-      in niHelper (record
-         { η = λ (H , i) → ρ⇒/ H
-         ; η⁻¹ = λ (H , i) →
-            let module H = Slice⇒₁ H
-                open 1Category (hom X.Y A)
-                open HomReasoning
-                open Equiv
-            in SliceHom.slicearr₂ $ begin
-               Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐ ))                                   ≈˘⟨ identity₂ˡ ⟩
-               (id₂ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐ )))                          ≈˘⟨ (▷id₂ ⟩∘⟨refl ) ⟩
-               (Y.arr ▷ id₂) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐))                   ≈˘⟨ (refl⟩⊚⟨ unitʳ.iso.isoˡ _ ⟩∘⟨refl) ⟩
-               (Y.arr ▷ (ρ⇐ ∘ᵥ ρ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐))            ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
-               ((Y.arr ▷ ρ⇐) ∘ᵥ (Y.arr ▷ ρ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐ )) ≈⟨ assoc ⟩
-               (Y.arr ▷ ρ⇐) ∘ᵥ (Y.arr ▷ ρ⇒) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐))    ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (ρ⇒/ H)) ⟩
-               Y.arr ▷ ρ⇐ ∘ᵥ H.Δ                                                                  ∎
+    ; unitʳ = niHelper (record
+         { η       = λ (H , i) → ρ⇒/ H
+         ; η⁻¹     = λ (H , i) → slice-inv (ρ⇒/ H) ρ⇐ (unitʳ.iso.isoˡ _)
          ; commute = λ f → ρ⇒-∘ᵥ-◁
-         ; iso = λ where
-          ((SliceHom.slicearr₁ {h} Δ) , i) →
-            record { isoˡ = unitʳ.iso.isoˡ (h , _)
-                   ; isoʳ = unitʳ.iso.isoʳ (h , _) } })
+         ; iso     = λ Hi → record { isoˡ = unitʳ.iso.isoˡ _ ; isoʳ = unitʳ.iso.isoʳ _ } })
     }
-  ; triangle = λ {X}{Y}{Z}{H}{K} → triangle
-  ; pentagon = λ {V} {W} {X} {Y} {Z} {H} {J} {K} {L} → pentagon
+  ; triangle = triangle
+  ; pentagon = pentagon
   }
-  where
-    open SliceHom A
-    open Shorthands
-    open Functor
+  where open SliceHom A

--- a/src/Categories/Bicategory/Construction/LaxSlice.agda
+++ b/src/Categories/Bicategory/Construction/LaxSlice.agda
@@ -1,6 +1,7 @@
 {-# OPTIONS --without-K --safe #-}
 
--- Mentioned in passing https://ncatlab.org/nlab/show/slice+2-category
+-- Mentioned in passing here:
+-- https://ncatlab.org/nlab/show/slice+2-category
 
 open import Categories.Bicategory using (Bicategory)
 
@@ -9,20 +10,19 @@ module Categories.Bicategory.Construction.LaxSlice
        (𝒞 : Bicategory o ℓ e t)
        where
 
-open import Categories.Category using () renaming (Category to 1Category)
-import Categories.Morphism.Reasoning as MR
+open import Data.Product using (_,_)
+open import Function using (_$_)
+open import Level using (_⊔_)
+
 open import Categories.Bicategory.Extras 𝒞
 open Shorthands
-
-open import Categories.Functor.Construction.Constant using (const)
-open import Categories.Functor.Bifunctor using (Bifunctor)
-open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism; niHelper)
-open import Function using (_$_)
-open import Data.Product using (_,_)
+open import Categories.Category using () renaming (Category to 1Category)
 open import Categories.Functor using (Functor)
 open Functor using (F₀)
-
-open import Level using (_⊔_)
+open import Categories.Functor.Bifunctor using (Bifunctor)
+open import Categories.Functor.Construction.Constant using (const)
+import Categories.Morphism.Reasoning as MR
+open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism; niHelper)
 
 record SliceObj (X : Obj) : Set (t ⊔ o) where
   constructor sliceobj
@@ -81,10 +81,7 @@ module SliceHom (A : Obj) where
     ; identityˡ = hom.identityˡ
     ; identityʳ = hom.identityʳ
     ; identity² = hom.identity²
-    ; equiv = record
-      { refl = refl
-      ; sym = sym
-      ; trans = trans }
+    ; equiv = record { refl = refl ; sym = sym ; trans = trans }
     ; ∘-resp-≈ = hom.∘-resp-≈
     }
     where

--- a/src/Categories/Bicategory/Construction/LaxSlice.agda
+++ b/src/Categories/Bicategory/Construction/LaxSlice.agda
@@ -17,6 +17,7 @@ open Shorthands
 open import Categories.Functor.Construction.Constant using (const)
 open import Categories.Functor.Bifunctor using (Bifunctor)
 open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism; niHelper)
+open import Function using (_$_)
 open import Data.Product using (_,_)
 open import Categories.Functor using (Functor)
 
@@ -54,14 +55,12 @@ module SliceHom (A : Obj) where
   open hom.Equiv
 
   _∘'_ : ∀ {X Y : SliceObj A}{H K L : Slice⇒₁ X Y} → Slice⇒₂ K L → Slice⇒₂ H K → Slice⇒₂ H L
-  _∘'_ {X}{Y}{H}{K}{L} (slicearr₂ {ϕ = ϕ} E) (slicearr₂ {ϕ = ψ} F) = slicearr₂ {ϕ = ϕ ∘ᵥ ψ} 
-     (begin
-      L.Δ ≈⟨ E ⟩
-      (Y.arr ▷ ϕ ∘ᵥ K.Δ) ≈⟨ refl⟩∘⟨ F ⟩
+  _∘'_ {X}{Y}{H}{K}{L} (slicearr₂ {ϕ = ϕ} E) (slicearr₂ {ϕ = ψ} F) = slicearr₂ {ϕ = ϕ ∘ᵥ ψ} $ begin
+      L.Δ                             ≈⟨ E ⟩
+      (Y.arr ▷ ϕ ∘ᵥ K.Δ)              ≈⟨ refl⟩∘⟨ F ⟩
       Y.arr ▷ ϕ ∘ᵥ (Y.arr ▷ ψ ∘ᵥ H.Δ) ≈˘⟨ hom.assoc ⟩
       (Y.arr ▷ ϕ ∘ᵥ Y.arr ▷ ψ) ∘ᵥ H.Δ ≈⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
-      Y.arr ▷ (ϕ ∘ᵥ ψ) ∘ᵥ H.Δ ∎
-        )
+      Y.arr ▷ (ϕ ∘ᵥ ψ) ∘ᵥ H.Δ         ∎
     where module X = SliceObj X
           module Y = SliceObj Y
           module H = Slice⇒₁ H
@@ -94,11 +93,10 @@ module SliceHom (A : Obj) where
     }
     where
       slice-id : ∀ (H : Slice⇒₁ X Y) → Slice⇒₂ H H
-      slice-id H = slicearr₂ (begin
-        (H.Δ        ≈˘⟨ identity₂ˡ ⟩
-         id₂ ∘ᵥ H.Δ ≈⟨ (sym ▷id₂ ⟩∘⟨refl) ⟩
-         (arr Y ▷ id₂) ∘ H.Δ
-         ∎))
+      slice-id H = slicearr₂ $ begin
+        H.Δ                 ≈˘⟨ identity₂ˡ ⟩
+        id₂ ∘ᵥ H.Δ          ≈⟨ (sym ▷id₂ ⟩∘⟨refl) ⟩
+        (arr Y ▷ id₂) ∘ H.Δ ∎
         where module X = SliceObj X
               module H = Slice⇒₁ H
               open 1Category (hom X.Y A)
@@ -122,30 +120,30 @@ module SliceHom (A : Obj) where
                 module δ = Slice⇒₂ δ
                 open 1Category (hom X.Y A)
                 open HomReasoning
-            in slicearr₂ (begin
-               (α⇒ ∘ᵥ J'.Δ ◁ J.h) ∘ᵥ J.Δ ≈⟨ (refl⟩∘⟨ δ.E) ⟩
-               (α⇒ ∘ᵥ J'.Δ ◁ J.h) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈⟨ ((refl⟩∘⟨ γ.E ⟩⊚⟨refl) ⟩∘⟨refl) ⟩
-               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ ∘ᵥ H'.Δ) ◁ J.h) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈˘⟨ (((refl⟩∘⟨ ∘ᵥ-distr-◁ ) ⟩∘⟨refl)) ⟩
+            in slicearr₂ $ begin
+               (α⇒ ∘ᵥ J'.Δ ◁ J.h) ∘ᵥ J.Δ                                                   ≈⟨ (refl⟩∘⟨ δ.E) ⟩
+               (α⇒ ∘ᵥ J'.Δ ◁ J.h) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ)                                  ≈⟨ ((refl⟩∘⟨ γ.E ⟩⊚⟨refl) ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ ∘ᵥ H'.Δ) ◁ J.h) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ)                 ≈˘⟨ (((refl⟩∘⟨ ∘ᵥ-distr-◁ ) ⟩∘⟨refl)) ⟩
 
                 -- generalized assoc
-               (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h)) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ) ≈˘⟨ assoc ⟩
-               ((α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h)) ∘ᵥ Y.arr ▷ δ.ϕ) ∘ᵥ H.Δ ≈⟨ (assoc ⟩∘⟨refl) ⟩
-               (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h) ∘ᵥ Y.arr ▷ δ.ϕ) ∘ᵥ H.Δ ≈⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h)) ∘ᵥ (Y.arr ▷ δ.ϕ ∘ᵥ H.Δ)         ≈˘⟨ assoc ⟩
+               ((α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h)) ∘ᵥ Y.arr ▷ δ.ϕ) ∘ᵥ H.Δ         ≈⟨ (assoc ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ H'.Δ ◁ J.h) ∘ᵥ Y.arr ▷ δ.ϕ) ∘ᵥ H.Δ           ≈⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
                    
-               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ (H'.Δ ◁ J.h ∘ᵥ Y.arr ▷ δ.ϕ)) ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ (refl⟩∘⟨ ◁-▷-exchg)) ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ (H'.Δ ◁ J.h ∘ᵥ Y.arr ▷ δ.ϕ)) ∘ᵥ H.Δ           ≈˘⟨ ((refl⟩∘⟨ (refl⟩∘⟨ ◁-▷-exchg)) ⟩∘⟨refl) ⟩
 
                -- generalized assoc
-               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ (Z.arr ⊚₀ H'.h ▷ δ.ϕ ∘ᵥ H'.Δ ◁ H.h)) ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
-               (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ ≈˘⟨ (assoc ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ (Z.arr ⊚₀ H'.h ▷ δ.ϕ ∘ᵥ H'.Δ ◁ H.h)) ∘ᵥ H.Δ   ≈˘⟨ ((refl⟩∘⟨ assoc) ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ ((Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ   ≈˘⟨ (assoc ⟩∘⟨refl) ⟩
                (((α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ)) ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ ≈⟨ assoc ⟩
 
-               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈˘⟨ ((refl⟩∘⟨ ⊚.homomorphism) ⟩∘⟨refl) ⟩
-               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ ∘ᵥ id₂) ⊚₁ (id₂ ∘ᵥ δ.ϕ)) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ ((refl⟩∘⟨ identity₂ʳ ⟩⊚⟨ identity₂ˡ) ⟩∘⟨refl) ⟩
-               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ⊚₁ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ (⊚-assoc.⇒.commute ((id₂ , γ.ϕ) , δ.ϕ) ⟩∘⟨refl) ⟩
-               ((Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ α⇒) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈⟨ assoc ⟩
-               (Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ α⇒ ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ ≈˘⟨ refl⟩∘⟨ assoc ⟩
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ◁ J.h ∘ᵥ Z.arr ⊚₀ H'.h ▷ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ     ≈˘⟨ ((refl⟩∘⟨ ⊚.homomorphism) ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ ∘ᵥ id₂) ⊚₁ (id₂ ∘ᵥ δ.ϕ)) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ           ≈⟨ ((refl⟩∘⟨ identity₂ʳ ⟩⊚⟨ identity₂ˡ) ⟩∘⟨refl) ⟩
+               (α⇒ ∘ᵥ (Z.arr ▷ γ.ϕ) ⊚₁ δ.ϕ) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ                           ≈⟨ (⊚-assoc.⇒.commute ((id₂ , γ.ϕ) , δ.ϕ) ⟩∘⟨refl) ⟩
+               ((Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ α⇒) ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ                           ≈⟨ assoc ⟩
+               (Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ α⇒ ∘ᵥ H'.Δ ◁ H.h ∘ᵥ H.Δ                             ≈˘⟨ refl⟩∘⟨ assoc ⟩
                (Z.arr ▷ γ.ϕ ⊚₁ δ.ϕ) ∘ᵥ ((α⇒ ∘ᵥ H'.Δ ◁ H.h) ∘ᵥ H.Δ)
-               ∎)
+               ∎
       ; identity = ⊚.identity
       ; homomorphism = ⊚.homomorphism
       ; F-resp-≈ = ⊚.F-resp-≈
@@ -156,13 +154,12 @@ module SliceHom (A : Obj) where
 
   
   α⇒/ : ∀ {W X Y Z}(H : Slice⇒₁ Y Z) (J : Slice⇒₁ X Y) (K : Slice⇒₁ W X) → Slice⇒₂ ((F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) (F₀ _⊚/_ (H  , F₀ _⊚/_ (J , K)))
-  α⇒/ {W}{X}{Y}{Z} H J K =
-            slicearr₂ (begin (
+  α⇒/ {W}{X}{Y}{Z} H J K = slicearr₂ $ begin
               Slice⇒₁.Δ (F₀ _⊚/_ (H  , F₀ _⊚/_ (J , K))) ≈⟨ Equiv.refl ⟩
-              (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ ((α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ) ≈⟨ (refl⟩∘⟨ assoc) ⟩
-              (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ α⇒ ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)   ≈˘⟨ assoc ⟩
-              ((α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ α⇒) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ (assoc ⟩∘⟨refl) ⟩
-              (α⇒ ∘ᵥ (H.Δ ◁ J.h ⊚₀ K.h ∘ᵥ α⇒)) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ) ≈⟨ assoc ⟩
+              (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ ((α⇒ ∘ᵥ J.Δ ◁ K.h) ∘ᵥ K.Δ)                  ≈⟨ (refl⟩∘⟨ assoc) ⟩
+              (α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ α⇒ ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                    ≈˘⟨ assoc ⟩
+              ((α⇒ ∘ᵥ H.Δ ◁ J.h ⊚₀ K.h) ∘ᵥ α⇒) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                  ≈⟨ (assoc ⟩∘⟨refl) ⟩
+              (α⇒ ∘ᵥ (H.Δ ◁ J.h ⊚₀ K.h ∘ᵥ α⇒)) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                  ≈⟨ assoc ⟩
 
               α⇒ ∘ᵥ (H.Δ ◁ J.h ⊚₀ K.h ∘ᵥ α⇒) ∘ᵥ (J.Δ ◁ K.h ∘ᵥ K.Δ)                    ≈˘⟨ (refl⟩∘⟨ (α⇒-◁-∘ₕ  ⟩∘⟨refl)) ⟩
   
@@ -182,8 +179,7 @@ module SliceHom (A : Obj) where
               Z.arr ▷ α⇒ ∘ᵥ α⇒ ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ           ≈⟨ (refl⟩∘⟨ Equiv.sym assoc) ⟩
 
               Z.arr ▷ α⇒ ∘ᵥ ((α⇒ ∘ᵥ (((α⇒ ∘ᵥ H.Δ ◁ J.h)) ∘ᵥ J.Δ) ◁ K.h) ∘ᵥ K.Δ)       ≈⟨ Equiv.refl ⟩
-              Z.arr ▷ α⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))
-              ∎))
+              Z.arr ▷ α⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))                 ∎
     where module W = SliceObj W
           module X = SliceObj X
           module Y = SliceObj Y
@@ -196,19 +192,17 @@ module SliceHom (A : Obj) where
           open MR (hom W.Y A) using (assoc²')
 
   λ⇒/ : ∀ {X Y} (H : Slice⇒₁ X Y) → Slice⇒₂ (F₀ _⊚/_ (slicearr₁ ρ⇐ , H)) H
-  λ⇒/ {X}{Y} H =
-    slicearr₂ (begin (
-              H.Δ                                   ≈˘⟨ identity₂ˡ ⟩
-              id₂ ∘ᵥ H.Δ                            ≈˘⟨ (id₂◁ ⟩∘⟨refl) ⟩
-              (id₂ ◁ H.h) ∘ᵥ H.Δ                    ≈˘⟨ (unitʳ.iso.isoʳ (Y.arr , (lift _)) ⟩⊚⟨refl ⟩∘⟨refl) ⟩
-              ((ρ⇒ ∘ᵥ ρ⇐) ◁ H.h) ∘ᵥ H.Δ             ≈˘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl) ⟩
-              (ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ         ≈⟨ assoc ⟩
-              ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ           ≈˘⟨ (triangle ⟩∘⟨refl) ⟩
-              (Y.arr ▷ λ⇒ ∘ᵥ α⇒) ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ ≈⟨ assoc ⟩
-              Y.arr ▷ λ⇒ ∘ᵥ α⇒ ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ   ≈˘⟨ (refl⟩∘⟨ assoc) ⟩
-              Y.arr ▷ λ⇒ ∘ᵥ (α⇒ ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ ≈⟨ refl ⟩
-              Y.arr ▷ λ⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (slicearr₁ ρ⇐ , H))
-              ∎))
+  λ⇒/ {X}{Y} H = slicearr₂ $ begin
+              H.Δ                                                  ≈˘⟨ identity₂ˡ ⟩
+              id₂ ∘ᵥ H.Δ                                           ≈˘⟨ (id₂◁ ⟩∘⟨refl) ⟩
+              (id₂ ◁ H.h) ∘ᵥ H.Δ                                   ≈˘⟨ (unitʳ.iso.isoʳ (Y.arr , (lift _)) ⟩⊚⟨refl ⟩∘⟨refl) ⟩
+              ((ρ⇒ ∘ᵥ ρ⇐) ◁ H.h) ∘ᵥ H.Δ                            ≈˘⟨ (∘ᵥ-distr-◁ ⟩∘⟨refl) ⟩
+              (ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ                        ≈⟨ assoc ⟩
+              ρ⇒ ◁ H.h ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ                          ≈˘⟨ (triangle ⟩∘⟨refl) ⟩
+              (Y.arr ▷ λ⇒ ∘ᵥ α⇒) ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ                ≈⟨ assoc ⟩
+              Y.arr ▷ λ⇒ ∘ᵥ α⇒ ∘ᵥ ρ⇐ ◁ H.h ∘ᵥ H.Δ                  ≈˘⟨ (refl⟩∘⟨ assoc) ⟩
+              Y.arr ▷ λ⇒ ∘ᵥ (α⇒ ∘ᵥ ρ⇐ ◁ H.h) ∘ᵥ H.Δ                ≈⟨ refl ⟩
+              Y.arr ▷ λ⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (slicearr₁ ρ⇐ , H)) ∎
     where module X = SliceObj X
           module Y = SliceObj Y
           module H = Slice⇒₁ H
@@ -216,18 +210,16 @@ module SliceHom (A : Obj) where
           open HomReasoning
 
   ρ⇒/ : ∀{X}{Y} (H : Slice⇒₁ X Y) → Slice⇒₂ (F₀ _⊚/_ (H , slicearr₁ ρ⇐)) H
-  ρ⇒/ {X}{Y} H =
-     slicearr₂ (begin (
-               H.Δ ≈˘⟨ identity₂ʳ ⟩
-               H.Δ ∘ᵥ id₂ ≈˘⟨ refl⟩∘⟨ unitʳ.iso.isoʳ (X.arr , _) ⟩
-               H.Δ ∘ᵥ ρ⇒ ∘ᵥ ρ⇐ ≈˘⟨ assoc ⟩
-               (H.Δ ∘ᵥ ρ⇒) ∘ᵥ ρ⇐ ≈˘⟨ ρ⇒-∘ᵥ-◁ ⟩∘⟨refl ⟩
-               (ρ⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ unitorʳ-coherence  ⟩∘⟨refl ⟩∘⟨refl ⟩
-               ((Y.arr ▷ ρ⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ assoc ⟩∘⟨refl ⟩
-               (Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁)) ∘ᵥ ρ⇐ ≈⟨ assoc ⟩
-               Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐ ≈⟨ refl ⟩
-               Y.arr ▷ ρ⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , slicearr₁ ρ⇐ ))
-               ∎))
+  ρ⇒/ {X}{Y} H = slicearr₂ $ begin
+               H.Δ                                                   ≈˘⟨ identity₂ʳ ⟩
+               H.Δ ∘ᵥ id₂                                            ≈˘⟨ refl⟩∘⟨ unitʳ.iso.isoʳ (X.arr , _) ⟩
+               H.Δ ∘ᵥ ρ⇒ ∘ᵥ ρ⇐                                       ≈˘⟨ assoc ⟩
+               (H.Δ ∘ᵥ ρ⇒) ∘ᵥ ρ⇐                                     ≈˘⟨ ρ⇒-∘ᵥ-◁ ⟩∘⟨refl ⟩
+               (ρ⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐                               ≈⟨ unitorʳ-coherence  ⟩∘⟨refl ⟩∘⟨refl ⟩
+               ((Y.arr ▷ ρ⇒ ∘ᵥ α⇒) ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐               ≈⟨ assoc ⟩∘⟨refl ⟩
+               (Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁)) ∘ᵥ ρ⇐               ≈⟨ assoc ⟩
+               Y.arr ▷ ρ⇒ ∘ᵥ (α⇒ ∘ᵥ H.Δ ◁ id₁) ∘ᵥ ρ⇐                 ≈⟨ refl ⟩
+               Y.arr ▷ ρ⇒ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , slicearr₁ ρ⇐ )) ∎
     where module X = SliceObj X
           module Y = SliceObj Y
           module H = Slice⇒₁ H
@@ -257,16 +249,14 @@ LaxSlice A   = record
               open 1Category (hom W.Y A)
               open HomReasoning
           in
-          SliceHom.slicearr₂ 
-            (begin (
-            Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))         ≈˘⟨ identity₂ˡ ⟩
-            id₂ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈⟨ (Equiv.sym ▷id₂ ⟩∘⟨refl) ⟩
-            (Z.arr ▷ id₂) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈˘⟨ (refl⟩⊚⟨ ⊚-assoc.iso.isoˡ ((H.h , J.h) , K.h) ⟩∘⟨refl) ⟩
-            (Z.arr ▷ (α⇐ ∘ᵥ α⇒)) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+          SliceHom.slicearr₂ $ begin
+            Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))                                 ≈˘⟨ identity₂ˡ ⟩
+            id₂ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K)))                        ≈⟨ (Equiv.sym ▷id₂ ⟩∘⟨refl) ⟩
+            (Z.arr ▷ id₂) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K)))              ≈˘⟨ (refl⟩⊚⟨ ⊚-assoc.iso.isoˡ ((H.h , J.h) , K.h) ⟩∘⟨refl) ⟩
+            (Z.arr ▷ (α⇐ ∘ᵥ α⇒)) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K)))       ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
             (Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒) ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈⟨ assoc ⟩
-            Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K))) ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (α⇒/ H J K)) ⟩
-            Z.arr ▷ α⇐ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H  , F₀ _⊚/_ (J , K)))
-            ∎))
+            Z.arr ▷ α⇐ ∘ᵥ Z.arr ▷ α⇒ ∘ᵥ (Slice⇒₁.Δ (F₀ _⊚/_ (F₀ _⊚/_ (H , J) , K)))   ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (α⇒/ H J K)) ⟩
+            Z.arr ▷ α⇐ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H  , F₀ _⊚/_ (J , K)))                  ∎
 
       ; commute = λ where
         {(H , J) , K} {(H' , J') , K'} (( β , γ ) , δ) →
@@ -293,15 +283,14 @@ LaxSlice A   = record
                 open 1Category (hom X.Y A)
                 open HomReasoning
                 open Equiv
-            in SliceHom.slicearr₂ (begin (
+            in SliceHom.slicearr₂ $ begin
                Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))                                   ≈˘⟨ identity₂ˡ ⟩
                (id₂ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H)))                          ≈˘⟨ (▷id₂ ⟩∘⟨refl ) ⟩
                (Y.arr ▷ id₂) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))                  ≈˘⟨ (refl⟩⊚⟨ unitˡ.iso.isoˡ _ ⟩∘⟨refl) ⟩
                (Y.arr ▷ (λ⇐ ∘ᵥ λ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))           ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
                ((Y.arr ▷ λ⇐) ∘ᵥ (Y.arr ▷ λ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H)) ≈⟨ assoc ⟩
                (Y.arr ▷ λ⇐) ∘ᵥ (Y.arr ▷ λ⇒) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (SliceHom.slicearr₁ ρ⇐ , H))   ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (λ⇒/ H)) ⟩
-               Y.arr ▷ λ⇐ ∘ᵥ H.Δ
-               ∎))
+               Y.arr ▷ λ⇐ ∘ᵥ H.Δ                                                                 ∎
       ; commute = λ where
           {lift _ , SliceHom.slicearr₁ {Hh} HΔ} {lift _ , SliceHom.slicearr₁ {Jh} JΔ} (lift _ , SliceHom.slicearr₂ {ϕ} E) → λ⇒-∘ᵥ-▷
       ; iso = λ where
@@ -319,15 +308,14 @@ LaxSlice A   = record
                 open 1Category (hom X.Y A)
                 open HomReasoning
                 open Equiv
-            in SliceHom.slicearr₂ (begin (
-               Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐ )) ≈˘⟨ identity₂ˡ ⟩
+            in SliceHom.slicearr₂ $ begin
+               Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐ ))                                   ≈˘⟨ identity₂ˡ ⟩
                (id₂ ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐ )))                          ≈˘⟨ (▷id₂ ⟩∘⟨refl ) ⟩
                (Y.arr ▷ id₂) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐))                   ≈˘⟨ (refl⟩⊚⟨ unitʳ.iso.isoˡ _ ⟩∘⟨refl) ⟩
                (Y.arr ▷ (ρ⇐ ∘ᵥ ρ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐))            ≈˘⟨ (∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
                ((Y.arr ▷ ρ⇐) ∘ᵥ (Y.arr ▷ ρ⇒)) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐ )) ≈⟨ assoc ⟩
                (Y.arr ▷ ρ⇐) ∘ᵥ (Y.arr ▷ ρ⇒) ∘ᵥ Slice⇒₁.Δ (F₀ _⊚/_ (H , SliceHom.slicearr₁ ρ⇐))    ≈˘⟨ (refl⟩∘⟨ Slice⇒₂.E (ρ⇒/ H)) ⟩
-               Y.arr ▷ ρ⇐ ∘ᵥ H.Δ
-               ∎))
+               Y.arr ▷ ρ⇐ ∘ᵥ H.Δ                                                                  ∎
          ; commute = λ f → ρ⇒-∘ᵥ-◁
          ; iso = λ where
           ((SliceHom.slicearr₁ {h} Δ) , i) →


### PR DESCRIPTION
The lax slice bicategory is like the slice category, but rather than a commuting triangle you get a 2-cell.

This is my first time using Agda in earnest so I am not very adept at using the module system, so some code review would help here for sure. I'm not really sure if I got the naming conventions right. I based most of the naming on the slice 1-category.

Some caveats
1. I still have two spots of yellow in Emacs when I type check on Line 310. I'm not sure how to debug this.
2. Type checking at least while it was incomplete became *very* slow. When I was working on the unitors I had to comment out the associator proofs to speed things up. Not sure what the best practice is for mitigating this. Should I break it up into multiple files? Maybe move the SliceHom module into a different file.
3. The proofs sometimes had several lines in a row of associativity, is there a simpler way to do this? A reflective free category solver maybe?
4. One proof (inverse of the right unitor) is a copy-paste-rename of the proof for the inverse of the left unitor. This should probably be a lemma instead.