### PR TITLE
Distributive Category

### DIFF
--- a/src/Categories/Category/Distributive.agda
+++ b/src/Categories/Category/Distributive.agda
@@ -1,10 +1,10 @@
 {-# OPTIONS --without-K --safe #-}
 
 open import Level
-open import Categories.Category
-open import Categories.Category.Cartesian
-open import Categories.Category.BinaryProducts
-open import Categories.Category.Cocartesian
+open import Categories.Category.Core
+open import Categories.Category.Cartesian using (Cartesian)
+open import Categories.Category.BinaryProducts using (BinaryProducts)
+open import Categories.Category.Cocartesian using (Cocartesian)
 import Categories.Morphism as M
 import Categories.Morphism.Reasoning as MR
 

--- a/src/Categories/Category/Distributive.agda
+++ b/src/Categories/Category/Distributive.agda
@@ -1,0 +1,65 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Level
+open import Categories.Category
+open import Categories.Category.Cartesian
+open import Categories.Category.BinaryProducts
+open import Categories.Category.Cocartesian
+import Categories.Morphism as M
+import Categories.Morphism.Reasoning as MR
+
+-- A distributive category is a cartesian, cocartesian category
+-- where the canonical distributivity morphism is an iso
+-- https://ncatlab.org/nlab/show/distributive+category
+
+module Categories.Category.Distributive {o ℓ e} (𝒞 : Category o ℓ e) where
+open Category 𝒞
+open M 𝒞
+open MR 𝒞
+open HomReasoning
+open Equiv
+
+record Distributive : Set (levelOfTerm 𝒞) where
+  field
+    cartesian : Cartesian 𝒞
+    cocartesian : Cocartesian 𝒞
+
+  open Cartesian cartesian using (products)
+  open BinaryProducts products
+  open Cocartesian cocartesian
+
+  distributeˡ : ∀ {A B C : Obj} → A × B + A × C ⇒ A × (B + C)
+  distributeˡ = [ id ⁂ i₁ , id ⁂ i₂ ]
+
+  field
+    isIsoˡ : ∀ {A B C : Obj} → IsIso (distributeˡ {A} {B} {C})
+
+  -- the dual to the canonical distributivity morphism is then also an iso
+  distributeʳ : ∀ {A B C : Obj} →  B × A + C × A ⇒ (B + C) × A
+  distributeʳ = [ i₁ ⁂ id , i₂ ⁂ id ]
+
+  isIsoʳ : ∀ {A B C : Obj} →  IsIso (distributeʳ {A} {B} {C})
+  isIsoʳ {A} {B} {C} = record 
+    { inv = ((swap +₁ swap) ∘ inv) ∘ swap
+    ; iso = record 
+      { isoˡ = begin 
+        (((swap +₁ swap) ∘ inv) ∘ swap) ∘ [ i₁ ⁂ id , i₂ ⁂ id ]                                       ≈⟨ ∘[] ⟩ 
+        [ (((swap +₁ swap) ∘ inv) ∘ swap) ∘ (i₁ ⁂ id) , (((swap +₁ swap) ∘ inv) ∘ swap) ∘ (i₂ ⁂ id) ] ≈⟨ []-cong₂ (pullʳ swap∘⁂) (pullʳ swap∘⁂) ⟩
+        [ ((swap +₁ swap) ∘ inv) ∘ (id ⁂ i₁) ∘ swap , ((swap +₁ swap) ∘ inv) ∘ (id ⁂ i₂) ∘ swap ]     ≈˘⟨ ∘[] ⟩
+        ((swap +₁ swap) ∘ inv) ∘ [ (id ⁂ i₁) ∘ swap , (id ⁂ i₂) ∘ swap ]                              ≈˘⟨ refl⟩∘⟨ []∘+₁ ⟩
+        ((swap +₁ swap) ∘ inv) ∘ [ (id ⁂ i₁) , (id ⁂ i₂) ] ∘ (swap +₁ swap)                           ≈⟨ cancelInner isoˡ ⟩
+        (swap +₁ swap) ∘ (swap +₁ swap)                                                               ≈⟨ +₁∘+₁ ⟩
+        (swap ∘ swap) +₁ (swap ∘ swap)                                                                ≈⟨ +₁-cong₂ swap∘swap swap∘swap ⟩
+        (id +₁ id)                                                                                    ≈⟨ +-unique id-comm-sym id-comm-sym ⟩
+        id                                                                                            ∎ 
+      ; isoʳ = begin 
+        [ i₁ ⁂ id , i₂ ⁂ id ] ∘ ((swap +₁ swap) ∘ inv) ∘ swap  ≈⟨ pull-first []∘+₁ ⟩
+        [ (i₁ ⁂ id) ∘ swap , (i₂ ⁂ id) ∘ swap ] ∘ inv ∘ swap   ≈˘⟨ []-cong₂ swap∘⁂ swap∘⁂ ⟩∘⟨refl ⟩
+        [ swap ∘ (id ⁂ i₁) , swap ∘ (id ⁂ i₂) ] ∘ inv ∘ swap   ≈˘⟨ ∘[] ⟩∘⟨refl ⟩
+        (swap ∘ [ (id ⁂ i₁) , (id ⁂ i₂) ]) ∘ inv ∘ swap        ≈⟨ cancelInner isoʳ  ⟩
+        swap ∘ swap                                            ≈⟨ swap∘swap ⟩
+        id                                                     ∎ 
+      } 
+    }
+    where
+      open IsIso (isIsoˡ {A} {B} {C})

--- a/src/Categories/Category/Extensive/Bundle.agda
+++ b/src/Categories/Category/Extensive/Bundle.agda
@@ -19,7 +19,7 @@ record ExtensiveCategory o ℓ e : Set (suc (o ⊔ ℓ ⊔ e)) where
   open Category U public
   open Extensive extensive public
 
--- Am extensive category with finite products
+-- An extensive category with finite products
 record ExtensiveDistributiveCategory o ℓ e : Set (suc (o ⊔ ℓ ⊔ e)) where
   field
     U           : Category o ℓ e  -- U for underlying

--- a/src/Categories/Category/Extensive/Bundle.agda
+++ b/src/Categories/Category/Extensive/Bundle.agda
@@ -1,0 +1,31 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Bundled version of an extensive (distributive) Category
+module Categories.Category.Extensive.Bundle where
+
+open import Level
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Extensive using (Extensive)
+open import Categories.Category.Distributive using (Distributive)
+open import Categories.Category.Cartesian using (Cartesian)
+open import Categories.Category.Extensive.Properties.Distributive using (Extensive×Cartesian⇒Distributive)
+
+record ExtensiveCategory o ℓ e : Set (suc (o ⊔ ℓ ⊔ e)) where
+  field
+    U           : Category o ℓ e  -- U for underlying
+    extensive   : Extensive U
+
+  open Category U public
+  open Extensive extensive public
+
+-- Am extensive category with finite products
+record ExtensiveDistributiveCategory o ℓ e : Set (suc (o ⊔ ℓ ⊔ e)) where
+  field
+    U           : Category o ℓ e  -- U for underlying
+    extensive   : Extensive U
+    cartesian   : Cartesian U
+
+  open Category U public
+  open Extensive extensive public
+  open Distributive (Extensive×Cartesian⇒Distributive U extensive cartesian) public

--- a/src/Categories/Category/Extensive/Properties/Distributive.agda
+++ b/src/Categories/Category/Extensive/Properties/Distributive.agda
@@ -7,11 +7,10 @@ open import Categories.Category.BinaryProducts using (BinaryProducts)
 open import Categories.Category.Cocartesian using (Cocartesian)
 open import Categories.Category.Distributive using (Distributive)
 open import Categories.Category.Extensive using (Extensive)
+open import Categories.Diagram.Pullback using (Pullback)
 
 import Categories.Morphism as M
 import Categories.Morphism.Reasoning as MR
-import Categories.Diagram.Pullback as PB
-open PB using (Pullback)
 import Categories.Object.Coproduct as CP
 open CP using (Coproduct; IsCoproduct; IsCoproduct⇒Coproduct)
 
@@ -41,10 +40,8 @@ module Categories.Category.Extensive.Properties.Distributive {o ℓ e} (𝒞 : C
   Extensive×Cartesian⇒Distributive extensive cartesian = record 
     { cartesian = cartesian 
     ; cocartesian = cocartesian 
-    ; isIsoˡ = λ {A B C} → record { inv = distrib.to ; iso = record 
-      { isoˡ = trans (∘-resp-≈ʳ (sym distrib-canon)) distrib.isoˡ 
-      ; isoʳ = trans (∘-resp-≈ˡ (sym distrib-canon)) distrib.isoʳ 
-      } } }
+    ; isIsoˡ = record { inv = distrib.to ; iso = distrib.iso }
+    }
     where
       open Extensive extensive
       open Cocartesian cocartesian
@@ -73,16 +70,9 @@ module Categories.Category.Extensive.Properties.Distributive {o ℓ e} (𝒞 : C
           ; p₂∘universal≈h₂ = project₂
           } }
         
-        -- by the diagram we gain a distributivity (iso-)morphism
+        -- by the diagram we get the canonical distributivity (iso-)morphism
         distrib : (A × B) + (A × C) ≅ A × (B + C)
-        distrib = CP.up-to-iso 𝒞 coproduct (CP.Mobile 𝒞 
-          (IsCoproduct⇒Coproduct 𝒞 (pullback-of-cp-is-cp (π₂ {A = A} {B = B + C}))) 
-          (PB.up-to-iso 𝒞 (pullback₁ (π₂ {A = A} {B = B + C})) (pb i₁)) 
-          (PB.up-to-iso 𝒞 (pullback₂ (π₂ {A = A} {B = B + C})) (pb i₂)))
+        distrib = CP.up-to-iso 𝒞
+          coproduct
+          (IsCoproduct⇒Coproduct 𝒞 (pullback-of-cp-is-cp' (pb i₁) (pb i₂)))
         module distrib  = _≅_ distrib
-        
-        -- which is actually the canonical distributivity morphism
-        distrib-canon : distrib.from ≈ [ id ⁂ i₁ , id ⁂ i₂ ]
-        distrib-canon = sym (Coproduct.unique coproduct 
-          (trans inject₁ (p₁∘universal≈h₁ (pullback₁ (π₂ {A = A} {B = B + C}))))
-          (trans inject₂ (p₁∘universal≈h₁ (pullback₂ (π₂ {A = A} {B = B + C})))))

--- a/src/Categories/Category/Extensive/Properties/Distributive.agda
+++ b/src/Categories/Category/Extensive/Properties/Distributive.agda
@@ -1,0 +1,88 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Level
+open import Categories.Category.Core
+open import Categories.Category.Cartesian using (Cartesian)
+open import Categories.Category.BinaryProducts using (BinaryProducts)
+open import Categories.Category.Cocartesian using (Cocartesian)
+open import Categories.Category.Distributive using (Distributive)
+open import Categories.Category.Extensive using (Extensive)
+
+import Categories.Morphism as M
+import Categories.Morphism.Reasoning as MR
+import Categories.Diagram.Pullback as PB
+open PB using (Pullback)
+import Categories.Object.Coproduct as CP
+open CP using (Coproduct; IsCoproduct; IsCoproduct⇒Coproduct)
+
+import Categories.Object.Duality as Duality
+
+module Categories.Category.Extensive.Properties.Distributive {o ℓ e} (𝒞 : Category o ℓ e) where
+  open Category 𝒞
+  open Pullback using (p₁∘universal≈h₁)
+  open M 𝒞
+  open MR 𝒞
+  open HomReasoning
+  open Equiv
+  open Duality 𝒞
+
+  -- Any extensive cartesian category is also distributive
+  -- To show this we construct the following two pullbacks and then show by pullback-of-cp-is-cp
+  -- that the top row must be a coproduct, and thereby isomorphic to A × B + A × C
+  {-
+  A × B -- id ⁂ i₁ --> A × (B + C) <-- id ⁂ i₂ -- A × C
+    |                       |                        |
+    π₂        pb₁           π₂           pb₂         π₂
+    |                       |                        |
+    V                       V                        V
+    B  ------ i₁ -------> B + C <------- i₂ ------  C  
+  -}
+  Extensive×Cartesian⇒Distributive : Extensive 𝒞 → Cartesian 𝒞 → Distributive 𝒞
+  Extensive×Cartesian⇒Distributive extensive cartesian = record 
+    { cartesian = cartesian 
+    ; cocartesian = cocartesian 
+    ; isIsoˡ = λ {A B C} → record { inv = distrib.to ; iso = record 
+      { isoˡ = trans (∘-resp-≈ʳ (sym distrib-canon)) distrib.isoˡ 
+      ; isoʳ = trans (∘-resp-≈ˡ (sym distrib-canon)) distrib.isoʳ 
+      } } }
+    where
+      open Extensive extensive
+      open Cocartesian cocartesian
+      open Cartesian cartesian using (products)
+      module BP = BinaryProducts products
+      open BP
+
+      module _ {A B C : Obj} where
+        -- we can even proof that the square is a pullback for any g
+        -- then the left and right square are just instances with g = i₁ and g = i₂
+        pb : ∀ {D} (g : D ⇒ B + C) → Pullback 𝒞 (π₂ {A = A} {B = B + C}) g
+        pb g = record { p₁ = id ⁂ g ; p₂ = π₂ ; isPullback = record
+          { commute = π₂∘⁂
+          ; universal = λ {_} {h₁} {h₂} H → ⟨ π₁ ∘ h₁ , h₂ ⟩
+          ; unique = λ {X} {h₁} {h₂} {i} {eq} H1 H2 → sym (BP.unique (begin 
+              π₁ ∘ i              ≈˘⟨ identityˡ ⟩∘⟨refl ⟩ 
+              ((id ∘ π₁) ∘ i)     ≈˘⟨ pullˡ π₁∘⁂ ⟩
+              (π₁ ∘ (id ⁂ g) ∘ i) ≈⟨ refl⟩∘⟨ H1 ⟩
+              π₁ ∘ h₁             ∎) H2)
+          ; p₁∘universal≈h₁ = λ {X} {h₁} {h₂} {eq} → begin
+              (id ⁂ g) ∘ ⟨ π₁ ∘ h₁ , h₂ ⟩ ≈⟨ ⁂∘⟨⟩ ⟩
+              ⟨ id ∘ π₁ ∘ h₁ , g ∘ h₂ ⟩   ≈⟨ ⟨⟩-congʳ identityˡ ⟩
+              ⟨ π₁ ∘ h₁ , g ∘ h₂ ⟩        ≈˘⟨ ⟨⟩-congˡ eq ⟩
+              ⟨ π₁ ∘ h₁ , π₂ ∘ h₁ ⟩       ≈⟨ g-η ⟩
+              h₁                          ∎
+          ; p₂∘universal≈h₂ = project₂
+          } }
+        
+        -- by the diagram we gain a distributivity (iso-)morphism
+        distrib : (A × B) + (A × C) ≅ A × (B + C)
+        distrib = CP.up-to-iso 𝒞 coproduct (CP.Mobile 𝒞 
+          (IsCoproduct⇒Coproduct 𝒞 (pullback-of-cp-is-cp (π₂ {A = A} {B = B + C}))) 
+          (PB.up-to-iso 𝒞 (pullback₁ (π₂ {A = A} {B = B + C})) (pb i₁)) 
+          (PB.up-to-iso 𝒞 (pullback₂ (π₂ {A = A} {B = B + C})) (pb i₂)))
+        module distrib  = _≅_ distrib
+        
+        -- which is actually the canonical distributivity morphism
+        distrib-canon : distrib.from ≈ [ id ⁂ i₁ , id ⁂ i₂ ]
+        distrib-canon = sym (Coproduct.unique coproduct 
+          (trans inject₁ (p₁∘universal≈h₁ (pullback₁ (π₂ {A = A} {B = B + C}))))
+          (trans inject₂ (p₁∘universal≈h₁ (pullback₂ (π₂ {A = A} {B = B + C})))))

--- a/src/Categories/Object/Coproduct.agda
+++ b/src/Categories/Object/Coproduct.agda
@@ -1,10 +1,10 @@
 {-# OPTIONS --without-K --safe #-}
-open import Categories.Category
+open import Categories.Category hiding (_[_,_])
 
 module Categories.Object.Coproduct {o ℓ e} (𝒞 : Category o ℓ e) where
 
 open import Level
-open import Function using (_$_)
+open import Function using (flip; _$_)
 
 open Category 𝒞
 
@@ -15,7 +15,7 @@ open HomReasoning
 
 private
   variable
-    A B C D : Obj
+    A B C D X Y Z : Obj
     f g h : A ⇒ B
 
 record Coproduct (A B : Obj) : Set (o ⊔ ℓ ⊔ e) where
@@ -70,3 +70,117 @@ IsCoproduct⇒Coproduct c = record
   }
   where
     open IsCoproduct c
+  
+module _ {A B : Obj} where
+  open Coproduct {A} {B} renaming ([_,_] to _[_,_])
+
+  repack : (p₁ p₂ : Coproduct A B) → A+B p₁ ⇒ A+B p₂
+  repack p₁ p₂ = p₁ [ i₁ p₂ , i₂ p₂ ]
+
+  repack∘ : (p₁ p₂ p₃ : Coproduct A B) → repack p₂ p₃ ∘ repack p₁ p₂ ≈ repack p₁ p₃
+  repack∘ p₁ p₂ p₃ = ⟺ $ unique p₁ 
+    (glueTrianglesˡ (inject₁ p₂) (inject₁ p₁)) 
+    (glueTrianglesˡ (inject₂ p₂) (inject₂ p₁))
+
+  repack≡id : (p : Coproduct A B) → repack p p ≈ id
+  repack≡id = η
+
+  repack-cancel : (p₁ p₂ : Coproduct A B) → repack p₁ p₂ ∘ repack p₂ p₁ ≈ id
+  repack-cancel p₁ p₂ = repack∘ p₂ p₁ p₂ ○ repack≡id p₂
+
+up-to-iso : ∀ (p₁ p₂ : Coproduct A B) → Coproduct.A+B p₁ ≅ Coproduct.A+B p₂
+up-to-iso p₁ p₂ = record
+  { from = repack p₁ p₂
+  ; to   = repack p₂ p₁
+  ; iso  = record
+    { isoˡ = repack-cancel p₂ p₁
+    ; isoʳ = repack-cancel p₁ p₂
+    }
+  }
+
+transport-by-iso : ∀ (p : Coproduct A B) → ∀ {X} → Coproduct.A+B p ≅ X → Coproduct A B
+transport-by-iso p {X} p≅X = record
+  { A+B = X
+  ; i₁ = from ∘ i₁
+  ; i₂ = from ∘ i₂
+  ; [_,_] = λ h₁ h₂ → [ h₁ , h₂ ] ∘ to
+  ; inject₁ = cancelInner isoˡ ○ inject₁
+  ; inject₂ = cancelInner isoˡ ○ inject₂
+  ; unique = λ {_ i l r} pf₁ pf₂ → begin
+    [ l , r ] ∘ to                             ≈˘⟨ []-cong₂ pf₁ pf₂ ⟩∘⟨refl ⟩
+    [ i ∘ from ∘ i₁ , i ∘ from ∘ i₂ ] ∘ to     ≈⟨ unique assoc assoc ⟩∘⟨refl ⟩
+    (i ∘ from) ∘ to                            ≈⟨ cancelʳ isoʳ ⟩
+    i                                          ∎
+  }
+  where open Coproduct p
+        open _≅_ p≅X
+
+Reversible : (p : Coproduct A B) → Coproduct B A
+Reversible p = record
+  { A+B       = A+B
+  ; i₁        = i₂
+  ; i₂        = i₁
+  ; [_,_]     = flip [_,_]
+  ; inject₁  = inject₂
+  ; inject₂  = inject₁
+  ; unique = flip unique
+  }
+  where open Coproduct p
+
+Commutative : (p₁ : Coproduct A B) (p₂ : Coproduct B A) → Coproduct.A+B p₁ ≅ Coproduct.A+B p₂
+Commutative p₁ p₂ = up-to-iso p₁ (Reversible p₂)
+
+Associable : ∀ (p₁ : Coproduct X Y) (p₂ : Coproduct Y Z) (p₃ : Coproduct X (Coproduct.A+B p₂)) → Coproduct (Coproduct.A+B p₁) Z
+Associable p₁ p₂ p₃ = record
+  { A+B       = A+B p₃
+  ; i₁        = p₁ [ i₁ p₃ , i₂ p₃ ∘ i₁ p₂ ]
+  ; i₂        = i₂ p₃ ∘ i₂ p₂
+  ; [_,_]     = λ f g → p₃ [ f ∘ i₁ p₁ , p₂ [ f ∘ i₂ p₁ , g ] ]
+  ; inject₁  = λ {_ f g} → begin
+    p₃ [ f ∘ i₁ p₁ , p₂ [ f ∘ i₂ p₁ , g ] ] ∘ p₁ [ i₁ p₃ , i₂ p₃ ∘ i₁ p₂ ] ≈⟨ ∘-distribˡ-[] p₁ ⟩
+    p₁ [ p₃ [ f ∘ i₁ p₁ , p₂ [ f ∘ i₂ p₁ , g ] ] ∘ i₁ p₃ 
+       , p₃ [ f ∘ i₁ p₁ , p₂ [ f ∘ i₂ p₁ , g ] ] ∘ i₂ p₃ ∘ i₁ p₂ ]         ≈⟨ []-cong₂ p₁ (inject₁ p₃) (glueTrianglesʳ (inject₂ p₃) (inject₁  p₂)) ⟩
+    p₁ [ f ∘ i₁ p₁ , f ∘ i₂ p₁ ]                                           ≈⟨ g-η p₁ ⟩
+    f                                                                      ∎
+  ; inject₂  = λ {_ f g} → glueTrianglesʳ (inject₂ p₃) (inject₂ p₂)
+  ; unique = λ {_ i f g} pf₁ pf₂ → begin
+    p₃ [ f ∘ i₁ p₁ , p₂ [ f ∘ i₂ p₁ , g ] ]                   ≈⟨ []-cong₂ p₃ (∘-resp-≈ˡ (sym pf₁)) 
+                                                                ([]-cong₂ p₂ (∘-resp-≈ˡ (sym pf₁)) (sym pf₂)) ⟩
+    (p₃ [ (i ∘ p₁ [ i₁ p₃ , i₂ p₃ ∘ i₁ p₂ ]) ∘ i₁ p₁ 
+        , p₂ [ (i ∘ p₁ [ i₁ p₃ , i₂ p₃ ∘ i₁ p₂ ]) ∘ i₂ p₁ 
+             , i ∘ i₂ p₃ ∘ i₂ p₂ ] ])                         ≈⟨ []-cong₂ p₃ (pullʳ (inject₁ p₁)) 
+                                                                ([]-cong₂ p₂ (trans (pullʳ (inject₂ p₁)) sym-assoc) 
+                                                                             sym-assoc) ⟩
+    (p₃ [ i ∘ i₁ p₃ 
+        , p₂ [ (i ∘ i₂ p₃) ∘ i₁ p₂ , (i ∘ i₂ p₃) ∘ i₂ p₂ ] ]) ≈⟨ []-cong₂ p₃ refl (g-η p₂) ⟩
+    (p₃ [ i ∘ i₁ p₃ , i ∘ i₂ p₃ ])                            ≈⟨ g-η p₃ ⟩
+    i                                                         ∎
+  }
+  where
+  open Coproduct renaming ([_,_] to _[_,_])
+  open Equiv
+
+Associative : ∀ (p₁ : Coproduct X Y) (p₂ : Coproduct Y Z)
+                (p₃ : Coproduct X (Coproduct.A+B p₂)) (p₄ : Coproduct (Coproduct.A+B p₁) Z) →
+                (Coproduct.A+B p₃) ≅ (Coproduct.A+B p₄)
+Associative p₁ p₂ p₃ p₄ = up-to-iso (Associable p₁ p₂ p₃) p₄
+
+Mobile : ∀ {A₁ B₁ A₂ B₂} (p : Coproduct A₁ B₁) → A₁ ≅ A₂ → B₁ ≅ B₂ → Coproduct A₂ B₂
+Mobile p A₁≅A₂ B₁≅B₂ = record
+  { A+B              = A+B
+  ; i₁               = i₁ ∘ to A₁≅A₂
+  ; i₂               = i₂ ∘ to B₁≅B₂
+  ; [_,_]            = λ h k → [ h ∘ from A₁≅A₂ , k ∘ from B₁≅B₂ ]
+  ; inject₁         = begin
+    [ _ ∘ from A₁≅A₂ , _ ∘ from B₁≅B₂ ] ∘ i₁ ∘ to A₁≅A₂ ≈⟨ pullˡ inject₁ ⟩
+    (_ ∘ from A₁≅A₂) ∘ to A₁≅A₂                         ≈⟨ cancelʳ (isoʳ A₁≅A₂) ⟩
+    _                                                   ∎
+  ; inject₂         = begin
+    [ _ ∘ from A₁≅A₂ , _ ∘ from B₁≅B₂ ] ∘ i₂ ∘ to B₁≅B₂ ≈⟨ pullˡ inject₂ ⟩
+    (_ ∘ from B₁≅B₂) ∘ to B₁≅B₂                         ≈⟨ cancelʳ (isoʳ B₁≅B₂) ⟩
+    _                                                   ∎
+  ; unique        = λ pfˡ pfʳ → unique (switch-fromtoʳ (≅-sym A₁≅A₂) ((assoc ○ pfˡ))) (switch-fromtoʳ (≅-sym B₁≅B₂) ((assoc ○ pfʳ)))
+  }
+  where open Coproduct p
+        open _≅_
+        open ≅ using () renaming (sym to ≅-sym)


### PR DESCRIPTION
Distributive categories as described [here](https://ncatlab.org/nlab/show/distributive+category) and their relationship to extensive categories (an extensive and cartesian category is automatically distributive).

I needed some properties of coproducts (namely `up-to-iso` and `Mobile`) so I added them, but I was wondering if they have been left out on purpose and I should've used Duality?

Lastly I've also added bundled versions `ExtensiveCategory` and `ExtensiveDistributiveCategory`.