### PR TITLE
Add constructions for Monads and Comonads

### DIFF
--- a/src/Categories/Comonad.agda
+++ b/src/Categories/Comonad.agda
@@ -28,3 +28,15 @@ record Comonad {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
     sym-assoc : ∀ {X : Obj} → F₁ (δ.η X) ∘ δ.η X ≈ δ.η (F₀ X) ∘ δ.η X
     identityˡ : ∀ {X : Obj} → F₁ (ε.η X) ∘ δ.η X ≈ id
     identityʳ : ∀ {X : Obj} → ε.η (F₀ X) ∘ δ.η X ≈ id
+
+module _ {o ℓ e} (C : Category o ℓ e) where
+  open Comonad
+  open Category C
+  idCM : Comonad C
+  idCM .F = idF
+  idCM .ε = idN
+  idCM .δ = unitor² .F⇐G
+  idCM .assoc = Equiv.refl
+  idCM .sym-assoc = Equiv.refl
+  idCM .identityˡ = identity²
+  idCM .identityʳ = identity²

--- a/src/Categories/Comonad.agda
+++ b/src/Categories/Comonad.agda
@@ -21,7 +21,7 @@ record Comonad {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
   module δ = NaturalTransformation δ
 
   open Category C
-  open Functor F
+  open Functor F public
 
   field
     assoc     : ∀ {X : Obj} → δ.η (F₀ X) ∘ δ.η X ≈ F₁ (δ.η X) ∘ δ.η X

--- a/src/Categories/Comonad.agda
+++ b/src/Categories/Comonad.agda
@@ -21,7 +21,7 @@ record Comonad {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
   module δ = NaturalTransformation δ
 
   open Category C
-  open Functor F public
+  open Functor F
 
   field
     assoc     : ∀ {X : Obj} → δ.η (F₀ X) ∘ δ.η X ≈ F₁ (δ.η X) ∘ δ.η X

--- a/src/Categories/Comonad.agda
+++ b/src/Categories/Comonad.agda
@@ -31,12 +31,12 @@ record Comonad {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
 
 module _ {o ℓ e} (C : Category o ℓ e) where
   open Comonad
-  open Category C
-  idCM : Comonad C
-  idCM .F = idF
-  idCM .ε = idN
-  idCM .δ = unitor² .F⇐G
-  idCM .assoc = Equiv.refl
-  idCM .sym-assoc = Equiv.refl
-  idCM .identityˡ = identity²
-  idCM .identityʳ = identity²
+  open Category C hiding (id)
+  id : Comonad C
+  id .F = idF
+  id .ε = idN
+  id .δ = unitor² .F⇐G
+  id .assoc = Equiv.refl
+  id .sym-assoc = Equiv.refl
+  id .identityˡ = identity²
+  id .identityʳ = identity²

--- a/src/Categories/Comonad/Morphism.agda
+++ b/src/Categories/Comonad/Morphism.agda
@@ -1,0 +1,143 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Level
+open import Categories.Category using (Category)
+open import Categories.Comonad
+open import Categories.Functor renaming (id to idF)
+import Categories.Morphism.Reasoning as MR
+open import Categories.NaturalTransformation renaming (id to idN)
+open NaturalTransformation
+
+module Categories.Comonad.Morphism {o ℓ e} {C D : Category o ℓ e} where
+
+-- comonad morphism between generic comonads s : a -> a & t : b -> b
+--
+-- As the natural transformation underlying a monad morphism is contravariant,
+-- we take the natural transformation underlying a comonad morphism to be
+-- covariant by symmetry.
+record Comonad⇒ (S : Comonad C) (T : Comonad D) : Set (o ⊔ ℓ ⊔ e) where
+
+  private
+    module S = Comonad S
+    module T = Comonad T
+    open module D = Category D using (_∘_; _≈_)
+
+  field
+    X : Functor C D
+    α : NaturalTransformation (T.F ∘F X) (X ∘F S.F)
+
+  module X = Functor X
+  module α = NaturalTransformation α
+
+  field
+    -- we want this but no definitional functionality means sadness
+    -- counit-comp : (X ∘ˡ S.ε) ∘ᵥ α ≃ T.ε ∘ʳ X
+    counit-comp : ∀ {U} → X.₁ (S.ε.η U) ∘ α.η U ≈ T.ε.η (X.₀ U)
+    -- likewise here we want
+    -- comult-comp : (X ∘ˡ S.δ) ∘ α ≃ (α ∘ʳ S) ∘ (T ∘ˡ α) ∘ T.δ
+    comult-comp : ∀ {U} → X.₁ (S.δ.η U) ∘ α.η U ≈ α.η (S.F.₀ U) ∘ T.F.₁ (α.η U) ∘ T.δ.η (X.₀ U)
+
+-- comonad morphism in a different sense:
+-- comonads are on the same category, X is the identity
+record Comonad⇒-id (T S : Comonad C) : Set (o ⊔ ℓ ⊔ e) where
+
+  private
+    module T = Comonad T
+    module S = Comonad S
+    open module C = Category C using (_∘_; _≈_)
+
+  field
+    α : NaturalTransformation T.F S.F
+
+  module α = NaturalTransformation α
+
+  field
+    counit-comp : ∀ {U} → S.ε.η U ∘ α.η U ≈ T.ε.η U
+    comult-comp : ∀ {U} → S.δ.η U ∘ α.η U ≈ α.η (S.F.₀ U) ∘ T.F.₁ (α.η U) ∘ T.δ.η U
+
+
+-- not sure if this definition makes sense? or if it should be turned backwards
+record Comonad²⇒ {S : Comonad C} {T : Comonad D} (Γ Δ : Comonad⇒ S T) : Set (o ⊔ ℓ ⊔ e) where
+
+  private
+    module S = Comonad S
+    module T = Comonad T
+    module Γ = Comonad⇒ Γ
+    module Δ = Comonad⇒ Δ
+    open module D = Category D using (_∘_; _≈_)
+
+  field
+    m : NaturalTransformation Γ.X Δ.X
+
+  module m = NaturalTransformation m
+
+  field
+    comm : ∀ {U} → Δ.α.η U ∘ T.F.₁ (m.η U) ≈ m.η (S.F.₀ U) ∘ Γ.α.η U
+
+module _ {T : Comonad C} where
+  private
+    module T = Comonad T
+  open Comonad⇒-id
+  open Category C
+  open HomReasoning
+  Comonad⇒-id-id : (Comonad⇒-id T T)
+  Comonad⇒-id-id .α = idN
+  Comonad⇒-id-id .counit-comp {_} = identityʳ
+  Comonad⇒-id-id .comult-comp {U} = begin
+    T.δ.η U ∘ id
+    ≈⟨ identityʳ
+     ○ ⟺ identityˡ
+     ○ refl⟩∘⟨ ⟺ identityˡ
+     ○ refl⟩∘⟨ ⟺ T.F.identity ⟩∘⟨refl
+     ⟩
+    id ∘ T.F.F₁ id ∘ T.δ.η U
+    ∎
+
+module _ {S R T : Comonad C} where
+  private
+    module S = Comonad S
+    module T = Comonad T
+    module R = Comonad R
+  open Comonad⇒-id
+  module C = Category C
+  open C using(_∘_; _≈_)
+  open MR C
+  open C.HomReasoning
+  open Comonad
+
+  open import Categories.Tactic.Category using (solve)
+
+  Comonad⇒-id-∘ : (Comonad⇒-id S T) → (Comonad⇒-id T R) → (Comonad⇒-id S R)
+  Comonad⇒-id-∘ τ σ .α = σ .α ∘ᵥ τ .α
+  Comonad⇒-id-∘ τ σ .counit-comp {U} = begin
+    R.ε.η U ∘ (σ .α ∘ᵥ τ .α) .η  U
+    ≈⟨ C.sym-assoc ⟩
+    (R.ε.η U ∘ σ .α.η U) ∘ τ .α.η  U
+    ≈⟨ σ .counit-comp ⟩∘⟨refl ⟩
+    T.ε.η U ∘ τ .α.η  U
+    ≈⟨ τ .counit-comp ⟩
+    S.ε.η U
+    ∎
+  Comonad⇒-id-∘ τ σ .comult-comp {U} = begin
+    R.δ.η U ∘ σ .α.η U ∘ τ .α.η U
+    ≈⟨ C.sym-assoc ⟩
+    (R.δ.η U ∘ σ .α.η U) ∘ τ .α.η U
+    ≈⟨ σ .comult-comp ⟩∘⟨refl  ⟩
+    (σ .α.η (R.F.₀ U) ∘ T.F.₁ (σ .α.η U) ∘ T.δ.η U) ∘ τ .α.η U
+    ≈⟨ C.sym-assoc ⟩∘⟨refl
+     ○ C.assoc ⟩
+    (σ .α.η (R.F.₀ U) ∘ T.F.₁ (σ .α.η U)) ∘ (T.δ.η U ∘ τ .α.η U)
+    ≈⟨ refl⟩∘⟨ τ .comult-comp ⟩
+    (σ .α.η (R.F.₀ U) ∘ T.F.₁ (σ .α.η U)) ∘ (τ .α.η (T.F.₀ U) ∘ S.F.₁ (τ .α.η U) ∘ S.δ.η U)
+    ≈⟨ C.assoc
+     ○ refl⟩∘⟨ C.sym-assoc ⟩
+    σ .α.η (R.F.₀ U) ∘ (T.F.₁ (σ .α.η U) ∘ τ .α.η (T.F.₀ U)) ∘ S.F.₁ (τ .α.η U) ∘ S.δ.η U
+    ≈⟨ refl⟩∘⟨ τ .α .sym-commute (σ .α.η U) ⟩∘⟨refl  ⟩
+    σ .α.η (R.F.₀ U) ∘ (τ .α.η (R.F.₀ U) ∘ S.F.₁ (σ .α.η U)) ∘ S.F.₁ (τ .α.η U) ∘ S.δ.η U
+    ≈⟨ refl⟩∘⟨ C.assoc
+     ○ C.sym-assoc
+     ○ refl⟩∘⟨ C.sym-assoc ⟩
+    (σ .α.η (R.F.₀ U) ∘ τ .α.η (R.F.₀ U)) ∘ (S.F.₁ (σ .α.η U) ∘ S.F.₁ (τ .α.η U)) ∘ S.δ.η U
+    ≈⟨ refl⟩∘⟨ ⟺ S.F.homomorphism ⟩∘⟨refl ⟩
+    (σ .α.η (R.F.₀ U) ∘ τ .α.η (R.F.₀ U)) ∘ S.F.₁ (σ .α.η U ∘ τ .α.η  U) ∘ S.δ.η U
+    ∎

--- a/src/Categories/Comonad/Morphism.agda
+++ b/src/Categories/Comonad/Morphism.agda
@@ -99,14 +99,12 @@ module _ {S R T : Comonad C} where
     module S = Comonad S
     module T = Comonad T
     module R = Comonad R
+    module C = Category C
   open Comonad⇒-id
-  module C = Category C
   open C using(_∘_; _≈_)
   open MR C
   open C.HomReasoning
   open Comonad
-
-  open import Categories.Tactic.Category using (solve)
 
   Comonad⇒-id-∘ : (Comonad⇒-id T R) → (Comonad⇒-id S T) → (Comonad⇒-id S R)
   Comonad⇒-id-∘ σ τ .α = σ .α ∘ᵥ τ .α

--- a/src/Categories/Comonad/Morphism.agda
+++ b/src/Categories/Comonad/Morphism.agda
@@ -8,34 +8,54 @@ import Categories.Morphism.Reasoning as MR
 open import Categories.NaturalTransformation renaming (id to idN)
 open NaturalTransformation
 
-module Categories.Comonad.Morphism {o ℓ e} {C D : Category o ℓ e} where
+module Categories.Comonad.Morphism {o ℓ e} {C : Category o ℓ e} where
 
--- comonad morphism between generic comonads s : a -> a & t : b -> b
---
--- As the natural transformation underlying a monad morphism is contravariant,
--- we take the natural transformation underlying a comonad morphism to be
--- covariant by symmetry.
-record Comonad⇒ (S : Comonad C) (T : Comonad D) : Set (o ⊔ ℓ ⊔ e) where
 
-  private
-    module S = Comonad S
-    module T = Comonad T
-    open module D = Category D using (_∘_; _≈_)
+module _ {D : Category o ℓ e} where
+  -- comonad morphism between generic comonads s : a -> a & t : b -> b
+  --
+  -- As the natural transformation underlying a monad morphism is contravariant,
+  -- we take the natural transformation underlying a comonad morphism to be
+  -- covariant by symmetry.
+  record Comonad⇒ (S : Comonad C) (T : Comonad D) : Set (o ⊔ ℓ ⊔ e) where
 
-  field
-    X : Functor C D
-    α : NaturalTransformation (T.F ∘F X) (X ∘F S.F)
+    private
+      module S = Comonad S
+      module T = Comonad T
+      open module D = Category D using (_∘_; _≈_)
 
-  module X = Functor X
-  module α = NaturalTransformation α
+    field
+      X : Functor C D
+      α : NaturalTransformation (T.F ∘F X) (X ∘F S.F)
 
-  field
-    -- we want this but no definitional functionality means sadness
-    -- counit-comp : (X ∘ˡ S.ε) ∘ᵥ α ≃ T.ε ∘ʳ X
-    counit-comp : ∀ {U} → X.₁ (S.ε.η U) ∘ α.η U ≈ T.ε.η (X.₀ U)
-    -- likewise here we want
-    -- comult-comp : (X ∘ˡ S.δ) ∘ α ≃ (α ∘ʳ S) ∘ (T ∘ˡ α) ∘ T.δ
-    comult-comp : ∀ {U} → X.₁ (S.δ.η U) ∘ α.η U ≈ α.η (S.F.₀ U) ∘ T.F.₁ (α.η U) ∘ T.δ.η (X.₀ U)
+    module X = Functor X
+    module α = NaturalTransformation α
+
+    field
+      -- we want this but no definitional functionality means sadness
+      -- counit-comp : (X ∘ˡ S.ε) ∘ᵥ α ≃ T.ε ∘ʳ X
+      counit-comp : ∀ {U} → X.₁ (S.ε.η U) ∘ α.η U ≈ T.ε.η (X.₀ U)
+      -- likewise here we want
+      -- comult-comp : (X ∘ˡ S.δ) ∘ α ≃ (α ∘ʳ S) ∘ (T ∘ˡ α) ∘ T.δ
+      comult-comp : ∀ {U} → X.₁ (S.δ.η U) ∘ α.η U ≈ α.η (S.F.₀ U) ∘ T.F.₁ (α.η U) ∘ T.δ.η (X.₀ U)
+
+  -- not sure if this definition makes sense? or if it should be turned backwards
+  record Comonad²⇒ {S : Comonad C} {T : Comonad D} (Γ Δ : Comonad⇒ S T) : Set (o ⊔ ℓ ⊔ e) where
+
+    private
+      module S = Comonad S
+      module T = Comonad T
+      module Γ = Comonad⇒ Γ
+      module Δ = Comonad⇒ Δ
+      open module D = Category D using (_∘_; _≈_)
+
+    field
+      m : NaturalTransformation Γ.X Δ.X
+
+    module m = NaturalTransformation m
+
+    field
+      comm : ∀ {U} → Δ.α.η U ∘ T.F.₁ (m.η U) ≈ m.η (S.F.₀ U) ∘ Γ.α.η U
 
 -- comonad morphism in a different sense:
 -- comonads are on the same category, X is the identity
@@ -54,25 +74,6 @@ record Comonad⇒-id (T S : Comonad C) : Set (o ⊔ ℓ ⊔ e) where
   field
     counit-comp : ∀ {U} → S.ε.η U ∘ α.η U ≈ T.ε.η U
     comult-comp : ∀ {U} → S.δ.η U ∘ α.η U ≈ α.η (S.F.₀ U) ∘ T.F.₁ (α.η U) ∘ T.δ.η U
-
-
--- not sure if this definition makes sense? or if it should be turned backwards
-record Comonad²⇒ {S : Comonad C} {T : Comonad D} (Γ Δ : Comonad⇒ S T) : Set (o ⊔ ℓ ⊔ e) where
-
-  private
-    module S = Comonad S
-    module T = Comonad T
-    module Γ = Comonad⇒ Γ
-    module Δ = Comonad⇒ Δ
-    open module D = Category D using (_∘_; _≈_)
-
-  field
-    m : NaturalTransformation Γ.X Δ.X
-
-  module m = NaturalTransformation m
-
-  field
-    comm : ∀ {U} → Δ.α.η U ∘ T.F.₁ (m.η U) ≈ m.η (S.F.₀ U) ∘ Γ.α.η U
 
 module _ {T : Comonad C} where
   private

--- a/src/Categories/Comonad/Morphism.agda
+++ b/src/Categories/Comonad/Morphism.agda
@@ -81,16 +81,15 @@ module _ {T : Comonad C} where
   open Comonad⇒-id
   open Category C
   open HomReasoning
+  open MR C
   Comonad⇒-id-id : (Comonad⇒-id T T)
   Comonad⇒-id-id .α = idN
   Comonad⇒-id-id .counit-comp {_} = identityʳ
   Comonad⇒-id-id .comult-comp {U} = begin
     T.δ.η U ∘ id
-    ≈⟨ identityʳ
-     ○ ⟺ identityˡ
-     ○ refl⟩∘⟨ ⟺ identityˡ
-     ○ refl⟩∘⟨ ⟺ T.F.identity ⟩∘⟨refl
-     ⟩
+    ≈⟨ id-comm ⟩
+    id ∘ T.δ.η U
+    ≈⟨ refl⟩∘⟨ introˡ T.F.identity ⟩
     id ∘ T.F.F₁ id ∘ T.δ.η U
     ∎
 
@@ -110,32 +109,25 @@ module _ {S R T : Comonad C} where
   Comonad⇒-id-∘ σ τ .α = σ .α ∘ᵥ τ .α
   Comonad⇒-id-∘ σ τ .counit-comp {U} = begin
     R.ε.η U ∘ (σ .α ∘ᵥ τ .α) .η  U
-    ≈⟨ C.sym-assoc ⟩
-    (R.ε.η U ∘ σ .α.η U) ∘ τ .α.η  U
-    ≈⟨ σ .counit-comp ⟩∘⟨refl ⟩
+    ≈⟨ pullˡ (σ .counit-comp) ⟩
     T.ε.η U ∘ τ .α.η  U
     ≈⟨ τ .counit-comp ⟩
     S.ε.η U
     ∎
   Comonad⇒-id-∘ σ τ .comult-comp {U} = begin
     R.δ.η U ∘ σ .α.η U ∘ τ .α.η U
-    ≈⟨ C.sym-assoc ⟩
-    (R.δ.η U ∘ σ .α.η U) ∘ τ .α.η U
-    ≈⟨ σ .comult-comp ⟩∘⟨refl  ⟩
+    ≈⟨ pullˡ (σ .comult-comp) ⟩
     (σ .α.η (R.F.₀ U) ∘ T.F.₁ (σ .α.η U) ∘ T.δ.η U) ∘ τ .α.η U
-    ≈⟨ C.sym-assoc ⟩∘⟨refl
-     ○ C.assoc ⟩
+    -- there is no approx² that witnesses (a ∘ (b ∘ c)) ∘ d ≈ (a ∘ b) ∘ (c ∘ d)
+    ≈⟨ pushˡ C.sym-assoc ⟩
     (σ .α.η (R.F.₀ U) ∘ T.F.₁ (σ .α.η U)) ∘ (T.δ.η U ∘ τ .α.η U)
     ≈⟨ refl⟩∘⟨ τ .comult-comp ⟩
     (σ .α.η (R.F.₀ U) ∘ T.F.₁ (σ .α.η U)) ∘ (τ .α.η (T.F.₀ U) ∘ S.F.₁ (τ .α.η U) ∘ S.δ.η U)
-    ≈⟨ C.assoc
-     ○ refl⟩∘⟨ C.sym-assoc ⟩
+    ≈⟨ pullʳ C.sym-assoc ⟩
     σ .α.η (R.F.₀ U) ∘ (T.F.₁ (σ .α.η U) ∘ τ .α.η (T.F.₀ U)) ∘ S.F.₁ (τ .α.η U) ∘ S.δ.η U
     ≈⟨ refl⟩∘⟨ τ .α .sym-commute (σ .α.η U) ⟩∘⟨refl  ⟩
     σ .α.η (R.F.₀ U) ∘ (τ .α.η (R.F.₀ U) ∘ S.F.₁ (σ .α.η U)) ∘ S.F.₁ (τ .α.η U) ∘ S.δ.η U
-    ≈⟨ refl⟩∘⟨ C.assoc
-     ○ C.sym-assoc
-     ○ refl⟩∘⟨ C.sym-assoc ⟩
+    ≈⟨ pushʳ C.assoc ○ refl⟩∘⟨ C.sym-assoc ⟩ -- a ∘ (b ∘ c) ∘ (d ∘ e) ≈ (a ∘ b) ∘ (c ∘ d) ∘ e
     (σ .α.η (R.F.₀ U) ∘ τ .α.η (R.F.₀ U)) ∘ (S.F.₁ (σ .α.η U) ∘ S.F.₁ (τ .α.η U)) ∘ S.δ.η U
     ≈⟨ refl⟩∘⟨ ⟺ S.F.homomorphism ⟩∘⟨refl ⟩
     (σ .α.η (R.F.₀ U) ∘ τ .α.η (R.F.₀ U)) ∘ S.F.₁ (σ .α.η U ∘ τ .α.η  U) ∘ S.δ.η U

--- a/src/Categories/Comonad/Morphism.agda
+++ b/src/Categories/Comonad/Morphism.agda
@@ -86,12 +86,9 @@ module _ {T : Comonad C} where
   Comonad⇒-id-id .α = idN
   Comonad⇒-id-id .counit-comp {_} = identityʳ
   Comonad⇒-id-id .comult-comp {U} = begin
-    T.δ.η U ∘ id
-    ≈⟨ id-comm ⟩
-    id ∘ T.δ.η U
-    ≈⟨ refl⟩∘⟨ introˡ T.F.identity ⟩
-    id ∘ T.F.F₁ id ∘ T.δ.η U
-    ∎
+    T.δ.η U ∘ id             ≈⟨ id-comm ⟩
+    id ∘ T.δ.η U             ≈⟨ refl⟩∘⟨ introˡ T.F.identity ⟩
+    id ∘ T.F.F₁ id ∘ T.δ.η U ∎
 
 module _ {S R T : Comonad C} where
   private
@@ -108,27 +105,24 @@ module _ {S R T : Comonad C} where
   Comonad⇒-id-∘ : (Comonad⇒-id T R) → (Comonad⇒-id S T) → (Comonad⇒-id S R)
   Comonad⇒-id-∘ σ τ .α = σ .α ∘ᵥ τ .α
   Comonad⇒-id-∘ σ τ .counit-comp {U} = begin
-    R.ε.η U ∘ (σ .α ∘ᵥ τ .α) .η  U
-    ≈⟨ pullˡ (σ .counit-comp) ⟩
-    T.ε.η U ∘ τ .α.η  U
-    ≈⟨ τ .counit-comp ⟩
-    S.ε.η U
-    ∎
+    R.ε.η U ∘ (σ .α ∘ᵥ τ .α) .η  U ≈⟨ pullˡ (σ .counit-comp) ⟩
+    T.ε.η U ∘ τ .α.η  U            ≈⟨ τ .counit-comp ⟩
+    S.ε.η U                        ∎
   Comonad⇒-id-∘ σ τ .comult-comp {U} = begin
     R.δ.η U ∘ σ .α.η U ∘ τ .α.η U
-    ≈⟨ pullˡ (σ .comult-comp) ⟩
+      ≈⟨ pullˡ (σ .comult-comp) ⟩
     (σ .α.η (R.F.₀ U) ∘ T.F.₁ (σ .α.η U) ∘ T.δ.η U) ∘ τ .α.η U
-    -- there is no approx² that witnesses (a ∘ (b ∘ c)) ∘ d ≈ (a ∘ b) ∘ (c ∘ d)
-    ≈⟨ pushˡ C.sym-assoc ⟩
+      -- there is no approx² that witnesses (a ∘ (b ∘ c)) ∘ d ≈ (a ∘ b) ∘ (c ∘ d)
+      ≈⟨ pushˡ C.sym-assoc ⟩
     (σ .α.η (R.F.₀ U) ∘ T.F.₁ (σ .α.η U)) ∘ (T.δ.η U ∘ τ .α.η U)
-    ≈⟨ refl⟩∘⟨ τ .comult-comp ⟩
+      ≈⟨ refl⟩∘⟨ τ .comult-comp ⟩
     (σ .α.η (R.F.₀ U) ∘ T.F.₁ (σ .α.η U)) ∘ (τ .α.η (T.F.₀ U) ∘ S.F.₁ (τ .α.η U) ∘ S.δ.η U)
-    ≈⟨ pullʳ C.sym-assoc ⟩
+      ≈⟨ pullʳ C.sym-assoc ⟩
     σ .α.η (R.F.₀ U) ∘ (T.F.₁ (σ .α.η U) ∘ τ .α.η (T.F.₀ U)) ∘ S.F.₁ (τ .α.η U) ∘ S.δ.η U
-    ≈⟨ refl⟩∘⟨ τ .α .sym-commute (σ .α.η U) ⟩∘⟨refl  ⟩
+      ≈⟨ refl⟩∘⟨ τ .α .sym-commute (σ .α.η U) ⟩∘⟨refl  ⟩
     σ .α.η (R.F.₀ U) ∘ (τ .α.η (R.F.₀ U) ∘ S.F.₁ (σ .α.η U)) ∘ S.F.₁ (τ .α.η U) ∘ S.δ.η U
-    ≈⟨ pushʳ C.assoc ○ refl⟩∘⟨ C.sym-assoc ⟩ -- a ∘ (b ∘ c) ∘ (d ∘ e) ≈ (a ∘ b) ∘ (c ∘ d) ∘ e
+      ≈⟨ pushʳ C.assoc ○ refl⟩∘⟨ C.sym-assoc ⟩ -- a ∘ (b ∘ c) ∘ (d ∘ e) ≈ (a ∘ b) ∘ (c ∘ d) ∘ e
     (σ .α.η (R.F.₀ U) ∘ τ .α.η (R.F.₀ U)) ∘ (S.F.₁ (σ .α.η U) ∘ S.F.₁ (τ .α.η U)) ∘ S.δ.η U
-    ≈⟨ refl⟩∘⟨ ⟺ S.F.homomorphism ⟩∘⟨refl ⟩
+      ≈⟨ refl⟩∘⟨ ⟺ S.F.homomorphism ⟩∘⟨refl ⟩
     (σ .α.η (R.F.₀ U) ∘ τ .α.η (R.F.₀ U)) ∘ S.F.₁ (σ .α.η U ∘ τ .α.η  U) ∘ S.δ.η U
-    ∎
+      ∎

--- a/src/Categories/Comonad/Morphism.agda
+++ b/src/Categories/Comonad/Morphism.agda
@@ -108,9 +108,9 @@ module _ {S R T : Comonad C} where
 
   open import Categories.Tactic.Category using (solve)
 
-  Comonad⇒-id-∘ : (Comonad⇒-id S T) → (Comonad⇒-id T R) → (Comonad⇒-id S R)
-  Comonad⇒-id-∘ τ σ .α = σ .α ∘ᵥ τ .α
-  Comonad⇒-id-∘ τ σ .counit-comp {U} = begin
+  Comonad⇒-id-∘ : (Comonad⇒-id T R) → (Comonad⇒-id S T) → (Comonad⇒-id S R)
+  Comonad⇒-id-∘ σ τ .α = σ .α ∘ᵥ τ .α
+  Comonad⇒-id-∘ σ τ .counit-comp {U} = begin
     R.ε.η U ∘ (σ .α ∘ᵥ τ .α) .η  U
     ≈⟨ C.sym-assoc ⟩
     (R.ε.η U ∘ σ .α.η U) ∘ τ .α.η  U
@@ -119,7 +119,7 @@ module _ {S R T : Comonad C} where
     ≈⟨ τ .counit-comp ⟩
     S.ε.η U
     ∎
-  Comonad⇒-id-∘ τ σ .comult-comp {U} = begin
+  Comonad⇒-id-∘ σ τ .comult-comp {U} = begin
     R.δ.η U ∘ σ .α.η U ∘ τ .α.η U
     ≈⟨ C.sym-assoc ⟩
     (R.δ.η U ∘ σ .α.η U) ∘ τ .α.η U

--- a/src/Categories/Comonad/Morphism.agda
+++ b/src/Categories/Comonad/Morphism.agda
@@ -2,7 +2,7 @@
 
 open import Level
 open import Categories.Category using (Category)
-open import Categories.Comonad
+open import Categories.Comonad using (Comonad) renaming (id to idCM)
 open import Categories.Functor renaming (id to idF)
 import Categories.Morphism.Reasoning as MR
 open import Categories.NaturalTransformation renaming (id to idN)

--- a/src/Categories/Monad.agda
+++ b/src/Categories/Monad.agda
@@ -28,3 +28,15 @@ record Monad {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
     sym-assoc : ∀ {X : Obj} → μ.η X ∘ μ.η (F₀ X) ≈ μ.η X ∘ F₁ (μ.η X)
     identityˡ : ∀ {X : Obj} → μ.η X ∘ F₁ (η.η X) ≈ id
     identityʳ : ∀ {X : Obj} → μ.η X ∘ η.η (F₀ X) ≈ id
+
+module _ {o ℓ e} (C : Category o ℓ e) where
+  open Monad
+  open Category C
+  idM : Monad C
+  idM .F = idF
+  idM .η = idN
+  idM .μ = unitor² .F⇒G
+  idM .assoc = Equiv.refl
+  idM .sym-assoc = Equiv.refl
+  idM .identityˡ = identity²
+  idM .identityʳ = identity²

--- a/src/Categories/Monad.agda
+++ b/src/Categories/Monad.agda
@@ -31,12 +31,12 @@ record Monad {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
 
 module _ {o ℓ e} (C : Category o ℓ e) where
   open Monad
-  open Category C
-  idM : Monad C
-  idM .F = idF
-  idM .η = idN
-  idM .μ = unitor² .F⇒G
-  idM .assoc = Equiv.refl
-  idM .sym-assoc = Equiv.refl
-  idM .identityˡ = identity²
-  idM .identityʳ = identity²
+  open Category C hiding (id)
+  id : Monad C
+  id .F = idF
+  id .η = idN
+  id .μ = unitor² .F⇒G
+  id .assoc = Equiv.refl
+  id .sym-assoc = Equiv.refl
+  id .identityˡ = identity²
+  id .identityʳ = identity²

--- a/src/Categories/Monad.agda
+++ b/src/Categories/Monad.agda
@@ -21,7 +21,7 @@ record Monad {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
   module μ = NaturalTransformation μ
 
   open Category C
-  open F
+  open F public
 
   field
     assoc     : ∀ {X : Obj} → μ.η X ∘ F₁ (μ.η X) ≈ μ.η X ∘ μ.η (F₀ X)

--- a/src/Categories/Monad.agda
+++ b/src/Categories/Monad.agda
@@ -21,7 +21,7 @@ record Monad {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
   module μ = NaturalTransformation μ
 
   open Category C
-  open F public
+  open F
 
   field
     assoc     : ∀ {X : Obj} → μ.η X ∘ F₁ (μ.η X) ≈ μ.η X ∘ μ.η (F₀ X)

--- a/src/Categories/Monad/Morphism.agda
+++ b/src/Categories/Monad/Morphism.agda
@@ -2,71 +2,146 @@
 
 open import Level
 open import Categories.Category
+open import Categories.Functor renaming (id to idF)
 open import Categories.Monad
-
-module Categories.Monad.Morphism {o ℓ e} {C D : Category o ℓ e} where
-
-open import Categories.NaturalTransformation
-open import Categories.Functor
-
+import Categories.Morphism.Reasoning as MR
+open import Categories.NaturalTransformation renaming (id to idN)
 open NaturalTransformation
 
--- monad morphism in the sense of the nLab
--- https://ncatlab.org/nlab/show/monad#the_bicategory_of_monads
--- between generic monads t : a -> a & s : b -> b
-record Monad⇒ (M : Monad C) (N : Monad D) : Set (o ⊔ ℓ ⊔ e) where
+module Categories.Monad.Morphism {o ℓ e} {C : Category o ℓ e} where
 
-  private
-    module M = Monad M
-    module N = Monad N
+module _ {D : Category o ℓ e} where
+  -- monad morphism in the sense of the nLab
+  -- https://ncatlab.org/nlab/show/monad#the_bicategory_of_monads
+  -- between generic monads t : a -> a & s : b -> b
+  record Monad⇒ (M : Monad C) (N : Monad D) : Set (o ⊔ ℓ ⊔ e) where
 
-  open module D = Category D using (_∘_; _≈_)
+    private
+      module M = Monad M
+      module N = Monad N
+      open module D = Category D using (_∘_; _≈_)
 
-  field
-    X : Functor C D
-    α : NaturalTransformation (N.F ∘F X) (X ∘F M.F)
+    field
+      X : Functor C D
+      α : NaturalTransformation (N.F ∘F X) (X ∘F M.F)
 
-  module X = Functor X
-  module α = NaturalTransformation α
+    module X = Functor X
+    module α = NaturalTransformation α
 
-  field
-    unit-comp : ∀ {U} → α.η U ∘ (N.η.η (X.₀ U)) ≈ X.₁ (M.η.η U)
-    mult-comp : ∀ {U} → α.η U ∘ (N.μ.η (X.₀ U)) ≈ X.₁ (M.μ.η U) ∘ α.η (M.F.₀ U) ∘ N.F.₁ (α.η U)
+    field
+      unit-comp : ∀ {U} → α.η U ∘ (N.η.η (X.₀ U)) ≈ X.₁ (M.η.η U)
+      mult-comp : ∀ {U} → α.η U ∘ (N.μ.η (X.₀ U)) ≈ X.₁ (M.μ.η U) ∘ α.η (M.F.₀ U) ∘ N.F.₁ (α.η U)
+
+
+  -- monad 2-cell in the sense of https://ncatlab.org/nlab/show/monad#the_bicategory_of_monads
+  record Monad²⇒ {M : Monad C} {N : Monad D} (Γ Δ : Monad⇒ M N) : Set (o ⊔ ℓ ⊔ e) where
+
+    private
+      module M = Monad M
+      module N = Monad N
+      module Γ = Monad⇒ Γ
+      module Δ = Monad⇒ Δ
+      open module D = Category D using (_∘_; _≈_)
+
+    field
+      m : NaturalTransformation Γ.X Δ.X
+
+    module m = NaturalTransformation m
+
+
+    field
+      comm : ∀ {U} → Δ.α.η U ∘ N.F.₁ (m.η U) ≈ m.η (M.F.₀ U) ∘ Γ.α.η U
 
 -- monad morphism in a different sense:
 -- monads are on the same category, X is the identity
+--
+-- Really we would like to view this as a special case of the above, e.g. use a
+-- shared record of monad morphism properties containing the natural
+-- transformation and laws. However, this is not possible, as the following
+-- natural transformation would not be from N.F to M.F, but instead would be
+-- composed with the identity functor on both sides.
+--
+-- Unfortunately these natural transformations are not only not equal, but
+-- equality cannot be _stated_ as they are not between definitionally equal
+-- functors. Instead it is better to have a special definition with the identity
+-- functors removed.
 record Monad⇒-id (M N : Monad C) : Set (o ⊔ ℓ ⊔ e) where
 
   private
     module M = Monad M
     module N = Monad N
+    open module C = Category C using (_∘_; _≈_)
 
   field
     α : NaturalTransformation N.F M.F
 
   module α = NaturalTransformation α
 
-  open module C = Category C using (_∘_; _≈_)
-
   field
     unit-comp : ∀ {U} → α.η U ∘ N.η.η U ≈ M.η.η U
     mult-comp : ∀ {U} → α.η U ∘ (N.μ.η U) ≈ M.μ.η U ∘ α.η (M.F.₀ U) ∘ N.F.₁ (α.η U)
 
--- monad 2-cell in the sense of https://ncatlab.org/nlab/show/monad#the_bicategory_of_monads
-record Monad²⇒ {M : Monad C} {N : Monad D} (Γ Δ : Monad⇒ M N) : Set (o ⊔ ℓ ⊔ e) where
-
+module _ {T : Monad C} where
   private
-    module M = Monad M
-    module N = Monad N
-    module Γ = Monad⇒ Γ
-    module Δ = Monad⇒ Δ
+    module T = Monad T
+  open Monad⇒-id
+  open Category C
+  open HomReasoning
+  Monad⇒-id-id : (Monad⇒-id T T)
+  Monad⇒-id-id .α = idN
+  Monad⇒-id-id .unit-comp {_} = identityˡ
+  Monad⇒-id-id .mult-comp {U} = begin
+      id ∘ T.μ.η U
+      ≈⟨ identityˡ
+       ○ ⟺ identityʳ
+       ○ refl⟩∘⟨ ⟺ identityʳ
+       ⟩
+      T.μ.η U ∘ id ∘ id
+      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ T.F.identity ⟩
+      T.μ.η U ∘ id ∘ T.F.₁ id
+      ∎
 
-  field
-    m : NaturalTransformation Γ.X Δ.X
+module _ {S R T : Monad C} where
+  private
+    module S = Monad S
+    module T = Monad T
+    module R = Monad R
+  open Monad⇒-id
+  module C = Category C
+  open C using(_∘_; _≈_)
+  open MR C
+  open C.HomReasoning
+  open Monad
 
-  module m = NaturalTransformation m
+  open import Categories.Tactic.Category using (solve)
 
-  open module D = Category D using (_∘_; _≈_)
-
-  field
-    comm : ∀ {U} → Δ.α.η U ∘ N.F.₁ (m.η U) ≈ m.η (M.F.₀ U) ∘ Γ.α.η U
+  Monad⇒-id-∘ : (Monad⇒-id S T) → (Monad⇒-id T R) → (Monad⇒-id S R)
+  Monad⇒-id-∘ τ σ .α = τ .α ∘ᵥ σ .α
+  Monad⇒-id-∘ τ σ .unit-comp {U} = begin
+      (τ .α .η U ∘  σ .α .η U) ∘ R .η .η U
+      ≈⟨ C.assoc ⟩
+      τ .α .η U ∘  (σ .α .η U ∘ R .η .η U)
+      ≈⟨ refl⟩∘⟨ σ .unit-comp ⟩
+      τ .α .η U ∘ T .η .η U
+      ≈⟨ τ .unit-comp ⟩
+      S .η .η U
+      ∎
+  Monad⇒-id-∘ τ σ .mult-comp {U} = begin
+      (τ .α .η U ∘ σ .α .η U) ∘ R.μ.η U
+      ≈⟨ C.assoc ⟩
+      τ .α .η U ∘ (σ .α .η U ∘ R.μ.η U)
+      ≈⟨ refl⟩∘⟨ σ .mult-comp ⟩
+      τ .α .η U ∘ (T.μ.η U ∘ σ .α .η (T.F.₀ U) ∘ R.F.₁ (σ .α .η U))
+      ≈⟨ C.sym-assoc ⟩
+      (τ .α .η U ∘ T.μ.η U) ∘ σ .α .η (T.F.₀ U) ∘ R.F.₁ (σ .α .η U)
+      ≈⟨ τ .mult-comp ⟩∘⟨refl ⟩
+      (S.μ.η U ∘ τ .α.η (S.F.₀ U) ∘ T.F.₁ (τ .α.η U)) ∘ σ .α.η (T.F.₀ U) ∘ R.F.₁ (σ .α.η U)
+      ≈⟨ pushˡ C.sym-assoc  ⟩
+      (S.μ.η U ∘ τ .α.η (S.F.₀ U)) ∘ T.F.₁ (τ .α.η U) ∘ σ .α.η (T.F.₀ U) ∘ R.F.₁ (σ .α.η U)
+      ≈⟨ refl⟩∘⟨ (pullˡ (σ .α .sym-commute (τ .α.η U)) ○ C.assoc ) ⟩
+      (S.μ.η U ∘ τ .α.η (S.F.₀ U)) ∘ σ .α.η (S.F.₀ U) ∘ R.F.₁ (τ .α.η U) ∘ R.F.₁ (σ .α.η U)
+      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ R.F.homomorphism ⟩
+      (S.μ.η U ∘ τ .α.η (S.F.₀ U)) ∘ σ .α.η (S.F.₀ U) ∘ R.F.₁ (τ .α.η U ∘ σ .α.η U)
+      ≈⟨ pullˡ C.assoc ○ C.assoc ⟩
+      S.μ.η U ∘ (τ .α.η (S.F.₀ U) ∘ σ .α.η (S.F.₀ U)) ∘ R.F.₁ (τ .α.η U ∘ σ .α.η U)
+      ∎

--- a/src/Categories/Monad/Morphism.agda
+++ b/src/Categories/Monad/Morphism.agda
@@ -3,7 +3,7 @@
 open import Level
 open import Categories.Category
 open import Categories.Functor renaming (id to idF)
-open import Categories.Monad renaming (id to idM)
+open import Categories.Monad using (Monad) renaming (id to idM)
 import Categories.Morphism.Reasoning as MR
 open import Categories.NaturalTransformation renaming (id to idN)
 open NaturalTransformation

--- a/src/Categories/Monad/Morphism.agda
+++ b/src/Categories/Monad/Morphism.agda
@@ -106,14 +106,12 @@ module _ {S R T : Monad C} where
     module S = Monad S
     module T = Monad T
     module R = Monad R
+    module C = Category C
   open Monad⇒-id
-  module C = Category C
   open C using(_∘_; _≈_)
   open MR C
   open C.HomReasoning
   open Monad
-
-  open import Categories.Tactic.Category using (solve)
 
   Monad⇒-id-∘ : (Monad⇒-id T R) → (Monad⇒-id S T) → (Monad⇒-id S R)
   Monad⇒-id-∘ σ τ .α = τ .α ∘ᵥ σ .α

--- a/src/Categories/Monad/Morphism.agda
+++ b/src/Categories/Monad/Morphism.agda
@@ -115,9 +115,9 @@ module _ {S R T : Monad C} where
 
   open import Categories.Tactic.Category using (solve)
 
-  Monad⇒-id-∘ : (Monad⇒-id S T) → (Monad⇒-id T R) → (Monad⇒-id S R)
-  Monad⇒-id-∘ τ σ .α = τ .α ∘ᵥ σ .α
-  Monad⇒-id-∘ τ σ .unit-comp {U} = begin
+  Monad⇒-id-∘ : (Monad⇒-id T R) → (Monad⇒-id S T) → (Monad⇒-id S R)
+  Monad⇒-id-∘ σ τ .α = τ .α ∘ᵥ σ .α
+  Monad⇒-id-∘ σ τ .unit-comp {U} = begin
       (τ .α .η U ∘  σ .α .η U) ∘ R .η .η U
       ≈⟨ C.assoc ⟩
       τ .α .η U ∘  (σ .α .η U ∘ R .η .η U)
@@ -126,7 +126,7 @@ module _ {S R T : Monad C} where
       ≈⟨ τ .unit-comp ⟩
       S .η .η U
       ∎
-  Monad⇒-id-∘ τ σ .mult-comp {U} = begin
+  Monad⇒-id-∘ σ τ .mult-comp {U} = begin
       (τ .α .η U ∘ σ .α .η U) ∘ R.μ.η U
       ≈⟨ C.assoc ⟩
       τ .α .η U ∘ (σ .α .η U ∘ R.μ.η U)

--- a/src/Categories/Monad/Morphism.agda
+++ b/src/Categories/Monad/Morphism.agda
@@ -87,17 +87,15 @@ module _ {T : Monad C} where
   open Monad⇒-id
   open Category C
   open HomReasoning
+  open MR C
   Monad⇒-id-id : (Monad⇒-id T T)
   Monad⇒-id-id .α = idN
   Monad⇒-id-id .unit-comp {_} = identityˡ
   Monad⇒-id-id .mult-comp {U} = begin
       id ∘ T.μ.η U
-      ≈⟨ identityˡ
-       ○ ⟺ identityʳ
-       ○ refl⟩∘⟨ ⟺ identityʳ
-       ⟩
-      T.μ.η U ∘ id ∘ id
-      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ T.F.identity ⟩
+      ≈⟨ id-comm-sym ⟩
+      T.μ.η U ∘ id
+      ≈⟨ refl⟩∘⟨ introʳ T.F.identity ⟩
       T.μ.η U ∘ id ∘ T.F.₁ id
       ∎
 
@@ -117,29 +115,24 @@ module _ {S R T : Monad C} where
   Monad⇒-id-∘ σ τ .α = τ .α ∘ᵥ σ .α
   Monad⇒-id-∘ σ τ .unit-comp {U} = begin
       (τ .α .η U ∘  σ .α .η U) ∘ R .η .η U
-      ≈⟨ C.assoc ⟩
-      τ .α .η U ∘  (σ .α .η U ∘ R .η .η U)
-      ≈⟨ refl⟩∘⟨ σ .unit-comp ⟩
+      ≈⟨ pullʳ (σ .unit-comp) ⟩
       τ .α .η U ∘ T .η .η U
       ≈⟨ τ .unit-comp ⟩
       S .η .η U
       ∎
   Monad⇒-id-∘ σ τ .mult-comp {U} = begin
       (τ .α .η U ∘ σ .α .η U) ∘ R.μ.η U
-      ≈⟨ C.assoc ⟩
-      τ .α .η U ∘ (σ .α .η U ∘ R.μ.η U)
-      ≈⟨ refl⟩∘⟨ σ .mult-comp ⟩
+      ≈⟨ pullʳ (σ .mult-comp) ⟩
       τ .α .η U ∘ (T.μ.η U ∘ σ .α .η (T.F.₀ U) ∘ R.F.₁ (σ .α .η U))
-      ≈⟨ C.sym-assoc ⟩
-      (τ .α .η U ∘ T.μ.η U) ∘ σ .α .η (T.F.₀ U) ∘ R.F.₁ (σ .α .η U)
-      ≈⟨ τ .mult-comp ⟩∘⟨refl ⟩
+      ≈⟨ pullˡ (τ .mult-comp) ⟩
       (S.μ.η U ∘ τ .α.η (S.F.₀ U) ∘ T.F.₁ (τ .α.η U)) ∘ σ .α.η (T.F.₀ U) ∘ R.F.₁ (σ .α.η U)
+      -- (a ∘ (b ∘ c)) ∘ d ≈ (a ∘ b) ∘ (c ∘ d)
       ≈⟨ pushˡ C.sym-assoc  ⟩
       (S.μ.η U ∘ τ .α.η (S.F.₀ U)) ∘ T.F.₁ (τ .α.η U) ∘ σ .α.η (T.F.₀ U) ∘ R.F.₁ (σ .α.η U)
-      ≈⟨ refl⟩∘⟨ (pullˡ (σ .α .sym-commute (τ .α.η U)) ○ C.assoc ) ⟩
+      ≈⟨ refl⟩∘⟨ extendʳ (σ .α .sym-commute (τ .α.η U)) ⟩
       (S.μ.η U ∘ τ .α.η (S.F.₀ U)) ∘ σ .α.η (S.F.₀ U) ∘ R.F.₁ (τ .α.η U) ∘ R.F.₁ (σ .α.η U)
-      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ R.F.homomorphism ⟩
+      ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ R.F.homomorphism ⟩
       (S.μ.η U ∘ τ .α.η (S.F.₀ U)) ∘ σ .α.η (S.F.₀ U) ∘ R.F.₁ (τ .α.η U ∘ σ .α.η U)
-      ≈⟨ pullˡ C.assoc ○ C.assoc ⟩
+      ≈˘⟨ assoc²'' ⟩
       S.μ.η U ∘ (τ .α.η (S.F.₀ U) ∘ σ .α.η (S.F.₀ U)) ∘ R.F.₁ (τ .α.η U ∘ σ .α.η U)
       ∎

--- a/src/Categories/Monad/Morphism.agda
+++ b/src/Categories/Monad/Morphism.agda
@@ -92,12 +92,9 @@ module _ {T : Monad C} where
   Monad⇒-id-id .α = idN
   Monad⇒-id-id .unit-comp {_} = identityˡ
   Monad⇒-id-id .mult-comp {U} = begin
-      id ∘ T.μ.η U
-      ≈⟨ id-comm-sym ⟩
-      T.μ.η U ∘ id
-      ≈⟨ refl⟩∘⟨ introʳ T.F.identity ⟩
-      T.μ.η U ∘ id ∘ T.F.₁ id
-      ∎
+      id ∘ T.μ.η U            ≈⟨ id-comm-sym ⟩
+      T.μ.η U ∘ id            ≈⟨ refl⟩∘⟨ introʳ T.F.identity ⟩
+      T.μ.η U ∘ id ∘ T.F.₁ id ∎
 
 module _ {S R T : Monad C} where
   private
@@ -114,25 +111,22 @@ module _ {S R T : Monad C} where
   Monad⇒-id-∘ : (Monad⇒-id T R) → (Monad⇒-id S T) → (Monad⇒-id S R)
   Monad⇒-id-∘ σ τ .α = τ .α ∘ᵥ σ .α
   Monad⇒-id-∘ σ τ .unit-comp {U} = begin
-      (τ .α .η U ∘  σ .α .η U) ∘ R .η .η U
-      ≈⟨ pullʳ (σ .unit-comp) ⟩
-      τ .α .η U ∘ T .η .η U
-      ≈⟨ τ .unit-comp ⟩
-      S .η .η U
-      ∎
+      (τ .α .η U ∘  σ .α .η U) ∘ R .η .η U ≈⟨ pullʳ (σ .unit-comp) ⟩
+      τ .α .η U ∘ T .η .η U                ≈⟨ τ .unit-comp ⟩
+      S .η .η U                            ∎
   Monad⇒-id-∘ σ τ .mult-comp {U} = begin
       (τ .α .η U ∘ σ .α .η U) ∘ R.μ.η U
-      ≈⟨ pullʳ (σ .mult-comp) ⟩
+        ≈⟨ pullʳ (σ .mult-comp) ⟩
       τ .α .η U ∘ (T.μ.η U ∘ σ .α .η (T.F.₀ U) ∘ R.F.₁ (σ .α .η U))
-      ≈⟨ pullˡ (τ .mult-comp) ⟩
+        ≈⟨ pullˡ (τ .mult-comp) ⟩
       (S.μ.η U ∘ τ .α.η (S.F.₀ U) ∘ T.F.₁ (τ .α.η U)) ∘ σ .α.η (T.F.₀ U) ∘ R.F.₁ (σ .α.η U)
-      -- (a ∘ (b ∘ c)) ∘ d ≈ (a ∘ b) ∘ (c ∘ d)
-      ≈⟨ pushˡ C.sym-assoc  ⟩
+        -- (a ∘ (b ∘ c)) ∘ d ≈ (a ∘ b) ∘ (c ∘ d)
+        ≈⟨ pushˡ C.sym-assoc  ⟩
       (S.μ.η U ∘ τ .α.η (S.F.₀ U)) ∘ T.F.₁ (τ .α.η U) ∘ σ .α.η (T.F.₀ U) ∘ R.F.₁ (σ .α.η U)
-      ≈⟨ refl⟩∘⟨ extendʳ (σ .α .sym-commute (τ .α.η U)) ⟩
+        ≈⟨ refl⟩∘⟨ extendʳ (σ .α .sym-commute (τ .α.η U)) ⟩
       (S.μ.η U ∘ τ .α.η (S.F.₀ U)) ∘ σ .α.η (S.F.₀ U) ∘ R.F.₁ (τ .α.η U) ∘ R.F.₁ (σ .α.η U)
-      ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ R.F.homomorphism ⟩
+        ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ R.F.homomorphism ⟩
       (S.μ.η U ∘ τ .α.η (S.F.₀ U)) ∘ σ .α.η (S.F.₀ U) ∘ R.F.₁ (τ .α.η U ∘ σ .α.η U)
-      ≈˘⟨ assoc²'' ⟩
+        ≈˘⟨ assoc²'' ⟩
       S.μ.η U ∘ (τ .α.η (S.F.₀ U) ∘ σ .α.η (S.F.₀ U)) ∘ R.F.₁ (τ .α.η U ∘ σ .α.η U)
-      ∎
+        ∎

--- a/src/Categories/Monad/Morphism.agda
+++ b/src/Categories/Monad/Morphism.agda
@@ -3,7 +3,7 @@
 open import Level
 open import Categories.Category
 open import Categories.Functor renaming (id to idF)
-open import Categories.Monad
+open import Categories.Monad renaming (id to idM)
 import Categories.Morphism.Reasoning as MR
 open import Categories.NaturalTransformation renaming (id to idN)
 open NaturalTransformation

--- a/src/Categories/Monad/Strong.agda
+++ b/src/Categories/Monad/Strong.agda
@@ -16,7 +16,7 @@ open import Categories.Functor renaming (id to idF)
 open import Categories.Category.Monoidal
 open import Categories.Category.Product
 open import Categories.NaturalTransformation hiding (id)
-open import Categories.Monad
+open import Categories.Monad hiding (id)
 
 private
   variable


### PR DESCRIPTION
This commit adds a few constructions for monads and comonads. In particular, it adds the identity monad and comonad for a category. It also adds the identity and composite morphism between monads on the same category.