### PR TITLE
2-Terminal Object and 2-Product

### DIFF
--- a/src/Categories/Bicategory/Object/Product.agda
+++ b/src/Categories/Bicategory/Object/Product.agda
@@ -1,0 +1,32 @@
+{-# OPTIONS --without-K --safe #-}
+open import Categories.Bicategory using (Bicategory)
+
+module Categories.Bicategory.Object.Product {o ℓ e t} (𝒞 : Bicategory o ℓ e t) where
+
+open import Level
+
+open Bicategory 𝒞
+open import Categories.Category using (_[_,_])
+open import Categories.Morphism using (_≅_)
+open import Categories.Morphism.Notation using (_[_≅_])
+
+record Product  (A B : Obj) : Set (o ⊔ ℓ ⊔ e ⊔ t) where
+  infix 10 ⟨_,_⟩₁ ⟨_,_⟩₂
+  field
+    A×B : Obj
+    πa : A×B ⇒₁ A
+    πb : A×B ⇒₁ B
+    ⟨_,_⟩₁ : ∀ {Γ} → Γ ⇒₁ A → Γ ⇒₁ B → Γ ⇒₁ A×B
+    ⟨_,_⟩₂ : ∀ {Γ}{fa ga : Γ ⇒₁ A}{fb gb : Γ ⇒₁ B}
+           → fa ⇒₂ ga → fb ⇒₂ gb → ⟨ fa , fb ⟩₁ ⇒₂ ⟨ ga , gb ⟩₁
+
+    β₁a : ∀ {Γ} f g → hom Γ A [ πa ∘₁ ⟨ f , g ⟩₁  ≅ f ]
+    β₁b : ∀ {Γ} f g → hom Γ B [ πb ∘₁ ⟨ f , g ⟩₁  ≅ g ]
+    β₂a : ∀ {Γ}{fa ga fb gb}(αa : hom Γ A [ fa , ga ])(αb : hom Γ B [ fb , gb ])
+        → πa ▷ ⟨ αa , αb ⟩₂ ≈ _≅_.to (β₁a _ _) ∘ᵥ αa ∘ᵥ _≅_.from (β₁a _ _)
+    β₂b : ∀ {Γ}{fa ga fb gb}(αa : hom Γ A [ fa , ga ])(αb : hom Γ B [ fb , gb ])
+        → πb ▷ ⟨ αa , αb ⟩₂ ≈ _≅_.to (β₁b _ _) ∘ᵥ αb ∘ᵥ _≅_.from (β₁b _ _)
+
+    η₁ : ∀ {Γ} p → hom Γ A×B [ p ≅ ⟨ πa ∘₁ p , πb ∘₁ p ⟩₁ ]
+    η₂ : ∀ {Γ}{p p'}(ϕ : hom Γ A×B [ p , p' ])
+       → ϕ ≈ _≅_.to (η₁ _) ∘ᵥ ⟨ (πa ▷ ϕ) , (πb ▷ ϕ) ⟩₂ ∘ᵥ _≅_.from (η₁ _)

--- a/src/Categories/Bicategory/Object/Product.agda
+++ b/src/Categories/Bicategory/Object/Product.agda
@@ -8,6 +8,7 @@ open import Level
 open Bicategory 𝒞
 open import Categories.Category using (_[_,_])
 open import Categories.Morphism using (_≅_)
+open import Categories.Morphism.HeterogeneousEquality
 open import Categories.Morphism.Notation using (_[_≅_])
 
 record Product  (A B : Obj) : Set (o ⊔ ℓ ⊔ e ⊔ t) where
@@ -23,10 +24,10 @@ record Product  (A B : Obj) : Set (o ⊔ ℓ ⊔ e ⊔ t) where
     β₁a : ∀ {Γ} f g → hom Γ A [ πa ∘₁ ⟨ f , g ⟩₁  ≅ f ]
     β₁b : ∀ {Γ} f g → hom Γ B [ πb ∘₁ ⟨ f , g ⟩₁  ≅ g ]
     β₂a : ∀ {Γ}{fa ga fb gb}(αa : hom Γ A [ fa , ga ])(αb : hom Γ B [ fb , gb ])
-        → πa ▷ ⟨ αa , αb ⟩₂ ≈ _≅_.to (β₁a _ _) ∘ᵥ αa ∘ᵥ _≅_.from (β₁a _ _)
+        → Along β₁a _ _ , β₁a _ _ [ πa ▷ ⟨ αa , αb ⟩₂ ≈ αa ] 
     β₂b : ∀ {Γ}{fa ga fb gb}(αa : hom Γ A [ fa , ga ])(αb : hom Γ B [ fb , gb ])
-        → πb ▷ ⟨ αa , αb ⟩₂ ≈ _≅_.to (β₁b _ _) ∘ᵥ αb ∘ᵥ _≅_.from (β₁b _ _)
+        → Along β₁b _ _ , β₁b _ _ [ πb ▷ ⟨ αa , αb ⟩₂ ≈ αb ] 
 
     η₁ : ∀ {Γ} p → hom Γ A×B [ p ≅ ⟨ πa ∘₁ p , πb ∘₁ p ⟩₁ ]
     η₂ : ∀ {Γ}{p p'}(ϕ : hom Γ A×B [ p , p' ])
-       → ϕ ≈ _≅_.to (η₁ _) ∘ᵥ ⟨ (πa ▷ ϕ) , (πb ▷ ϕ) ⟩₂ ∘ᵥ _≅_.from (η₁ _)
+       → Along (η₁ _) , (η₁ _) [ ϕ ≈ ⟨ πa ▷ ϕ , πb ▷ ϕ ⟩₂ ]

--- a/src/Categories/Bicategory/Object/Terminal.agda
+++ b/src/Categories/Bicategory/Object/Terminal.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --without-K --safe #-}
+open import Categories.Bicategory using (Bicategory)
+
+module Categories.Bicategory.Object.Terminal {o ℓ e t} (𝒞 : Bicategory o ℓ e t) where
+
+open Bicategory 𝒞
+open import Level
+open import Categories.Category using (_[_,_])
+open import Categories.Morphism.Notation using (_[_≅_])
+open import Categories.Morphism using (_≅_)
+
+record IsTerminal (⊤ : Obj) : Set (o ⊔ ℓ ⊔ e ⊔ t) where
+  field
+    !₁ : {A : Obj} → (A ⇒₁ ⊤)
+    !₂ : {A : Obj} → !₁ {A} ⇒₂ !₁
+
+    η₁ : ∀ {A} f → hom A ⊤ [ f ≅ !₁ ]
+    η₂ : ∀ {A}{f g}(α : hom A ⊤ [ f , g ])
+       → α ≈ _≅_.to (η₁ _) ∘ᵥ !₂ ∘ᵥ _≅_.from (η₁ _)

--- a/src/Categories/Bicategory/Object/Terminal.agda
+++ b/src/Categories/Bicategory/Object/Terminal.agda
@@ -6,6 +6,7 @@ module Categories.Bicategory.Object.Terminal {o ℓ e t} (𝒞 : Bicategory o �
 open Bicategory 𝒞
 open import Level
 open import Categories.Category using (_[_,_])
+open import Categories.Morphism.HeterogeneousEquality using (Along_,_[_≈_])
 open import Categories.Morphism.Notation using (_[_≅_])
 open import Categories.Morphism using (_≅_)
 
@@ -16,4 +17,5 @@ record IsTerminal (⊤ : Obj) : Set (o ⊔ ℓ ⊔ e ⊔ t) where
 
     η₁ : ∀ {A} f → hom A ⊤ [ f ≅ !₁ ]
     η₂ : ∀ {A}{f g}(α : hom A ⊤ [ f , g ])
-       → α ≈ _≅_.to (η₁ _) ∘ᵥ !₂ ∘ᵥ _≅_.from (η₁ _)
+       → Along η₁ _ , η₁ _ [ α ≈ !₂ ] 
+

--- a/src/Categories/Morphism/HeterogeneousEquality.agda
+++ b/src/Categories/Morphism/HeterogeneousEquality.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --without-K --safe #-}
+open import Categories.Category using (Category; module Definitions)
+
+module Categories.Morphism.HeterogeneousEquality where
+
+open import Level
+
+open import Categories.Category using (_[_,_]; _[_≈_])
+open import Categories.Morphism using (_≅_)
+open import Categories.Morphism.Notation using (_[_≅_])
+
+private
+  variable
+    o ℓ e : Level
+
+
+Along_,_[_≈_] : {C : Category o ℓ e}{A A' B B' : Category.Obj C}
+              → (i : C [ A ≅ A' ])(j : C [ B ≅ B' ])(f : C [ A , B ])(f' : C [ A' , B' ]) → Set e
+Along_,_[_≈_] {C = C} i j f f' = C [ _≅_.from j ∘ f ≈ f' ∘ _≅_.from i ]
+  where open Category C


### PR DESCRIPTION
A couple of simple examples of 2-limits to get us started discussing design decisions.

I have been playing with the 2-Yoneda lemma to try to figure out what the correct version of these is. I think I have figured out a simple/systematic presentation but it will be nice to prove these equivalent to a definition by representable 2-functors at some point.

The terminal object definition can probably be simplified further but I wanted to show the general pattern.
For these two examples you basically need a 1-cell and 2-cell version of the "introduction form" and correspondingly need 1-cell beta/eta isomorphisms, and then 2-cell beta/eta equations that only make sense "up to" 1-cell beta/eta isomorphisms.

It would simplify the 2-cell beta/eta (and I think based on sketching comma objects generally useful) to have a notation for the situation where
```
i : A ≅ A'
j : B ≅ B'
f : A → B
g : A' → B'
```
and we want to say `f` is equal to `g` along this isomorphism.
```
Along i j [ f ≈ g ]
```
maybe? It looks like this is a morphism in an arrow category, so maybe there's something already in the library for this?

For instance in this notation, `η₂` would become
```
η₂ : ∀ {Γ}{p p'}(ϕ : hom Γ A×B [ p , p' ])
   → Along (η₁ _) (η₁ _) [ ϕ ≈ ⟨ (πa ▷ ϕ) , (πb ▷ ϕ) ⟩₂ ]
```
This is in the spirit of viewing isomorphism as equality. In the strict version, the 1-cell beta/eta *are* equalities.

Aside: I think the HoTT people have a name for this. "path-over" or something like that, but I couldn't find anything with some quick googling.

Any advice on which arguments should be implicit would also be appreciated.

