### PR TITLE
add kleisli triple

### DIFF
--- a/src/Categories/Adjoint/Relative.agda
+++ b/src/Categories/Adjoint/Relative.agda
@@ -68,6 +68,7 @@ RA⇒RMonad {C = C} {D} {E} {J} RA = record
   ; identityʳ = idʳ
   ; identityˡ = R.F-resp-≈ (iso.isoʳ _ D.Equiv.refl) ○ R.identity
   ; assoc = a
+  ; sym-assoc = sym a
   ; extend-≈ = λ k≈h → F-resp-≈ R (Π.cong (⇒.η _) k≈h)
   }
   where
@@ -82,6 +83,7 @@ RA⇒RMonad {C = C} {D} {E} {J} RA = record
   open Category C
   open HomReasoning
   open MR C
+  open Equiv using (sym)
   idʳ : {x y : E.Obj} {k : J.₀ x ⇒ F₀ (R ∘F L) y} → R.₁ (⇒.η (x , L.₀ y) ⟨$⟩ k) ∘ (⇐.η (x , L.₀ x) ⟨$⟩ D.id) ≈ k
   idʳ {x} {y} {k} = begin
     R.₁ (⇒.η (x , L.₀ y) ⟨$⟩ k) ∘ (⇐.η (x , L.₀ x) ⟨$⟩ D.id)               ≈⟨ introʳ J.identity ⟩

--- a/src/Categories/Comonad/Construction/CoKleisli.agda
+++ b/src/Categories/Comonad/Construction/CoKleisli.agda
@@ -1,0 +1,116 @@
+{-# OPTIONS --without-K --safe #-}
+
+module Categories.Comonad.Construction.CoKleisli where
+
+-- Definition of kleisli cotriple as a relative comonad
+-- and the equivalence of kleisli cotriple and comonad
+-- mostly dual to Categories.Monad.Construction.Kleisli
+
+open import Level
+open import Categories.Category.Core using (Category)
+open import Categories.Comonad.Relative using (RComonad⇒Functor) renaming (Comonad to RComonad)
+open import Categories.Comonad using (Comonad)
+open import Categories.Functor using (Functor; Endofunctor; _∘F_) renaming (id to idF)
+open import Categories.NaturalTransformation using (ntHelper; NaturalTransformation)
+import Categories.Morphism.Reasoning as MR
+
+private
+  variable
+    o ℓ e : Level
+
+module _ (C : Category o ℓ e) where
+  open Category C
+  open HomReasoning
+  open Equiv
+  open MR C
+
+  -- a kleisli cotriple is a relative monad with J = idF
+  KleisliCotriple : Set (o ⊔ ℓ ⊔ e)
+  KleisliCotriple = RComonad {C = C} idF
+
+  -- kleisli cotriples are equivalent to comonads
+  Kleisli⇒Comonad : KleisliCotriple → Comonad C
+  Kleisli⇒Comonad K = record
+    { F = F
+    ; ε = ε
+    ; δ = δ
+    ; assoc = assoc'
+    ; sym-assoc = sym assoc'
+    ; identityˡ = identityˡ'
+    ; identityʳ = K.identityʳ
+    }
+    where
+      module K = RComonad K
+      open K using (counit; cobind)
+
+      -- Extract a functor from the relative comonad
+      F : Endofunctor C
+      F = RComonad⇒Functor K
+      open Functor F using (F₀; F₁)
+
+      -- constructing ε from counit
+      ε = ntHelper {F = F} {G = idF} record
+        { η = λ X → counit
+        ; commute = λ f → K.identityʳ
+        }
+
+      -- helper for δ.commute and assoc'
+      commute' : ∀ {X Y : Obj } (f : F₀ Y ⇒ X) → cobind id ∘ cobind f ≈ cobind (cobind f ∘ counit) ∘ cobind id
+      commute' {X} {Y} f = begin
+        cobind id ∘ cobind f                     ≈⟨ K.sym-assoc ⟩
+        cobind (id ∘ cobind f)                   ≈⟨ K.cobind-≈ id-comm-sym ⟩
+        cobind (cobind f ∘ id)                   ≈⟨ sym (K.cobind-≈ (pullʳ K.identityʳ)) ⟩
+        cobind ((cobind f ∘ counit) ∘ cobind id) ≈⟨ K.assoc ⟩
+        cobind (cobind f ∘ counit) ∘ cobind id   ∎
+
+      -- constructing δ from cobind
+      δ = ntHelper {F = F} {G = F ∘F F} record 
+        { η = λ X → cobind id 
+        ; commute = λ f → commute' (f ∘ counit) 
+        }
+
+      module ε = NaturalTransformation ε
+      module δ = NaturalTransformation δ
+
+      assoc' : {X : Obj} → δ.η (F₀ X) ∘ δ.η X ≈ F₁ (δ.η X) ∘ δ.η X
+      assoc' = commute' id
+
+      identityˡ' : {X : Obj} → F₁ (ε.η X) ∘ δ.η X ≈ id
+      identityˡ' = begin 
+        cobind (counit ∘ counit) ∘ cobind id   ≈⟨ K.sym-assoc ⟩ 
+        cobind ((counit ∘ counit) ∘ cobind id) ≈⟨ K.cobind-≈ (pullʳ K.identityʳ) ⟩ 
+        cobind (counit ∘ id)                   ≈⟨ K.cobind-≈ identityʳ ⟩ 
+        cobind counit                          ≈⟨ K.identityˡ ⟩ 
+        id                                     ∎
+
+  Comonad⇒Kleisli : Comonad C → KleisliCotriple
+  Comonad⇒Kleisli M = record
+    { F₀ = F₀
+    ; counit = ε.η _
+    ; cobind = λ f → F₁ f ∘ δ.η _
+    ; identityʳ = identityʳ'
+    ; identityˡ = M.identityˡ
+    ; assoc = assoc'
+    ; sym-assoc = sym assoc'
+    ; cobind-≈ = λ fg → ∘-resp-≈ˡ (F-resp-≈ fg)
+    }
+    where
+      module M = Comonad M
+      open Comonad M using (F; ε; δ)
+      open Functor F
+
+      identityʳ' : {X Y : Obj} {k : F₀ X ⇒ Y} → ε.η Y ∘ F₁ k ∘ δ.η X ≈ k
+      identityʳ' {X} {Y} {k} = begin 
+        ε.η Y ∘ F₁ k ∘ δ.η X     ≈⟨ pullˡ (ε.commute _) ⟩
+        (k ∘ ε.η (F₀ X)) ∘ δ.η X ≈⟨ cancelʳ M.identityʳ ⟩
+        k                        ∎
+
+      assoc' : {X Y Z : Obj} {k : F₀ X ⇒ Y} {l : F₀ Y ⇒ Z} → F₁ (l ∘ F₁ k ∘ δ.η X) ∘ δ.η X ≈ (F₁ l ∘ δ.η Y) ∘ F₁ k ∘ δ.η X
+      assoc' {X} {Y} {Z} {k} {l} = begin
+        F₁ (l ∘ F₁ k ∘ δ.η X) ∘ δ.η X               ≈⟨ (homomorphism ⟩∘⟨refl) ⟩
+        ((F₁ l ∘ F₁ (F₁ k ∘ δ.η X) ) ∘ δ.η X)       ≈⟨ ((refl⟩∘⟨ homomorphism) ⟩∘⟨refl) ⟩
+        ((F₁ l ∘ (F₁ (F₁ k) ∘ F₁ (δ.η X))) ∘ δ.η X) ≈⟨ pullʳ (pullʳ M.sym-assoc) ⟩
+        (F₁ l ∘ F₁ (F₁ k) ∘ δ.η (F₀ X) ∘ δ.η X)     ≈⟨ (refl⟩∘⟨ (pullˡ (sym (δ.commute k)))) ⟩
+        (F₁ l ∘ (δ.η Y ∘ F₁ k) ∘ δ.η X)             ≈⟨ assoc²'' ⟩
+        (F₁ l ∘ δ.η Y) ∘ F₁ k ∘ δ.η X               ∎
+      

--- a/src/Categories/Comonad/Relative.agda
+++ b/src/Categories/Comonad/Relative.agda
@@ -31,6 +31,8 @@ record Comonad {C : Category o ℓ e} {D : Category o′ ℓ′ e′} (J : Funct
     identityˡ : {x : C.Obj} → cobind {x} counit ≈ D.id
     assoc : {x y z : C.Obj} {k : F₀ x ⇒ J.₀ y} {l : F₀ y ⇒ J.₀ z} →
       cobind (l ∘ cobind k) ≈ cobind l ∘ cobind k
+    sym-assoc : {x y z : C.Obj} {k : F₀ x ⇒ J.₀ y} {l : F₀ y ⇒ J.₀ z} →
+      cobind l ∘ cobind k ≈ cobind (l ∘ cobind k)
     cobind-≈ : {x y : C.Obj} {k h : F₀ x ⇒ J.₀ y} → k ≈ h → cobind k ≈ cobind h
 
 -- From a Relative Comonad, we can extract a functor

--- a/src/Categories/Monad/Construction/Kleisli.agda
+++ b/src/Categories/Monad/Construction/Kleisli.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --without-K --safe #-}
+
 module Categories.Monad.Construction.Kleisli where
 
 -- Definition of kleisli triple as a relative monad
@@ -5,112 +7,111 @@ module Categories.Monad.Construction.Kleisli where
 -- see https://ncatlab.org/nlab/show/extension+system (the naming differs)
 
 open import Level
-open import Categories.Category
-open import Categories.Monad.Relative renaming (Monad to RMonad)
-open import Categories.Monad
-open import Categories.Functor renaming (id to idF)
-open import Categories.NaturalTransformation renaming (id to idN)
+open import Categories.Category.Core using (Category)
+open import Categories.Monad.Relative using (RMonad⇒Functor) renaming (Monad to RMonad)
+open import Categories.Monad using (Monad)
+open import Categories.Functor using (Functor; Endofunctor; _∘F_) renaming (id to idF)
+open import Categories.NaturalTransformation using (ntHelper; NaturalTransformation)
 import Categories.Morphism.Reasoning as MR
 
 private
-    variable
-        o ℓ e : Level
+  variable
+    o ℓ e : Level
 
 module _ (C : Category o ℓ e) where
-    open Category C
-    open HomReasoning
-    open Equiv
-    open MR C
+  open Category C
+  open HomReasoning
+  open Equiv
+  open MR C
 
-    -- a kleisli triple is a relative monad with J = idF
-    Kleisli : Set (o ⊔ ℓ ⊔ e)
-    Kleisli = RMonad {C = C} {D = C} idF
+  -- a kleisli triple is a relative monad with J = idF
+  KleisliTriple : Set (o ⊔ ℓ ⊔ e)
+  KleisliTriple = RMonad {C = C} idF
 
-    -- kleisli triples are equivalent to monads
-    Kleisli⇒Monad : Kleisli → Monad C
-    Kleisli⇒Monad K = record
-        { F = F
-        ; η = η
-        ; μ = μ
-        ; assoc = assoc'
-        ; sym-assoc = sym assoc'
-        ; identityˡ = identityˡ'
-        ; identityʳ = K.identityʳ
+  -- kleisli triples are equivalent to monads
+  Kleisli⇒Monad : KleisliTriple → Monad C
+  Kleisli⇒Monad K = record
+    { F = F
+    ; η = η
+    ; μ = μ
+    ; assoc = assoc'
+    ; sym-assoc = sym assoc'
+    ; identityˡ = identityˡ'
+    ; identityʳ = K.identityʳ
+    }
+    where
+      module K = RMonad K
+      open K using (unit; extend)
+
+      -- Extract a functor from the relative monad
+      F : Endofunctor C
+      F = RMonad⇒Functor K
+      open Functor F using (F₀; F₁)
+
+      -- constructing η from unit
+      η = ntHelper {F = idF} {G = F} record
+        { η = λ X → unit
+        ; commute = λ f → sym K.identityʳ
         }
-        where
-            module K = RMonad K
-            open K using (unit; extend)
 
-            -- Extract a functor from the relative monad
-            F : Endofunctor C
-            F = RMonad⇒Functor K
-            open Functor F
+      -- helper for μ.commute and assoc'
+      commute' : ∀ {X Y : Obj } (f : X ⇒ F₀ Y) → extend id ∘ extend (unit ∘ extend f) ≈ extend f ∘ (extend id)
+      commute' {X} {Y} f = begin
+        extend id ∘ extend (unit ∘ extend f)   ≈⟨ K.sym-assoc ⟩
+        extend (extend id ∘ unit ∘ extend f)   ≈⟨ K.extend-≈ (pullˡ K.identityʳ) ⟩
+        extend (id ∘ extend f)                 ≈⟨ K.extend-≈ id-comm-sym ⟩
+        extend (extend f ∘ id)                 ≈⟨ K.assoc ⟩
+        extend f ∘ (extend id)                 ∎
 
-            -- constructing η from unit
-            η = ntHelper {F = idF} {G = F} record
-                { η = λ X → unit
-                ; commute = λ f → sym K.identityʳ
-                }
-
-            -- constructing μ from extend
-            μ = ntHelper {F = F ∘F F} {G = F} record
-                { η = λ X → extend id
-                ; commute = λ f → begin 
-                    extend id ∘ extend (unit ∘ extend (unit ∘ f))   ≈⟨ sym K.assoc ⟩
-                    extend (extend id ∘ unit ∘ extend (unit ∘ f))   ≈⟨ K.extend-≈ (pullˡ K.identityʳ) ⟩
-                    extend (id ∘ extend (unit ∘ f))                 ≈⟨ K.extend-≈ id-comm-sym ⟩
-                    extend (extend (unit ∘ f) ∘ id)                 ≈⟨ K.assoc ⟩
-                    extend (unit ∘ f) ∘ (extend id)                 ∎
-                }
-
-            module μ = NaturalTransformation μ
-            module η = NaturalTransformation η
-
-            assoc' : ∀ {X : Obj} → μ.η X ∘ F₁ (μ.η X) ≈ μ.η X ∘ μ.η (F₀ X)
-            assoc' = begin 
-                extend id ∘ extend (unit ∘ extend id)   ≈⟨ sym K.assoc ⟩
-                extend (extend id ∘ unit ∘ extend id)   ≈⟨ K.extend-≈ (pullˡ K.identityʳ) ⟩
-                extend (id ∘ extend id)                 ≈⟨ K.extend-≈ id-comm-sym ⟩
-                extend (extend id ∘ id)                 ≈⟨ K.assoc ⟩
-                extend id ∘ extend id                   ∎
-
-            identityˡ' : ∀ {X : Obj} → μ.η X ∘ F₁ (η.η X) ≈ id
-            identityˡ' = begin 
-                extend id ∘ extend (unit ∘ unit)   ≈⟨ sym K.assoc ⟩ 
-                extend (extend id ∘ (unit ∘ unit)) ≈⟨ K.extend-≈ (pullˡ K.identityʳ) ⟩
-                extend (id ∘ unit)                 ≈⟨ K.extend-≈ identityˡ ⟩
-                extend unit                        ≈⟨ K.identityˡ ⟩
-                id                                 ∎
-
-    Monad⇒Kleisli : Monad C → Kleisli
-    Monad⇒Kleisli M = record
-        { F₀ = F₀
-        ; unit = η.η _
-        ; extend = λ f → μ.η _ ∘ F₁ f
-        ; identityʳ = identityʳ'
-        ; identityˡ = M.identityˡ
-        ; assoc = assoc'
-        ; extend-≈ = λ fg → ∘-resp-≈ʳ (F-resp-≈ fg)
+      -- constructing μ from extend
+      μ = ntHelper {F = F ∘F F} {G = F} record
+        { η = λ X → extend id
+        ; commute = λ f → commute' (unit ∘ f)
         }
-        where
-            module M = Monad M
-            open Monad M using (F; η; μ)
-            open Functor F
-            
-            identityʳ' : ∀ {X Y} {k : X ⇒ F₀ Y} → (μ.η Y ∘ F₁ k) ∘ η.η X ≈ k
-            identityʳ' {X} {Y} {k}  = begin 
-                ((μ.η Y ∘ F₁ k) ∘ η.η X)   ≈⟨ pullʳ (sym (η.commute _)) ⟩
-                (μ.η Y ∘ η.η (F₀ Y) ∘ k)   ≈⟨ pullˡ M.identityʳ ⟩
-                (id ∘ k)                   ≈⟨ identityˡ ⟩
-                k                          ∎
 
-            assoc' : ∀  {X Y Z} {k : X ⇒ F₀ Y} {l : Y ⇒ F₀ Z} → μ.η Z ∘ F₁ ((μ.η Z ∘ F₁ l) ∘ k) ≈ (μ.η Z ∘ F₁ l) ∘ μ.η Y ∘ F₁ k
-            assoc' {X} {Y} {Z} {k} {l} = begin
-                (μ.η Z ∘ F₁ ((μ.η Z ∘ F₁ l) ∘ k))           ≈⟨ refl⟩∘⟨ homomorphism ⟩ 
-                (μ.η Z ∘ F₁ (C [ μ.η Z ∘ ₁ l ]) ∘ F₁ k)     ≈⟨ refl⟩∘⟨ homomorphism ⟩∘⟨refl ⟩ 
-                (μ.η Z ∘ (F₁ (μ.η Z) ∘ F₁ (F₁ l)) ∘ F₁ k)   ≈⟨ pullˡ (pullˡ M.assoc) ⟩ 
-                (((μ.η Z ∘ μ.η (F₀ Z)) ∘ F₁ (F₁ l)) ∘ F₁ k) ≈⟨ pullʳ (μ.commute l) ⟩∘⟨refl ⟩
-                (μ.η Z ∘ F₁ l ∘ μ.η Y) ∘ F₁ k               ≈⟨ trans assoc²' sym-assoc ⟩
-                (μ.η Z ∘ F₁ l) ∘ μ.η Y ∘ F₁ k               ∎
-            
+      module η = NaturalTransformation η
+      module μ = NaturalTransformation μ
+
+      assoc' : ∀ {X : Obj} → μ.η X ∘ F₁ (μ.η X) ≈ μ.η X ∘ μ.η (F₀ X)
+      assoc' = commute' id
+
+      identityˡ' : ∀ {X : Obj} → μ.η X ∘ F₁ (η.η X) ≈ id
+      identityˡ' = begin 
+        extend id ∘ extend (unit ∘ unit)   ≈⟨ K.sym-assoc ⟩ 
+        extend (extend id ∘ (unit ∘ unit)) ≈⟨ K.extend-≈ (pullˡ K.identityʳ) ⟩
+        extend (id ∘ unit)                 ≈⟨ K.extend-≈ identityˡ ⟩
+        extend unit                        ≈⟨ K.identityˡ ⟩
+        id                                 ∎
+
+  Monad⇒Kleisli : Monad C → KleisliTriple
+  Monad⇒Kleisli M = record
+    { F₀ = F₀
+    ; unit = η.η _
+    ; extend = λ f → μ.η _ ∘ F₁ f
+    ; identityʳ = identityʳ'
+    ; identityˡ = M.identityˡ
+    ; assoc = assoc'
+    ; sym-assoc = sym assoc'
+    ; extend-≈ = λ fg → ∘-resp-≈ʳ (F-resp-≈ fg)
+    }
+    where
+      module M = Monad M
+      open Monad M using (F; η; μ)
+      open Functor F
+
+      identityʳ' : ∀ {X Y} {k : X ⇒ F₀ Y} → (μ.η Y ∘ F₁ k) ∘ η.η X ≈ k
+      identityʳ' {X} {Y} {k}  = begin 
+        ((μ.η Y ∘ F₁ k) ∘ η.η X)   ≈⟨ pullʳ (sym (η.commute _)) ⟩
+        (μ.η Y ∘ η.η (F₀ Y) ∘ k)   ≈⟨ cancelˡ M.identityʳ ⟩
+        k                          ∎
+
+      assoc' : ∀  {X Y Z} {k : X ⇒ F₀ Y} {l : Y ⇒ F₀ Z} → μ.η Z ∘ F₁ ((μ.η Z ∘ F₁ l) ∘ k) ≈ (μ.η Z ∘ F₁ l) ∘ μ.η Y ∘ F₁ k
+      assoc' {X} {Y} {Z} {k} {l} = begin
+        (μ.η Z ∘ F₁ ((μ.η Z ∘ F₁ l) ∘ k))           ≈⟨ refl⟩∘⟨ homomorphism ⟩ 
+        (μ.η Z ∘ F₁ (μ.η Z ∘ ₁ l) ∘ F₁ k)           ≈⟨ refl⟩∘⟨ homomorphism ⟩∘⟨refl ⟩ 
+        (μ.η Z ∘ (F₁ (μ.η Z) ∘ F₁ (F₁ l)) ∘ F₁ k)   ≈⟨ pullˡ (pullˡ M.assoc) ⟩ 
+        (((μ.η Z ∘ μ.η (F₀ Z)) ∘ F₁ (F₁ l)) ∘ F₁ k) ≈⟨ pullʳ (μ.commute l) ⟩∘⟨refl ⟩
+        (μ.η Z ∘ F₁ l ∘ μ.η Y) ∘ F₁ k               ≈⟨ trans assoc²' sym-assoc ⟩
+        (μ.η Z ∘ F₁ l) ∘ μ.η Y ∘ F₁ k               ∎
+
 

--- a/src/Categories/Monad/Construction/Kleisli.agda
+++ b/src/Categories/Monad/Construction/Kleisli.agda
@@ -1,0 +1,116 @@
+module Categories.Monad.Construction.Kleisli where
+
+-- Definition of kleisli triple as a relative monad
+-- and the equivalence of kleisli triple and monad
+-- see https://ncatlab.org/nlab/show/extension+system (the naming differs)
+
+open import Level
+open import Categories.Category
+open import Categories.Monad.Relative renaming (Monad to RMonad)
+open import Categories.Monad
+open import Categories.Functor renaming (id to idF)
+open import Categories.NaturalTransformation renaming (id to idN)
+import Categories.Morphism.Reasoning as MR
+
+private
+    variable
+        o ℓ e : Level
+
+module _ (C : Category o ℓ e) where
+    open Category C
+    open HomReasoning
+    open Equiv
+    open MR C
+
+    -- a kleisli triple is a relative monad with J = idF
+    Kleisli : Set (o ⊔ ℓ ⊔ e)
+    Kleisli = RMonad {C = C} {D = C} idF
+
+    -- kleisli triples are equivalent to monads
+    Kleisli⇒Monad : Kleisli → Monad C
+    Kleisli⇒Monad K = record
+        { F = F
+        ; η = η
+        ; μ = μ
+        ; assoc = assoc'
+        ; sym-assoc = sym assoc'
+        ; identityˡ = identityˡ'
+        ; identityʳ = K.identityʳ
+        }
+        where
+            module K = RMonad K
+            open K using (unit; extend)
+
+            -- Extract a functor from the relative monad
+            F : Endofunctor C
+            F = RMonad⇒Functor K
+            open Functor F
+
+            -- constructing η from unit
+            η = ntHelper {F = idF} {G = F} record
+                { η = λ X → unit
+                ; commute = λ f → sym K.identityʳ
+                }
+
+            -- constructing μ from extend
+            μ = ntHelper {F = F ∘F F} {G = F} record
+                { η = λ X → extend id
+                ; commute = λ f → begin 
+                    extend id ∘ extend (unit ∘ extend (unit ∘ f))   ≈⟨ sym K.assoc ⟩
+                    extend (extend id ∘ unit ∘ extend (unit ∘ f))   ≈⟨ K.extend-≈ (pullˡ K.identityʳ) ⟩
+                    extend (id ∘ extend (unit ∘ f))                 ≈⟨ K.extend-≈ id-comm-sym ⟩
+                    extend (extend (unit ∘ f) ∘ id)                 ≈⟨ K.assoc ⟩
+                    extend (unit ∘ f) ∘ (extend id)                 ∎
+                }
+
+            module μ = NaturalTransformation μ
+            module η = NaturalTransformation η
+
+            assoc' : ∀ {X : Obj} → μ.η X ∘ F₁ (μ.η X) ≈ μ.η X ∘ μ.η (F₀ X)
+            assoc' = begin 
+                extend id ∘ extend (unit ∘ extend id)   ≈⟨ sym K.assoc ⟩
+                extend (extend id ∘ unit ∘ extend id)   ≈⟨ K.extend-≈ (pullˡ K.identityʳ) ⟩
+                extend (id ∘ extend id)                 ≈⟨ K.extend-≈ id-comm-sym ⟩
+                extend (extend id ∘ id)                 ≈⟨ K.assoc ⟩
+                extend id ∘ extend id                   ∎
+
+            identityˡ' : ∀ {X : Obj} → μ.η X ∘ F₁ (η.η X) ≈ id
+            identityˡ' = begin 
+                extend id ∘ extend (unit ∘ unit)   ≈⟨ sym K.assoc ⟩ 
+                extend (extend id ∘ (unit ∘ unit)) ≈⟨ K.extend-≈ (pullˡ K.identityʳ) ⟩
+                extend (id ∘ unit)                 ≈⟨ K.extend-≈ identityˡ ⟩
+                extend unit                        ≈⟨ K.identityˡ ⟩
+                id                                 ∎
+
+    Monad⇒Kleisli : Monad C → Kleisli
+    Monad⇒Kleisli M = record
+        { F₀ = F₀
+        ; unit = η.η _
+        ; extend = λ f → μ.η _ ∘ F₁ f
+        ; identityʳ = identityʳ'
+        ; identityˡ = M.identityˡ
+        ; assoc = assoc'
+        ; extend-≈ = λ fg → ∘-resp-≈ʳ (F-resp-≈ fg)
+        }
+        where
+            module M = Monad M
+            open Monad M using (F; η; μ)
+            open Functor F
+            
+            identityʳ' : ∀ {X Y} {k : X ⇒ F₀ Y} → (μ.η Y ∘ F₁ k) ∘ η.η X ≈ k
+            identityʳ' {X} {Y} {k}  = begin 
+                ((μ.η Y ∘ F₁ k) ∘ η.η X)   ≈⟨ pullʳ (sym (η.commute _)) ⟩
+                (μ.η Y ∘ η.η (F₀ Y) ∘ k)   ≈⟨ pullˡ M.identityʳ ⟩
+                (id ∘ k)                   ≈⟨ identityˡ ⟩
+                k                          ∎
+
+            assoc' : ∀  {X Y Z} {k : X ⇒ F₀ Y} {l : Y ⇒ F₀ Z} → μ.η Z ∘ F₁ ((μ.η Z ∘ F₁ l) ∘ k) ≈ (μ.η Z ∘ F₁ l) ∘ μ.η Y ∘ F₁ k
+            assoc' {X} {Y} {Z} {k} {l} = begin
+                (μ.η Z ∘ F₁ ((μ.η Z ∘ F₁ l) ∘ k))           ≈⟨ refl⟩∘⟨ homomorphism ⟩ 
+                (μ.η Z ∘ F₁ (C [ μ.η Z ∘ ₁ l ]) ∘ F₁ k)     ≈⟨ refl⟩∘⟨ homomorphism ⟩∘⟨refl ⟩ 
+                (μ.η Z ∘ (F₁ (μ.η Z) ∘ F₁ (F₁ l)) ∘ F₁ k)   ≈⟨ pullˡ (pullˡ M.assoc) ⟩ 
+                (((μ.η Z ∘ μ.η (F₀ Z)) ∘ F₁ (F₁ l)) ∘ F₁ k) ≈⟨ pullʳ (μ.commute l) ⟩∘⟨refl ⟩
+                (μ.η Z ∘ F₁ l ∘ μ.η Y) ∘ F₁ k               ≈⟨ trans assoc²' sym-assoc ⟩
+                (μ.η Z ∘ F₁ l) ∘ μ.η Y ∘ F₁ k               ∎
+            
+

--- a/src/Categories/Monad/Relative.agda
+++ b/src/Categories/Monad/Relative.agda
@@ -30,6 +30,7 @@ record Monad {C : Category o ℓ e} {D : Category o′ ℓ′ e′} (J : Functor
     identityʳ : {x y : C.Obj} { k : J.₀ x ⇒ F₀ y} → extend k ∘ unit ≈ k
     identityˡ : {x : C.Obj} → extend {x} unit ≈ D.id
     assoc : {x y z : C.Obj} {k : J.₀ x ⇒ F₀ y} {l : J.₀ y ⇒ F₀ z} → extend (extend l ∘ k) ≈ extend l ∘ extend k
+    sym-assoc : {x y z : C.Obj} {k : J.₀ x ⇒ F₀ y} {l : J.₀ y ⇒ F₀ z} → extend l ∘ extend k ≈ extend (extend l ∘ k)
     extend-≈ : {x y : C.Obj} {k h : J.₀ x ⇒ F₀ y} → k ≈ h → extend k ≈ extend h
 
 -- From a Relative Monad, we can extract a functor


### PR DESCRIPTION
Small proof that kleisli triples are equivalent to monads. I'm looking for some feedback and then I'd do the same for comonads.

I've defined the kleisli-triple as a typedef for `RMonad idF` to avoid redundancy, but this might make things a little unclear.

