### PR TITLE
CI: Add build caching for agda-stdlib and agda-categories to improve CI build time

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -86,9 +86,9 @@ jobs:
       # downloading ghc and cabal and rebuilding Agda if absolutely necessary
       # i.e. if we change either the version of Agda, ghc, or cabal that we want
       # to use for the build.
-      - name: Cache cabal packages
+      - name: Open cache
         uses: actions/cache@v3
-        id: cache-cabal
+        id: cache-everything
         with:
           path: |
             ~/.cabal/packages
@@ -98,8 +98,10 @@ jobs:
             ~/.agda-build-cache
           key: ${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_COMMIT }}
 
+      # If a build cache exists for agda-categories, use it, but don't fail if
+      # there isn't.
       - name: Unpack agda-categories build cache
-        if: steps.cache-cabal.outputs.cache-hit == 'true'
+        if: steps.cache-everything.outputs.cache-hit == 'true'
         run: |
           cp -rpv ~/.agda-build-cache/agda-categories ./_build/ || exit 0
 
@@ -108,18 +110,18 @@ jobs:
 ########################################################################
 
       - name: Install ghc and cabal
-        if: steps.cache-cabal.outputs.cache-hit != 'true'
+        if: steps.cache-everything.outputs.cache-hit != 'true'
         uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ env.GHC_VERSION }}
           cabal-version: ${{ env.CABAL_VERSION }}
 
       - name: Cabal update
-        if: steps.cache-cabal.outputs.cache-hit != 'true'
+        if: steps.cache-everything.outputs.cache-hit != 'true'
         run: cabal update
 
       - name: Download and install Agda from github
-        if: steps.cache-cabal.outputs.cache-hit != 'true'
+        if: steps.cache-everything.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/agda/agda
           cd agda
@@ -141,8 +143,10 @@ jobs:
           echo "~/.agda/agda-stdlib/standard-library.agda-lib" > libraries
           cd -
 
+      # If a build cache exists for agda-stdlib, use it, but don't fail if there
+      # isn't.
       - name: Unpack agda-stdlib build cache
-        if: steps.cache-cabal.outputs.cache-hit == 'true'
+        if: steps.cache-everything.outputs.cache-hit == 'true'
         run: |
           cp -rpv ~/.agda-build-cache/agda-stdlib ~/.agda/agda-stdlib/_build/ || exit 0
 
@@ -166,9 +170,11 @@ jobs:
           ${{ env.AGDA }} --html --html-dir html index.agda
 
 ########################################################################
-## PKG BUILD CACHING
+## PACKAGE BUILD CACHING
 ########################################################################
 
+      # Package type-checked agda-stdlib and agda-categories libraries for
+      # future CI runs.
       - name: "Pack Agda build cache"
         run: |
           mkdir -p ~/.agda-build-cache/

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -51,12 +51,16 @@ env:
   GHC_VERSION: 8.10.7
   CABAL_VERSION: 3.6.2.0
   CABAL_INSTALL: cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS' --installdir $HOME/.cabal/bin
-  AGDA: agda --auto-inline -Werror +RTS -M6G -H3.5G -A128M -RTS -i. -i src/
+  AGDA: agda --auto-inline -Werror +RTS -M6G -H3.5G -A128M -RTS -i . -i src/
 
 jobs:
   test-categories:
     runs-on: ubuntu-latest
     steps:
+
+      # By default github actions do not pull the repo
+      - name: Checkout agda-categories
+        uses: actions/checkout@v4
 
 ########################################################################
 ## SETTINGS
@@ -91,7 +95,13 @@ jobs:
             ~/.cabal/store
             ~/.cabal/bin
             ~/.cabal/share
+            ~/.agda-build-cache
           key: ${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_COMMIT }}
+
+      - name: Unpack agda-categories build cache
+        if: steps.cache-cabal.outputs.cache-hit == 'true'
+        run: |
+          cp -rpv ~/.agda-build-cache/agda-categories ./_build/ || exit 0
 
 ########################################################################
 ## INSTALLATION STEPS
@@ -131,13 +141,14 @@ jobs:
           echo "~/.agda/agda-stdlib/standard-library.agda-lib" > libraries
           cd -
 
-########################################################################
-## TESTING AND DEPLOYMENT
-########################################################################
+      - name: Unpack agda-stdlib build cache
+        if: steps.cache-cabal.outputs.cache-hit == 'true'
+        run: |
+          cp -rpv ~/.agda-build-cache/agda-stdlib ~/.agda/agda-stdlib/_build/ || exit 0
 
-      # By default github actions do not pull the repo
-      - name: Checkout agda-categories
-        uses: actions/checkout@v4
+########################################################################
+## TESTING
+########################################################################
 
       # Generate a fresh Everything.agda & index.agda and start building!
       - name: Test agda-categories
@@ -154,10 +165,23 @@ jobs:
         run: |
           ${{ env.AGDA }} --html --html-dir html index.agda
 
+########################################################################
+## PKG BUILD CACHING
+########################################################################
+
+      - name: "Pack Agda build cache"
+        run: |
+          mkdir -p ~/.agda-build-cache/
+          cp -rpv ./_build/ ~/.agda-build-cache/agda-categories/ || exit 0
+          cp -rpv ~/.agda/agda-stdlib/_build/ ~/.agda-build-cache/agda-stdlib/ || exit 0
+
+########################################################################
+## DEPLOYMENT
+########################################################################
+
       - name: Deploy HTML
         uses: JamesIves/github-pages-deploy-action@v4.4.3
         if: ${{ success() && env.AGDA_DEPLOY }}
-
         with:
           branch: gh-pages
           folder: html


### PR DESCRIPTION
Notes:
1. For this PR to be merged in, you will first need to **manually** evict all caches, so that merging this can create a fresh cache for subsequent PRs. GitHub Actions doesn't seem to overwrite caches as often as one would like!
2. I'd call this PR "experimental" because it involves reusing agda build caches for subsequent PRs. I've tested it with 1 comments-level change (locally, not easy to show on GitHub) and [1 code-level change](https://github.com/balacij/agda-categories/pull/1) to make sure that subsequent PRs aren't infected by a "good, working build" of `agda-categories`.
3. ~~I have no idea if cross-repo PRs are able to use caches, so this is a bit of a live test~~ This PR changes the paths designated in the actions/cache use, so it doesn't/won't hit the cache. :smile:

This PR adds reusable build caching for `agda-stdlib` and `agda-categories` by adding their respective agda-produced `_build/` folders to the GH Cache. In my testing, it reduces build times for no-diff changes to 2min (which really should be reducible to 0min if there are no changes...) by simply not having to recompile any Agda code. For [other changes](https://github.com/balacij/agda-categories/pull/2), the normal recompilation is done as needed (aside: I edited `Categories.Adjoint.Equivalence`, which I assume is seemingly depended on by many modules, so the build time is >2min && <20min).
