### PR TITLE
+Commutative monads

### DIFF
--- a/src/Categories/Category/Product/Properties.agda
+++ b/src/Categories/Category/Product/Properties.agda
@@ -90,7 +90,7 @@ module _ (C : Category o ℓ e) (D : Category o′ ℓ′ e′) where
   ※-distrib F G H = record
     { F⇒G = ntHelper record { η = λ _ → C×D.id ; commute = λ _ → MR.id-comm-sym C , MR.id-comm-sym D }
     ; F⇐G = ntHelper record { η = λ _ → C×D.id ; commute = λ _ → MR.id-comm-sym C , MR.id-comm-sym D }
-    ; iso = λ X → record
+    ; iso = λ _ → record
       { isoˡ = C.identityˡ , D.identityˡ
       ; isoʳ = C.identityʳ , D.identityʳ
       }
@@ -102,5 +102,12 @@ module _ (C : Category o ℓ e) (D : Category o′ ℓ′ e′) where
   ※-distrib₂ F G = record
     { F⇒G = ntHelper record { η = λ X → C.id , D.id ; commute = λ _ → MR.id-comm-sym C , MR.id-comm-sym D }
     ; F⇐G = ntHelper record { η = λ X → C.id , D.id ; commute = λ _ → MR.id-comm-sym C , MR.id-comm-sym D }
-    ; iso = λ X → record { isoˡ = C.identityˡ , D.identityʳ  ; isoʳ = C.identityʳ , D.identityʳ }
+    ; iso = λ _ → record { isoˡ = C.identityˡ , D.identityʳ  ; isoʳ = C.identityʳ , D.identityʳ }
     }
+
+  SwapFG≅FGSwap : {o₁ ℓ₁ e₁ o₂ ℓ₂ e₂ : Level} {A : Category o₁ ℓ₁ e₁} {B : Category o₂ ℓ₂ e₂}
+    → (F : Functor B D) → (G : Functor A C) → Swap ∘F (F ⁂ G) ≃ (G ⁂ F) ∘F Swap
+   
+  NaturalIsomorphism.F⇒G (SwapFG≅FGSwap F G) = ntHelper record { η = λ _ → C×D.id ; commute = λ _ → MR.id-comm-sym C×D}
+  NaturalIsomorphism.F⇐G (SwapFG≅FGSwap F G) = ntHelper record { η = λ _ → C×D.id ; commute = λ _ → MR.id-comm-sym C×D}
+  NaturalIsomorphism.iso (SwapFG≅FGSwap F G) = λ _ → record { isoˡ = C.identityˡ , D.identityˡ ; isoʳ = C.identityˡ , D.identityˡ }

--- a/src/Categories/Monad/Commutative.agda
+++ b/src/Categories/Monad/Commutative.agda
@@ -1,0 +1,36 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Level
+open import Data.Product using (_,_)
+
+open import Categories.Category
+open import Categories.Category.Monoidal
+open import Categories.Monad
+open import Categories.Monad.Strong
+open import Categories.Category.Monoidal.Symmetric
+open import Categories.Functor using (Functor; Endofunctor; _∘F_) renaming (id to idF)
+
+open import Categories.NaturalTransformation using (NaturalTransformation)
+
+module Categories.Monad.Commutative {o ℓ e} {C : Category o ℓ e} {V : Monoidal C} (S : Symmetric V) (SM : StrongMonad S) where
+
+private
+  module M = StrongMonad.M SM
+  module τ  = StrongMonad.strengthen SM
+  module τ' = StrongMonad.strengthen' SM
+
+open NaturalTransformation
+open Category C
+open Monoidal V
+
+open NaturalTransformation M.η using (η)
+open NaturalTransformation M.μ renaming (η to μ)
+
+open M using (F)
+open Functor F
+
+record Commutative : Set (o ⊔ ℓ ⊔ e) where
+  field
+    commutativity : {A B : Obj} → μ (A ⊗₀ B) ∘ F₁ (τ'.η (A , B)) ∘ τ.η (F₀ A , B)
+                                ≈ μ (A ⊗₀ B) ∘ F₁ (τ.η (A , B)) ∘ τ'.η (A , F₀ B)
+

--- a/src/Categories/Monad/Strong.agda
+++ b/src/Categories/Monad/Strong.agda
@@ -14,27 +14,51 @@ open import Data.Product using (_,_)
 open import Categories.Category
 open import Categories.Functor renaming (id to idF)
 open import Categories.Category.Monoidal
+open import Categories.Category.Monoidal.Symmetric
+open import Categories.Category.Monoidal.Braided
+
 open import Categories.Category.Product
+open import Categories.Category.Product.Properties
 open import Categories.NaturalTransformation hiding (id)
+open import Categories.NaturalTransformation.NaturalIsomorphism renaming (associator to ∘-assoc)
 open import Categories.Monad
 
 private
   variable
     o ℓ e : Level
 
-record Strength {C : Category o ℓ e} (V : Monoidal C) (M : Monad C) : Set (o ⊔ ℓ ⊔ e) where
+record Strength {C : Category o ℓ e} {V : Monoidal C} (S : Symmetric V) (M : Monad C) : Set (o ⊔ ℓ ⊔ e) where
   open Category C
   open Monoidal V
+
   private
     module M = Monad M
+    
   open M using (F)
   open NaturalTransformation M.η using (η)
   open NaturalTransformation M.μ renaming (η to μ)
   open Functor F
+  open Symmetric S using (braided)
+  open NaturalIsomorphism using (F⇐G; F⇒G)
+
+  private
+    γ   = Braided.braiding.F⇒G braided
+    γ⁻¹ = Braided.braiding.F⇐G braided
+
   field
     strengthen : NaturalTransformation (⊗ ∘F (idF ⁂ F)) (F ∘F ⊗)
 
-  module strengthen = NaturalTransformation strengthen
+   -- dual strength
+  strengthen' : NaturalTransformation (⊗ ∘F (F ⁂ idF)) (F ∘F ⊗)
+  strengthen' = (F ∘ˡ γ⁻¹) ∘ᵥ F⇒G (∘-assoc Swap ⊗ F) ∘ᵥ (strengthen ∘ʳ Swap) ∘ᵥ
+                F⇐G (∘-assoc Swap (idF ⁂ F) ⊗) ∘ᵥ
+                  (⊗ ∘ˡ F⇒G (SwapFG≅FGSwap C C F idF)) ∘ᵥ
+                F⇒G (∘-assoc (F ⁂ idF) Swap ⊗) ∘ᵥ
+                (γ ∘ʳ (F ⁂ idF))
+
+  module strengthen  = NaturalTransformation strengthen
+  module strengthen' = NaturalTransformation strengthen'
+
   private
     module t = strengthen
 
@@ -48,12 +72,12 @@ record Strength {C : Category o ℓ e} (V : Monoidal C) (M : Monad C) : Set (o �
       ≈ t.η (A , B) ∘ id ⊗₁ μ B
     -- consecutive applications of strength commute (i.e. strength is associative)
     strength-assoc :  {A B C : Obj} → F₁ associator.from ∘ t.η (A ⊗₀ B , C)
-      ≈ t.η (A , B ⊗₀ C) ∘ id ⊗₁ t.η (B , C) ∘ associator.from
+      ≈ t.η (A , B ⊗₀ C) ∘ id ⊗₁ t.η (B , C) ∘ associator.from   
 
-record StrongMonad {C : Category o ℓ e} (V : Monoidal C) : Set (o ⊔ ℓ ⊔ e) where
+record StrongMonad {C : Category o ℓ e} {V : Monoidal C} (S : Symmetric V) : Set (o ⊔ ℓ ⊔ e) where
   field
     M        : Monad C
-    strength : Strength V M
+    strength : Strength S M
 
   module M = Monad M
   open Strength strength public


### PR DESCRIPTION
- added the definition of commutative monad (src/Categories/Monad/Commutative.agda)
- to that end, amended the definition of strong monad (src/Categories/Monad/Strong.agda): added the assumption of the underlying monodial category to be symmetric, and used it to define the dual strength  (`strengthen' : NaturalTransformation (⊗ ∘F (F ⁂ idF)) (F ∘F ⊗)`)
- added a helper `SwapFG≅FGSwap` to src/Categories/Category/Product/Properties.agda