### PR TITLE
Remove broken, unused, AllProducts and IndexedProduct

### DIFF
--- a/src/Categories/Object/Product/Indexed.agda
+++ b/src/Categories/Object/Product/Indexed.agda
@@ -37,16 +37,5 @@ record IndexedProductOf {i} {I : Set i} (P : I → Obj) : Set (i ⊔ o ⊔ e ⊔
   unique′ : ∀ {Y} (h h′ : Y ⇒ X) → (∀ i → π i ∘ h′ ≈ π i ∘ h) → h′ ≈ h
   unique′ h h′ f = trans (⟺ (unique _ _ f)) (η _)
 
-
-record IndexedProduct {i} (I : Set i) : Set (i ⊔ o ⊔ e ⊔ ℓ) where
-  field
-    P         : I → Obj
-    productOf : IndexedProductOf P
-
-  open IndexedProductOf productOf public
-
-AllProducts : ∀ i → Set (o ⊔ ℓ ⊔ e ⊔ suc i)
-AllProducts i = (I : Set i) → IndexedProduct I
-
 AllProductsOf : ∀ i → Set (o ⊔ ℓ ⊔ e ⊔ suc i)
 AllProductsOf i = ∀ {I : Set i} (P : I → Obj) → IndexedProductOf P


### PR DESCRIPTION
This construction was significantly weaker than its name suggested. See https://github.com/agda/agda-categories/issues/258#issuecomment-889119426 for proof that `AllProducts` was implied by `Terminal`. It is also unused.

Closes #258 