### PR TITLE
CI: Updated cached paths for `cabal` and update Haskell config action dep

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Install ghc and cabal
         if: steps.cache-cabal.outputs.cache-hit != 'true'
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ env.GHC_VERSION }}
           cabal-version: ${{ env.CABAL_VERSION }}

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -50,7 +50,7 @@ env:
 
   GHC_VERSION: 8.10.7
   CABAL_VERSION: 3.6.2.0
-  CABAL_INSTALL: cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS' --installdir $HOME/.local/state/cabal/bin
+  CABAL_INSTALL: cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS' --installdir $HOME/.cabal/bin
   AGDA: agda --auto-inline -Werror +RTS -M6G -H3.5G -A128M -RTS -i. -i src/
 
 jobs:
@@ -72,7 +72,7 @@ jobs:
       # The script won't be able to find Agda if we don't tell it to look at the
       # content of ~/.cabal/bin
       - name: Put cabal programs in PATH
-        run: echo "$HOME/.local/state/cabal/bin" >> $GITHUB_PATH
+        run: echo "$HOME/.cabal/bin" >> $GITHUB_PATH
 
 ########################################################################
 ## CACHING
@@ -87,10 +87,10 @@ jobs:
         id: cache-cabal
         with:
           path: |
-            ~/.local/state/cabal/packages
-            ~/.local/state/cabal/store
-            ~/.local/state/cabal/bin
-            ~/.local/state/cabal/share
+            ~/.cabal/packages
+            ~/.cabal/store
+            ~/.cabal/bin
+            ~/.cabal/share
           key: ${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_COMMIT }}
 
 ########################################################################
@@ -117,7 +117,7 @@ jobs:
           mkdir -p doc
           touch doc/user-manual.pdf
           # make sure it exists
-          mkdir -p $HOME/.local/state/cabal/bin
+          mkdir -p $HOME/.cabal/bin
           ${{ env.CABAL_INSTALL }}
           cd ..
 


### PR DESCRIPTION
Contributes to #375 

* This _should_ fix the "lack of caching issue" (#375) for the `cabal` cache. It looks like @JasonGross [had the right idea.](https://github.com/agda/agda-categories/issues/375#issuecomment-1668573583)
* Update the Haskell installation action to remove the deprecation warning in the CI.

I don't think this PR closes #375 because it doesn't have an Agda build cache, so building `agda-categories` is still completely fresh for each CI run, so we can have a look at that too.

To audit this solution, please have a look at my fork's [CI runs](https://github.com/balacij/agda-categories/actions), specifically the earliest 2's build times and logs. The first one is a completely fresh run without a cache, and the second one has a cache. There's a ~20min time cut with the cache hit, but I would hope that it can be brought down further by adding the Agda build cache to the CI cache too.