### PR TITLE
End calculus

### DIFF
--- a/src/Categories/Category/Construction/Functors.agda
+++ b/src/Categories/Category/Construction/Functors.agda
@@ -188,6 +188,12 @@ uncurry {C₁ = C₁} {C₂ = C₂} {D = D} = record
           } where module t = NaturalTransformation t
                   open NaturalTransformation
 
+module uncurry {o₁ e₁ ℓ₁} {C₁ : Category o₁ e₁ ℓ₁}
+               {o₂ e₂ ℓ₂} {C₂ : Category o₂ e₂ ℓ₂}
+               {o′ e′ ℓ′} {D  : Category o′ e′ ℓ′}
+               where
+  open Functor (uncurry {C₁ = C₁} {C₂ = C₂} {D = D}) public
+
 module _ {o₁ e₁ ℓ₁} {C₁ : Category o₁ e₁ ℓ₁}
          {o₂ e₂ ℓ₂} {C₂ : Category o₂ e₂ ℓ₂}
          {o′ e′ ℓ′} {D  : Category o′ e′ ℓ′} where

--- a/src/Categories/Category/Construction/Functors.agda
+++ b/src/Categories/Category/Construction/Functors.agda
@@ -130,6 +130,8 @@ module curry {o₁ e₁ ℓ₁} {C₁ : Category o₁ e₁ ℓ₁}
   open Category
   open NaturalIsomorphism
 
+  module ₀ (F : Bifunctor C₁ C₂ D) = Functor (Functor.F₀ curry F)
+
   -- Currying preserves natural isos.
   -- This makes |curry.F₀| a map between the hom-setoids of Cats.
 

--- a/src/Categories/Category/Construction/TwistedArrow.agda
+++ b/src/Categories/Category/Construction/TwistedArrow.agda
@@ -1,27 +1,24 @@
 {-# OPTIONS --without-K --safe #-}
-open import Data.Product using (_,_; _×_; map; zip)
-open import Function.Base using (_$_; flip)
-open import Level
-open import Relation.Binary.Core using (Rel)
 
 open import Categories.Category using (Category; module Definitions)
-open import Categories.Category.Product renaming (Product to _×ᶜ_)
-open import Categories.Functor
-
-import Categories.Morphism as M
-import Categories.Morphism.Reasoning as MR
 
 -- Definition of the "Twisted Arrow" Category of a Category 𝒞
 module Categories.Category.Construction.TwistedArrow {o ℓ e} (𝒞 : Category o ℓ e) where
 
+open import Level
+open import Data.Product using (_,_; _×_; map; zip)
+open import Function.Base using (_$_; flip)
+open import Relation.Binary.Core using (Rel)
+
+open import Categories.Category.Product renaming (Product to _×ᶜ_)
+open import Categories.Functor using (Functor)
+open import Categories.Morphism.Reasoning 𝒞 using (pullˡ; pullʳ )
+
 private
   open module 𝒞 = Category 𝒞
-
-
-open M 𝒞
 open Definitions 𝒞
-open MR 𝒞
 open HomReasoning
+
 
 private
   variable
@@ -78,14 +75,12 @@ TwistedArrow = record
 
 -- Consider TwistedArrow as the comma category * / Hom[C][-,-]
 -- We have the codomain functor TwistedArrow → C.op × C
-
-module _ where
-  open Morphism
-  open Morphism⇒
-  open Functor
-  Forget : Functor TwistedArrow (𝒞.op ×ᶜ 𝒞)
-  Forget .F₀ x = dom x , cod x
-  Forget .F₁ f = dom⇐ f , cod⇒ f
-  Forget .identity = Equiv.refl , Equiv.refl
-  Forget .homomorphism = Equiv.refl , Equiv.refl
-  Forget .F-resp-≈ e = e
+open Functor
+Codomain : Functor TwistedArrow (𝒞.op ×ᶜ 𝒞)
+Codomain .F₀ x = dom , cod
+  where open Morphism x
+Codomain .F₁ f = dom⇐ , cod⇒
+  where open Morphism⇒ f
+Codomain .identity = Equiv.refl , Equiv.refl
+Codomain .homomorphism = Equiv.refl , Equiv.refl
+Codomain .F-resp-≈ e = e

--- a/src/Categories/Category/Construction/TwistedArrow.agda
+++ b/src/Categories/Category/Construction/TwistedArrow.agda
@@ -1,20 +1,26 @@
 {-# OPTIONS --without-K --safe #-}
+open import Data.Product using (_,_; _×_; map; zip)
+open import Function.Base using (_$_; flip)
+open import Level
+open import Relation.Binary.Core using (Rel)
+
 open import Categories.Category using (Category; module Definitions)
+open import Categories.Category.Product renaming (Product to _×ᶜ_)
+open import Categories.Functor
+
+import Categories.Morphism as M
+import Categories.Morphism.Reasoning as MR
 
 -- Definition of the "Twisted Arrow" Category of a Category 𝒞
 module Categories.Category.Construction.TwistedArrow {o ℓ e} (𝒞 : Category o ℓ e) where
 
-open import Level
-open import Data.Product using (_,_; _×_; map; zip)
-open import Function.Base using (_$_; flip)
-open import Relation.Binary.Core using (Rel)
+private
+  open module 𝒞 = Category 𝒞
 
-import Categories.Morphism as M
+
 open M 𝒞
-open import Categories.Morphism.Reasoning 𝒞
-
-open Category 𝒞
 open Definitions 𝒞
+open MR 𝒞
 open HomReasoning
 
 private
@@ -68,3 +74,18 @@ TwistedArrow = record
     cod⇒ m₁ ∘ (cod⇒ m₂ ∘ Morphism.arr A) ∘ (dom⇐ m₂ ∘ dom⇐ m₁) ≈⟨ refl⟩∘⟨ (pullˡ assoc) ⟩
     cod⇒ m₁ ∘ (cod⇒ m₂ ∘ Morphism.arr A ∘ dom⇐ m₂) ∘ dom⇐ m₁   ≈⟨ (refl⟩∘⟨ square m₂ ⟩∘⟨refl) ⟩
     cod⇒ m₁ ∘ Morphism.arr B ∘ dom⇐ m₁ ∎
+
+
+-- Consider TwistedArrow as the comma category * / Hom[C][-,-]
+-- We have the codomain functor TwistedArrow → C.op × C
+
+module _ where
+  open Morphism
+  open Morphism⇒
+  open Functor
+  Forget : Functor TwistedArrow (𝒞.op ×ᶜ 𝒞)
+  Forget .F₀ x = dom x , cod x
+  Forget .F₁ f = dom⇐ f , cod⇒ f
+  Forget .identity = Equiv.refl , Equiv.refl
+  Forget .homomorphism = Equiv.refl , Equiv.refl
+  Forget .F-resp-≈ e = e

--- a/src/Categories/Diagram/End/Fubini.agda
+++ b/src/Categories/Diagram/End/Fubini.agda
@@ -6,7 +6,7 @@ open import Level
 open import Data.Product using (Σ; _,_; _×_) renaming (proj₁ to fst; proj₂ to snd)
 open import Function using (_$_)
 
-open import Categories.Category using (Category)
+open import Categories.Category using (Category; _[_,_]; _[_∘_])
 open import Categories.Category.Construction.Functors using (Functors; curry)
 open import Categories.Category.Product using (πˡ; πʳ; _⁂_; _※_; Swap) renaming (Product to _×ᶜ_)
 open import Categories.Diagram.End using () renaming (End to ∫)
@@ -49,6 +49,8 @@ module _  (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D)
     module C = Category C
     module P = Category P
     module D = Category D
+    C×P = (C ×ᶜ P)
+    module C×P = Category C×P
     open module F = Functor F using (F₀; F₁; F-resp-≈)
     ∫F = (⨏ (F ′) {ω})
     module ∫F = Functor ∫F
@@ -57,7 +59,7 @@ module _  (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D)
 
   open _≅_
   open Iso
-  open DinaturalTransformation using (α)
+  open DinaturalTransformation
   open NaturalTransformation using (η)
   open Wedge renaming (E to apex)
   open Category D
@@ -71,47 +73,58 @@ module _  (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D)
     -- first, our wedge gives us a wedge in the product
     ξ : Wedge F
     ξ .apex = x
-    ξ .dinatural = dtHelper record
-      { α = λ { (c , p) → ω.dinatural.α (p , p) c ∘ ρ.dinatural.α p }
-      ; commute = λ { {c , p} {d , q} (f , s) → begin
-          F₁ ((C.id , P.id) , (f , s)) ∘ (ω.dinatural.α (p , p) c ∘ ρ.dinatural.α p) ∘ id
+    ξ .dinatural .α (c , p) = ω.dinatural.α (p , p) c ∘ ρ.dinatural.α p
+    -- unfolded because dtHelper means opening up a record (i.e. no where clause)
+    ξ .dinatural .op-commute (f , s) = assoc ○ ⟺ (ξ .dinatural .commute (f , s)) ○ sym-assoc
+    ξ .dinatural .commute {c , p} {d , q} (f , s) = begin
+          F₁ (C×P.id , (f , s)) ∘ (ωp,p c ∘ ρp) ∘ id
             ≈⟨ refl⟩∘⟨ identityʳ ⟩
           -- First we show dinaturality in C, which is 'trivial'
-          F₁ ((C.id , P.id) , (f , s)) ∘ (ω.dinatural.α (p , p) c ∘ ρ.dinatural.α p)
-            ≈⟨ (F-resp-≈ ((C.Equiv.sym C.identity² , P.Equiv.sym P.identity²) , (C.Equiv.sym C.identityˡ , P.Equiv.sym P.identityʳ)) ○ F.homomorphism) ⟩∘⟨refl ○ pullˡ assoc ⟩
-          (F₁ ((C.id , P.id) , (C.id , s)) ∘ F₁ ((C.id , P.id) , (f , P.id)) ∘ ω.dinatural.α (p , p) c) ∘ ρ.dinatural.α p
+          F₁ (C×P.id , (f , s)) ∘ (ωp,p c ∘ ρp)
+            ≈⟨ F-resp-≈ ((C.Equiv.sym C.identity² , P.Equiv.sym P.identity²) , (C.Equiv.sym C.identityˡ , P.Equiv.sym P.identityʳ)) ⟩∘⟨refl ⟩
+          F₁ (C×P [ C×P.id ∘ C×P.id ] , C [ C.id ∘ f ] , P [ s ∘ P.id ]) ∘ (ωp,p c ∘ ρ.dinatural.α p)
+            ≈⟨ F.homomorphism ⟩∘⟨refl ⟩
+          (F₁ (C×P.id , (C.id , s)) ∘ F₁ (C×P.id , (f , P.id))) ∘ (ωp,p c ∘ ρp)
+            ≈⟨ assoc²γβ ⟩
+          (F₁ (C×P.id , (C.id , s)) ∘ F₁ (C×P.id , (f , P.id)) ∘ ωp,p c) ∘ ρp
             ≈⟨ (refl⟩∘⟨ refl⟩∘⟨ ⟺ identityʳ) ⟩∘⟨refl ⟩
-          (F₁ ((C.id , P.id) , (C.id , s)) ∘ F₁ ((C.id , P.id) , (f , P.id)) ∘ ω.dinatural.α (p , p) c ∘ id) ∘ ρ.dinatural.α p
+          (F₁ (C×P.id , (C.id , s)) ∘ F₁ (C×P.id , (f , P.id)) ∘ ωp,p c ∘ id) ∘ ρp
             ≈⟨ (refl⟩∘⟨ ω.dinatural.commute (p , p) f) ⟩∘⟨refl ⟩
-          (F₁ ((C.id , P.id) , (C.id , s)) ∘ F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , p) d ∘ id) ∘ ρ.dinatural.α p
+          (F₁ (C×P.id , (C.id , s)) ∘ F₁ ((f , P.id) , C×P.id) ∘ ωp,p d ∘ id) ∘ ρp
             ≈⟨ extendʳ (⟺ F.homomorphism ○ F-resp-≈ ((MR.id-comm C , P.Equiv.refl) , (C.Equiv.refl , MR.id-comm P)) ○ F.homomorphism) ⟩∘⟨refl ⟩
           -- now, we must show dinaturality in P
-          -- First, some reassosiations to make things easier
-          (F₁ ((f , P.id) , (C.id , P.id)) ∘ F₁ ((C.id , P.id) , (C.id , s)) ∘ ω.dinatural.α (p , p) d ∘ id) ∘ ρ.dinatural.α p
-            ≈⟨ assoc ○ refl⟩∘⟨ assoc ○ refl⟩∘⟨ refl⟩∘⟨ identityʳ ⟩∘⟨refl ⟩
-          F₁ ((f , P.id) , (C.id , P.id)) ∘ (F₁ ((C.id , P.id) , (C.id , s)) ∘ ω.dinatural.α (p , p) d ∘ ρ.dinatural.α p)
+          -- First, we get rid of the identity and reassoc
+          (F₁ ((f , P.id) , C×P.id) ∘ F₁ (C×P.id , (C.id , s)) ∘ ωp,p d ∘ id) ∘ ρp
+            ≈⟨ assoc²βε ⟩
+          F₁ ((f , P.id) , C×P.id) ∘ F₁ (C×P.id , (C.id , s)) ∘ (ωp,p d ∘ id)  ∘ ρp
+            ≈⟨ refl⟩∘⟨ refl⟩∘⟨ identityʳ ⟩∘⟨refl ⟩
+          F₁ ((f , P.id) , C×P.id) ∘ F₁ (C×P.id , (C.id , s)) ∘ ωp,p d ∘ ρp
           -- this is the hard part: we use commutativity from the bottom face of the cube.
           -- The fact that this exists (an arrow between ∫ F (p,p,- ,-) to ∫ F (p,q,- ,-)) is due to functorality of ∫ and curry₀.
           -- The square commutes by universiality of ω
             ≈⟨ refl⟩∘⟨ extendʳ (⟺ (end-η-commute ⦃ ω (p , p) ⦄ ⦃ ω (p , q) ⦄ (curry.₀.₁ (F ′) (P.id , s)) d)) ⟩
           -- now we can use dinaturality in ρ, which annoyingly has an `id` tacked on the end
-          F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , q) d ∘ ∫F.F₁ (P.id , s) ∘ ρ.dinatural.α p
+          F₁ ((f , P.id) , C×P.id) ∘ ωp,q d ∘ ∫F.F₁ (P.id , s) ∘ ρp
             ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨  ⟺ identityʳ ⟩
-          F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , q) d ∘ ∫F.F₁ (P.id , s) ∘ ρ.dinatural.α p ∘ id
+          F₁ ((f , P.id) , C×P.id) ∘ ωp,q d ∘ ∫F.F₁ (P.id , s) ∘ ρp ∘ id
             ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ρ.dinatural.commute s ⟩
-          F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , q) d ∘ ∫F.F₁ (s , P.id) ∘ ρ.dinatural.α q ∘ id
+          F₁ ((f , P.id) , C×P.id) ∘ ωp,q d ∘ ∫F.F₁ (s , P.id) ∘ ρq ∘ id
             ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ identityʳ ⟩
-          F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , q) d ∘ ∫F.F₁ (s , P.id) ∘ ρ.dinatural.α q
+          F₁ ((f , P.id) , C×P.id) ∘ ωp,q d ∘ ∫F.F₁ (s , P.id) ∘ ρq
           -- and now we're done. step backward through the previous isomorphisms to get dinaturality in f and s together
             ≈⟨ refl⟩∘⟨ extendʳ (end-η-commute ⦃ ω (q , q) ⦄ ⦃ ω (p , q) ⦄ (curry.₀.₁ (F ′) (s , P.id)) d) ⟩
-          F₁ ((f , P.id) , (C.id , P.id)) ∘ (F₁ ((C.id , s) , (C.id , P.id)) ∘ ω.dinatural.α (q , q) d ∘ ρ.dinatural.α q)
+          F₁ ((f , P.id) , C×P.id) ∘ (F₁ ((C.id , s) , C×P.id) ∘ ωq,q d ∘ ρq)
             ≈⟨ pullˡ (⟺ F.homomorphism ○ F-resp-≈ ((C.identityˡ , P.identityʳ) , (C.identity² , P.identity²))) ⟩
-          F₁ ((f , s) , (C.id , P.id)) ∘ ω.dinatural.α (q , q) d ∘ ρ.dinatural.α q
+          F₁ ((f , s) , C×P.id) ∘ ωq,q d ∘ ρq
             ≈˘⟨ refl⟩∘⟨ identityʳ ⟩
-          F₁ ((f , s) , (C.id , P.id)) ∘ (ω.dinatural.α (q , q) d ∘ ρ.dinatural.α q) ∘ id
+          F₁ ((f , s) , C×P.id) ∘ (ωq,q d ∘ ρq) ∘ id
           ∎
-        }
-      }
+      where ωp,p = ω.dinatural.α (p , p)
+            ωp,q = ω.dinatural.α (p , q)
+            ωq,q = ω.dinatural.α (q , q)
+            ρp = ρ.dinatural.α p
+            ρq = ρ.dinatural.α q
+
 
   -- now the opposite direction
   private module _ (ξ : Wedge F) where
@@ -119,37 +132,41 @@ module _  (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D)
       open module ξ = Wedge ξ using () renaming (E to x)
     ρ : Wedge ∫F
     ρ .apex = x
-    ρ .dinatural = dtHelper record
-      { α = λ p → ω.factor (p , p) record
+    ρ .dinatural .α p = ω.factor (p , p) record
         { E = x
         ; dinatural = dtHelper record
           { α = λ c → ξ.dinatural.α (c , p)
           ; commute = λ f → ξ.dinatural.commute (f , P.id)
           }
         }
-          -- end-η-commute ⦃ ω (?) ⦄ ⦃ ω (?) ⦄ (curry.₀.₁ (F ′) (?)) ?
-      ; commute = λ {p} {q} f → ω.unique′ (p , q) λ {c} → begin
-        ω.dinatural.α (p , q) c ∘ ∫F.₁ (P.id , f) ∘ ω.factor (p , p) _ ∘ id
+    ρ .dinatural .op-commute f = assoc ○ ⟺ (ρ .dinatural .commute f) ○ sym-assoc
+    ρ .dinatural .commute {p} {q} f = ω.unique′ (p , q) λ {c} → begin
+        ωp,q c ∘ ∫F.₁ (P.id , f) ∘ ρp ∘ id
           ≈⟨ refl⟩∘⟨ refl⟩∘⟨ identityʳ ⟩
-        ω.dinatural.α (p , q) c ∘ ∫F.₁ (P.id , f) ∘ ω.factor (p , p) _
+        ωp,q c ∘ ∫F.₁ (P.id , f) ∘ ρp
           ≈⟨ extendʳ $ end-η-commute ⦃ ω (p , p) ⦄ ⦃ ω (p , q) ⦄ (curry.₀.₁ (F ′) (P.id , f)) c ⟩
-        F₁ ((C.id , P.id) , (C.id , f)) ∘ ω.dinatural.α (p , p) c ∘ ∫.factor (ω (p , p)) _
+        F₁ (C×P.id , (C.id , f)) ∘ ωp,p c ∘ ρp
           ≈⟨ refl⟩∘⟨ ω.universal (p , p) ⟩
-        F₁ ((C.id , P.id) , (C.id , f)) ∘ ξ.dinatural.α (c , p)
+        F₁ (C×P.id , (C.id , f)) ∘ ξ.dinatural.α (c , p)
           ≈˘⟨ refl⟩∘⟨ identityʳ ⟩
-        F₁ ((C.id , P.id) , (C.id , f)) ∘ ξ.dinatural.α (c , p) ∘ id
+        F₁ (C×P.id , (C.id , f)) ∘ ξ.dinatural.α (c , p) ∘ id
           ≈⟨ ξ.dinatural.commute (C.id , f) ⟩
-        F₁ ((C.id , f) , (C.id , P.id)) ∘ ξ.dinatural.α (c , q) ∘ id
+        F₁ ((C.id , f) , C×P.id) ∘ ξ.dinatural.α (c , q) ∘ id
           ≈⟨ refl⟩∘⟨ identityʳ ⟩
-        F₁ ((C.id , f) , (C.id , P.id)) ∘ ξ.dinatural.α (c , q)
+        F₁ ((C.id , f) , C×P.id) ∘ ξ.dinatural.α (c , q)
           ≈˘⟨ refl⟩∘⟨ ω.universal (q , q) ⟩
-        F₁ ((C.id , f) , (C.id , P.id)) ∘ ω.dinatural.α (q , q) c ∘ ω.factor (q , q) _
+        F₁ ((C.id , f) , C×P.id) ∘ ωq,q c ∘ ρq
           ≈˘⟨ extendʳ $ end-η-commute ⦃ ω (q , q) ⦄ ⦃ ω (p , q) ⦄ (curry.₀.₁ (F ′) (f , P.id)) c ⟩
-        ω.dinatural.α (p , q) c ∘ ∫F.₁ (f , P.id) ∘ ω.factor (q , q) _
+        ωp,q c ∘ ∫F.₁ (f , P.id) ∘ ρq
           ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ identityʳ ⟩
-        ω.dinatural.α (p , q) c ∘ ∫F.₁ (f , P.id) ∘ ω.factor (q , q) _ ∘ id
+        ωp,q c ∘ ∫F.₁ (f , P.id) ∘ ρq ∘ id
           ∎
-      }
+      where ωp,p = ω.dinatural.α (p , p)
+            ωp,q = ω.dinatural.α (p , q)
+            ωq,q = ω.dinatural.α (q , q)
+            ρp = ρ  .dinatural.α p
+            ρq = ρ  .dinatural.α q
+
   -- This construction is actually stronger than Fubini. It states that the
   -- iterated end _is_ an end in the product category.
   -- Thus the product end need not exist.
@@ -160,9 +177,8 @@ module _  (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D)
     eₚ .∫.wedge = ξ eᵢ.wedge
     eₚ .∫.factor W = eᵢ.factor (ρ W)
     eₚ .∫.universal {W} {c , p} = begin
-      ξ eᵢ.wedge .dinatural.α (c , p) ∘ eᵢ.factor (ρ W)               ≈⟨ Equiv.refl ⟩
-      (ω.dinatural.α (p , p) c ∘ eᵢ.dinatural.α p)  ∘ eᵢ.factor (ρ W) ≈⟨ assoc ⟩
-      ω.dinatural.α (p , p) c ∘ (eᵢ.dinatural.α p  ∘ eᵢ.factor (ρ W)) ≈⟨ refl⟩∘⟨ eᵢ.universal {ρ W} {p} ⟩
+      ξ eᵢ.wedge .dinatural.α (c , p) ∘ eᵢ.factor (ρ W)               ≡⟨⟩
+      (ω.dinatural.α (p , p) c ∘ eᵢ.dinatural.α p)  ∘ eᵢ.factor (ρ W) ≈⟨ pullʳ (eᵢ.universal {ρ W} {p}) ⟩
       ω.dinatural.α (p , p) c ∘ (ρ W) .dinatural.α p                  ≈⟨ ω.universal (p , p) ⟩
       W .dinatural.α  (c , p)                                         ∎
     eₚ .∫.unique {W} {g} h = eᵢ.unique λ {A = p} → Equiv.sym $ ω.unique (p , p) (sym-assoc ○ h)

--- a/src/Categories/Diagram/End/Fubini.agda
+++ b/src/Categories/Diagram/End/Fubini.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --lossy-unification #-}
+{-# OPTIONS --without-K --lossy-unification --safe #-}
 
 open import Level
 open import Data.Product using (Σ; _,_; _×_) renaming (proj₁ to fst; proj₂ to snd)

--- a/src/Categories/Diagram/End/Fubini.agda
+++ b/src/Categories/Diagram/End/Fubini.agda
@@ -1,0 +1,206 @@
+{-# OPTIONS --without-K --lossy-unification #-}
+
+open import Level
+open import Data.Product using (Σ; _,_; _×_) renaming (proj₁ to fst; proj₂ to snd)
+open import Function using (_$_)
+
+open import Categories.Category
+open import Categories.Category.Construction.Functors
+open import Categories.Category.Product renaming (Product to _×ᶜ_)
+open import Categories.Diagram.End using () renaming (End to ∫)
+open import Categories.Diagram.End.Properties
+open import Categories.Diagram.End.Parameterized renaming (EndF to ⨏)
+open import Categories.Diagram.Wedge
+open import Categories.Functor renaming (id to idF)
+open import Categories.Functor.Bifunctor
+open import Categories.Functor.Bifunctor.Properties
+open import Categories.NaturalTransformation using (NaturalTransformation)
+open import Categories.NaturalTransformation.Dinatural
+
+import Categories.Morphism as M
+import Categories.Morphism.Reasoning as MR
+
+module Categories.Diagram.End.Fubini where
+variable
+  o ℓ e : Level
+  C P D : Category o ℓ e
+
+module Functor-Swaps  (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D) where
+  private
+    module C = Category C
+    module P = Category P
+
+  -- just shuffling arguments
+  -- An end of F ′ can be taken iterated, instead of in the product category
+  _′ : Bifunctor (P.op ×ᶜ P) (C.op ×ᶜ C) D
+  _′ = F ∘F ((πˡ ∘F πʳ ※ πˡ ∘F πˡ) ※ (πʳ ∘F πʳ ※ πʳ ∘F πˡ))
+
+  -- An end of F ′′ is the same as F, but the order in the product category is reversed
+  _′′ : Bifunctor (Category.op P ×ᶜ Category.op C) (P ×ᶜ C) D
+  _′′ = F ∘F (Swap ⁂ Swap)
+
+open Functor-Swaps
+
+module _  (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D)
+          {ω : ∀ ((p , q) : Category.Obj P × Category.Obj P) → ∫ (appˡ (F ′) (p , q))}
+           where
+  open M D
+  private
+    module C = Category C
+    module P = Category P
+    module D = Category D
+    open module F = Functor F using (F₀; F₁; F-resp-≈)
+    ∫F = (⨏ (F ′) {ω})
+    module ∫F = Functor ∫F
+
+    module ω ((p , q) : P.Obj × P.Obj) = ∫ (ω (p , q))
+
+  open _≅_
+  open Iso
+  open DinaturalTransformation using (α)
+  open NaturalTransformation using (η)
+  open Wedge renaming (E to apex)
+  open Category D
+  open import Categories.Morphism.Reasoning D
+  open HomReasoning
+  -- we show that wedges of (∫.E e₀) are in bijection with wedges of F
+  -- following MacLane §IX.8
+  private module _ (ρ : Wedge ∫F) where
+    private
+      open module ρ = Wedge ρ using () renaming (E to x)
+    -- first, our wedge gives us a wedge in the product
+    ξ : Wedge F
+    ξ .apex = x
+    ξ .dinatural = dtHelper record
+      { α = λ { (c , p) → ω.dinatural.α (p , p) c ∘ ρ.dinatural.α p }
+      ; commute = λ { {c , p} {d , q} (f , s) → begin
+          F₁ ((C.id , P.id) , (f , s)) ∘ (ω.dinatural.α (p , p) c ∘ ρ.dinatural.α p) ∘ id
+            ≈⟨ refl⟩∘⟨ identityʳ ⟩
+          -- First we show dinaturality in C, which is 'trivial'
+          F₁ ((C.id , P.id) , (f , s)) ∘ (ω.dinatural.α (p , p) c ∘ ρ.dinatural.α p)
+            ≈⟨ (F-resp-≈ ((C.Equiv.sym C.identity² , P.Equiv.sym P.identity²) , (C.Equiv.sym C.identityˡ , P.Equiv.sym P.identityʳ)) ○ F.homomorphism) ⟩∘⟨refl ○ pullˡ assoc ⟩
+          (F₁ ((C.id , P.id) , (C.id , s)) ∘ F₁ ((C.id , P.id) , (f , P.id)) ∘ ω.dinatural.α (p , p) c) ∘ ρ.dinatural.α p
+            ≈⟨ (refl⟩∘⟨ refl⟩∘⟨ ⟺ identityʳ) ⟩∘⟨refl ⟩
+          (F₁ ((C.id , P.id) , (C.id , s)) ∘ F₁ ((C.id , P.id) , (f , P.id)) ∘ ω.dinatural.α (p , p) c ∘ id) ∘ ρ.dinatural.α p
+            ≈⟨ (refl⟩∘⟨ ω.dinatural.commute (p , p) f ) ⟩∘⟨refl ⟩
+          (F₁ ((C.id , P.id) , (C.id , s)) ∘ F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , p) d ∘ id) ∘ ρ.dinatural.α p
+            ≈⟨ extendʳ (⟺ F.homomorphism ○ F-resp-≈ ((MR.id-comm C , P.Equiv.refl) , (C.Equiv.refl , MR.id-comm P)) ○ F.homomorphism) ⟩∘⟨refl ⟩
+          -- now, we must show dinaturality in P
+          -- First, some reassosiations to make things easier
+          (F₁ ((f , P.id) , (C.id , P.id)) ∘ F₁ ((C.id , P.id) , (C.id , s)) ∘ ω.dinatural.α (p , p) d ∘ id) ∘ ρ.dinatural.α p
+            ≈⟨ assoc ○ refl⟩∘⟨ assoc ○ refl⟩∘⟨ refl⟩∘⟨ identityʳ ⟩∘⟨refl ⟩
+          F₁ ((f , P.id) , (C.id , P.id)) ∘ (F₁ ((C.id , P.id) , (C.id , s)) ∘ ω.dinatural.α (p , p) d ∘ ρ.dinatural.α p)
+          -- this is the hard part: we use commutativity from the bottom face of the cube.
+          -- The fact that this exists (an arrow between ∫ F (p,p,- ,-) to ∫ F (p,q,- ,-)) is due to functorality of ∫ and curry₀.
+          -- The square commutes by universiality of ω
+            ≈⟨ refl⟩∘⟨ extendʳ (⟺ (end-η-commute ⦃ ω (p , p) ⦄ ⦃ ω (p , q) ⦄ (curry.₀.₁ (F ′) (P.id , s)) d )) ⟩
+          -- now we can use dinaturality in ρ, which annoyingly has an `id` tacked on the end
+          F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , q) d ∘ ∫F.F₁ (P.id , s) ∘ ρ.dinatural.α p
+            ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨  ⟺ identityʳ ⟩
+          F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , q) d ∘ ∫F.F₁ (P.id , s) ∘ ρ.dinatural.α p ∘ id
+            ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ρ.dinatural.commute s ⟩
+          F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , q) d ∘ ∫F.F₁ (s , P.id) ∘ ρ.dinatural.α q ∘ id
+            ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ identityʳ ⟩
+          F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , q) d ∘ ∫F.F₁ (s , P.id) ∘ ρ.dinatural.α q
+          -- and now we're done. step backward through the previous isomorphisms to get dinaturality in f and s together
+            ≈⟨ refl⟩∘⟨ extendʳ (end-η-commute ⦃ ω (q , q) ⦄ ⦃ ω (p , q) ⦄ (curry.₀.₁ (F ′) (s , P.id)) d) ⟩
+          F₁ ((f , P.id) , (C.id , P.id)) ∘ (F₁ ((C.id , s) , (C.id , P.id)) ∘ ω.dinatural.α (q , q) d ∘ ρ.dinatural.α q)
+            ≈⟨ pullˡ (⟺ F.homomorphism ○ F-resp-≈ ((C.identityˡ , P.identityʳ) , (C.identity² , P.identity²))) ⟩
+          F₁ ((f , s) , (C.id , P.id)) ∘ ω.dinatural.α (q , q) d ∘ ρ.dinatural.α q
+            ≈˘⟨ refl⟩∘⟨ identityʳ ⟩
+          F₁ ((f , s) , (C.id , P.id)) ∘ (ω.dinatural.α (q , q) d ∘ ρ.dinatural.α q) ∘ id
+          ∎
+        }
+      }
+
+  -- now the opposite direction
+  private module _ (ξ : Wedge F) where
+    private
+      open module ξ = Wedge ξ using () renaming (E to x)
+    ρ : Wedge ∫F
+    ρ .apex = x
+    ρ .dinatural = dtHelper record
+      { α = λ p → ω.factor (p , p) record
+        { E = x
+        ; dinatural = dtHelper record
+          { α = λ c → ξ.dinatural.α (c , p)
+          ; commute = λ f → ξ.dinatural.commute (f , P.id)
+          }
+        }
+          -- end-η-commute ⦃ ω (?) ⦄ ⦃ ω (?) ⦄ (curry.₀.₁ (F ′) (?)) ?
+      ; commute = λ {p} {q} f → ω.unique′ (p , q) λ {c} → begin
+        ω.dinatural.α (p , q) c ∘ ∫F.₁ (P.id , f) ∘ ω.factor (p , p) _ ∘ id
+          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ identityʳ ⟩
+        ω.dinatural.α (p , q) c ∘ ∫F.₁ (P.id , f) ∘ ω.factor (p , p) _
+          ≈⟨ extendʳ $ end-η-commute ⦃ ω (p , p) ⦄ ⦃ ω (p , q) ⦄ (curry.₀.₁ (F ′) (P.id , f)) c ⟩
+        F₁ ((C.id , P.id) , (C.id , f)) ∘ ω.dinatural.α (p , p) c ∘ ∫.factor (ω (p , p)) _
+          ≈⟨ refl⟩∘⟨ ω.universal (p , p) ⟩
+        F₁ ((C.id , P.id) , (C.id , f)) ∘ ξ.dinatural.α (c , p)
+          ≈˘⟨ refl⟩∘⟨ identityʳ ⟩
+        F₁ ((C.id , P.id) , (C.id , f)) ∘ ξ.dinatural.α (c , p) ∘ id
+          ≈⟨ ξ.dinatural.commute (C.id , f) ⟩
+        F₁ ((C.id , f) , (C.id , P.id)) ∘ ξ.dinatural.α (c , q) ∘ id
+          ≈⟨ refl⟩∘⟨ identityʳ ⟩
+        F₁ ((C.id , f) , (C.id , P.id)) ∘ ξ.dinatural.α (c , q)
+          ≈˘⟨ refl⟩∘⟨ ω.universal (q , q) ⟩
+        F₁ ((C.id , f) , (C.id , P.id)) ∘ ω.dinatural.α (q , q) c ∘ ω.factor (q , q) _
+          ≈˘⟨ extendʳ $ end-η-commute ⦃ ω (q , q) ⦄ ⦃ ω (p , q) ⦄ (curry.₀.₁ (F ′) (f , P.id)) c ⟩
+        ω.dinatural.α (p , q) c ∘ ∫F.₁ (f , P.id) ∘ ω.factor (q , q) _
+          ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ identityʳ ⟩
+        ω.dinatural.α (p , q) c ∘ ∫F.₁ (f , P.id) ∘ ω.factor (q , q) _ ∘ id
+          ∎
+      }
+  -- This construction is actually stronger than Fubini. It states that the
+  -- iterated end _is_ an end in the product category.
+  -- Thus the product end need not exist.
+  module _ {{eᵢ : ∫ (⨏ (F ′) {ω})}} where
+    private
+      module eᵢ = ∫ eᵢ
+    eₚ : ∫ F
+    eₚ .∫.wedge = ξ eᵢ.wedge
+    eₚ .∫.factor W = eᵢ.factor (ρ W)
+    eₚ .∫.universal {W} {c , p} = begin
+      ξ eᵢ.wedge .dinatural.α (c , p) ∘ eᵢ.factor (ρ W)               ≈⟨ Equiv.refl ⟩
+      (ω.dinatural.α (p , p) c ∘ eᵢ.dinatural.α p)  ∘ eᵢ.factor (ρ W) ≈⟨ assoc ⟩
+      ω.dinatural.α (p , p) c ∘ (eᵢ.dinatural.α p  ∘ eᵢ.factor (ρ W)) ≈⟨ refl⟩∘⟨ eᵢ.universal {ρ W} {p} ⟩
+      ω.dinatural.α (p , p) c ∘ (ρ W) .dinatural.α p                  ≈⟨ ω.universal (p , p) ⟩
+      W .dinatural.α  (c , p)                                         ∎
+    eₚ .∫.unique {W} {g} h = eᵢ.unique λ {A = p} → Equiv.sym $ ω.unique (p , p) (sym-assoc ○ h)
+    module eₚ = ∫ eₚ
+
+    -- corollary: if a product end exists, it is iso
+    Fubini : {eₚ' : ∫ F} → ∫.E eᵢ ≅ ∫.E eₚ'
+    Fubini {eₚ'} = end-unique eₚ eₚ'
+
+  -- TODO show that an end ∫ F yields an end of ∫ (⨏ (F ′) {ω})
+
+module _ (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D)
+         {ωᴾ : ∀ ((p , q) : Category.Obj P × Category.Obj P) → ∫ (appˡ (F ′) (p , q))}
+         {ωᶜ : ∀ ((c , d) : Category.Obj C × Category.Obj C) → ∫ (appˡ (F ′′ ′)(c , d))}
+         {{e₁ : ∫ (⨏ (F ′) {ωᴾ})}} {{e₂ : ∫ (⨏ (F ′′ ′) {ωᶜ})}} where
+  open M D
+  -- since `F` and `F′′` are functors from different categories we can't construct a
+  -- natural isomorphism between them. Instead it is best to show that eₚ F is an end in
+  -- ∫ (F ′′) or vice-versa, and then Fubini follows due to uniqueness of ends
+  open Wedge renaming (E to apex)
+  private
+    eₚ′′ : ∫ (F ′′)
+    eₚ′′  .∫.wedge .apex = eₚ.wedge.E F
+    eₚ′′  .∫.wedge .dinatural = dtHelper record
+      { α = λ (p , c) → eₚ.dinatural.α F (c , p)
+      ; commute = λ (s , f) → eₚ.dinatural.commute F (f , s)
+      }
+    eₚ′′  .∫.factor W = eₚ.factor F record
+      { W ; dinatural = dtHelper record
+        { α = λ (c , p) → W.dinatural.α (p , c)
+        ; commute = λ (f , s) → W.dinatural.commute (s , f)
+        }
+      }
+      where module W = Wedge W
+    eₚ′′  .∫.universal {W} {p , c} = eₚ.universal F
+    eₚ′′  .∫.unique {W} {g} h = eₚ.unique F h
+
+  Fubini′ : ∫.E e₁ ≅ ∫.E e₂
+  Fubini′ = ≅.trans (Fubini F {ωᴾ} {eₚ' = eₚ F} ) $
+            ≅.trans (end-unique eₚ′′ (eₚ (F ′′)))
+                    (≅.sym (Fubini (F ′′) {ωᶜ} {eₚ' = eₚ (F ′′)}))

--- a/src/Categories/Diagram/End/Fubini.agda
+++ b/src/Categories/Diagram/End/Fubini.agda
@@ -1,26 +1,26 @@
 {-# OPTIONS --without-K --lossy-unification --safe #-}
 
+module Categories.Diagram.End.Fubini where
+
 open import Level
 open import Data.Product using (Σ; _,_; _×_) renaming (proj₁ to fst; proj₂ to snd)
 open import Function using (_$_)
 
-open import Categories.Category
-open import Categories.Category.Construction.Functors
-open import Categories.Category.Product renaming (Product to _×ᶜ_)
+open import Categories.Category using (Category)
+open import Categories.Category.Construction.Functors using (Functors; curry)
+open import Categories.Category.Product using (πˡ; πʳ; _⁂_; _※_; Swap) renaming (Product to _×ᶜ_)
 open import Categories.Diagram.End using () renaming (End to ∫)
-open import Categories.Diagram.End.Properties
-open import Categories.Diagram.End.Parameterized renaming (EndF to ⨏)
-open import Categories.Diagram.Wedge
-open import Categories.Functor renaming (id to idF)
-open import Categories.Functor.Bifunctor
-open import Categories.Functor.Bifunctor.Properties
+open import Categories.Diagram.End.Properties using (end-η-commute; end-unique)
+open import Categories.Diagram.End.Parameterized using () renaming (EndF to ⨏)
+open import Categories.Diagram.Wedge using (Wedge)
+open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
+open import Categories.Functor.Bifunctor using (Bifunctor; appˡ)
 open import Categories.NaturalTransformation using (NaturalTransformation)
-open import Categories.NaturalTransformation.Dinatural
+open import Categories.NaturalTransformation.Dinatural using (DinaturalTransformation; dtHelper)
 
 import Categories.Morphism as M
 import Categories.Morphism.Reasoning as MR
 
-module Categories.Diagram.End.Fubini where
 variable
   o ℓ e : Level
   C P D : Category o ℓ e
@@ -82,7 +82,7 @@ module _  (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D)
           (F₁ ((C.id , P.id) , (C.id , s)) ∘ F₁ ((C.id , P.id) , (f , P.id)) ∘ ω.dinatural.α (p , p) c) ∘ ρ.dinatural.α p
             ≈⟨ (refl⟩∘⟨ refl⟩∘⟨ ⟺ identityʳ) ⟩∘⟨refl ⟩
           (F₁ ((C.id , P.id) , (C.id , s)) ∘ F₁ ((C.id , P.id) , (f , P.id)) ∘ ω.dinatural.α (p , p) c ∘ id) ∘ ρ.dinatural.α p
-            ≈⟨ (refl⟩∘⟨ ω.dinatural.commute (p , p) f ) ⟩∘⟨refl ⟩
+            ≈⟨ (refl⟩∘⟨ ω.dinatural.commute (p , p) f) ⟩∘⟨refl ⟩
           (F₁ ((C.id , P.id) , (C.id , s)) ∘ F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , p) d ∘ id) ∘ ρ.dinatural.α p
             ≈⟨ extendʳ (⟺ F.homomorphism ○ F-resp-≈ ((MR.id-comm C , P.Equiv.refl) , (C.Equiv.refl , MR.id-comm P)) ○ F.homomorphism) ⟩∘⟨refl ⟩
           -- now, we must show dinaturality in P
@@ -93,7 +93,7 @@ module _  (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D)
           -- this is the hard part: we use commutativity from the bottom face of the cube.
           -- The fact that this exists (an arrow between ∫ F (p,p,- ,-) to ∫ F (p,q,- ,-)) is due to functorality of ∫ and curry₀.
           -- The square commutes by universiality of ω
-            ≈⟨ refl⟩∘⟨ extendʳ (⟺ (end-η-commute ⦃ ω (p , p) ⦄ ⦃ ω (p , q) ⦄ (curry.₀.₁ (F ′) (P.id , s)) d )) ⟩
+            ≈⟨ refl⟩∘⟨ extendʳ (⟺ (end-η-commute ⦃ ω (p , p) ⦄ ⦃ ω (p , q) ⦄ (curry.₀.₁ (F ′) (P.id , s)) d)) ⟩
           -- now we can use dinaturality in ρ, which annoyingly has an `id` tacked on the end
           F₁ ((f , P.id) , (C.id , P.id)) ∘ ω.dinatural.α (p , q) d ∘ ∫F.F₁ (P.id , s) ∘ ρ.dinatural.α p
             ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨  ⟺ identityʳ ⟩
@@ -201,6 +201,6 @@ module _ (F : Bifunctor (Category.op C ×ᶜ Category.op P) (C ×ᶜ P) D)
     eₚ′′  .∫.unique {W} {g} h = eₚ.unique F h
 
   Fubini′ : ∫.E e₁ ≅ ∫.E e₂
-  Fubini′ = ≅.trans (Fubini F {ωᴾ} {eₚ' = eₚ F} ) $
+  Fubini′ = ≅.trans (Fubini F {ωᴾ} {eₚ' = eₚ F}) $
             ≅.trans (end-unique eₚ′′ (eₚ (F ′′)))
                     (≅.sym (Fubini (F ′′) {ωᶜ} {eₚ' = eₚ (F ′′)}))

--- a/src/Categories/Diagram/End/Instances/NaturalTransformation.agda
+++ b/src/Categories/Diagram/End/Instances/NaturalTransformation.agda
@@ -1,0 +1,66 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Data.Product using (Σ; _,_)
+open import Function using (_$_)
+open import Level
+
+open import Categories.Category
+open import Categories.Category.Instance.Setoids
+open import Categories.Category.Product
+open import Categories.Diagram.End using () renaming (End to ∫)
+open import Categories.Functor renaming (id to idF)
+open import Categories.Functor.Hom
+open import Categories.NaturalTransformation renaming (id to idN)
+open import Categories.NaturalTransformation.Dinatural using (DinaturalTransformation; dtHelper)
+open import Categories.NaturalTransformation.Equivalence
+open import Function.Bundles using (Func)
+
+import Categories.Diagram.Wedge as Wedges
+import Categories.Morphism as M
+import Categories.Morphism.Reasoning as MR
+
+module Categories.Diagram.End.Instances.NaturalTransformation {ℓ e o′}
+  {C : Category ℓ ℓ e} {D : Category o′ ℓ ℓ} (F G : Functor C D) where
+
+private
+  module C = Category C
+  module D = Category D
+  open module F = Functor F using (F₀; F₁)
+  module G = Functor G
+
+open Wedges (Hom[ D ][-,-] ∘F (F.op ⁂ G))
+open D
+open HomReasoning
+open MR D
+open NaturalTransformation renaming (η to app)
+open ∫ hiding (dinatural)
+open Wedge
+open Func
+
+NTs-are-End : ∫ (Hom[ D ][-,-] ∘F (F.op ⁂ G))
+NTs-are-End .wedge .E = (≃-setoid F G)
+NTs-are-End .wedge .dinatural = dtHelper record
+  { α = λ C → record
+    { to = λ η → η .app C
+    ; cong = λ e → e
+    }
+  ; commute = λ {X} {Y} f {η} → begin
+    G.₁ f ∘ η .app X ∘ F₁ C.id  ≈⟨ pullˡ (η .sym-commute f) ⟩
+    (η .app Y ∘ F₁ f) ∘ F₁ C.id ≈⟨ refl⟩∘⟨ F.identity ⟩
+    (η .app Y ∘ F₁ f) ∘ id      ≈⟨ id-comm ⟩
+    id ∘ η .app Y ∘ F₁ f        ≈⟨ ⟺ G.identity ⟩∘⟨refl ⟩
+    G.₁ C.id ∘ η .app Y ∘ F₁ f  ∎
+  }
+NTs-are-End .factor W .to s = ntHelper record
+  { η = λ X → W.dinatural.α X .to s
+  -- basically the opposite proof of above
+  ; commute = λ {X} {Y} f → begin
+    W.dinatural.α Y .to s ∘ F₁ f            ≈⟨ introˡ G.identity ⟩
+    G.₁ C.id ∘ W.dinatural.α Y .to s ∘ F₁ f ≈˘⟨ W.dinatural.commute f ⟩
+    G.₁ f ∘ W.dinatural.α X .to s ∘ F₁ C.id ≈⟨ refl⟩∘⟨ elimʳ F.identity ⟩
+    G.F₁ f ∘ W.dinatural.α X .to s          ∎
+  }
+  where module W = Wedge W
+NTs-are-End .factor W .cong e {x} = W .dinatural.α x .cong e
+NTs-are-End .universal = Equiv.refl
+NTs-are-End .unique h = Equiv.sym h

--- a/src/Categories/Diagram/End/Parameterized.agda
+++ b/src/Categories/Diagram/End/Parameterized.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K #-}
+{-# OPTIONS --without-K --safe #-}
 module Categories.Diagram.End.Parameterized where
 
 open import Level

--- a/src/Categories/Diagram/End/Parameterized.agda
+++ b/src/Categories/Diagram/End/Parameterized.agda
@@ -153,18 +153,35 @@ module _ {C : Category o ℓ e}
     }
   --module appˡ-resp-∘ X = NaturalIsomorphism (appˡ-resp-∘ X)
 
-  Continuous-preserve-endf-motive : ∀ X → ∫ (appˡ (F ∘F J) X)
-  Continuous-preserve-endf-motive X = ≅-yields-end (appˡ-resp-∘ X) (contF-as-end (appˡ J X) F {cont} (ω X))
-
   open NaturalTransformation using (η)
-
-  private
-    ω' = Continuous-preserve-endf-motive
-    module ω' (X : P.Obj) = ∫ (ω' X)
-    --module EndF {A B} (J : Functor A B) {ω} = Functor (EndF J {ω})
-
   open MR E
-  Continuous-pres-EndF :  F ∘F (EndF J {ω}) ≃ⁱ EndF (F ∘F J) {ω'}
+
+  Fω : ∀ X → ∫ (appˡ (F ∘F J) X)
+  Fω X = ≅-yields-end (appˡ-resp-∘ X) (contF-as-end (appˡ J X) F {cont} (ω X))
+  module Fω (p : P.Obj) = ∫ (Fω p)
+
+  Fω≈Fω : ∀ {p : P.Obj} {c : C.Obj} → Fω.dinatural.α p c ≈ F.₁ (ω.dinatural.α p c)
+  Fω≈Fω {p} {A} = begin
+    Fω.dinatural.α p A
+      ≡⟨⟩
+    id ∘ F₁ (J₁ (P.id , C.id , C.id)) ∘
+    id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α p A)
+      ≈⟨ identityˡ ⟩
+    F₁ (J₁ (P.id , C.id , C.id)) ∘
+    id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α p A)
+      ≈⟨ F-resp-≈ J.identity ⟩∘⟨refl ⟩
+    F₁ (D.id) ∘ id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α p A)
+      ≈⟨ elimˡ F.identity ⟩
+    id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α p A)
+      ≈⟨ identityˡ ⟩
+    F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α p A)
+      ≈⟨ F-resp-≈ (D.∘-resp-≈ˡ J.identity) ⟩
+    F₁ (D.id D.∘ ω.dinatural.α p A)
+      ≈⟨ F-resp-≈ D.identityˡ ⟩
+    F₁ (ω.dinatural.α p A) 
+      ∎
+
+  Continuous-pres-EndF :  F ∘F (EndF J {ω}) ≃ⁱ EndF (F ∘F J) {Fω}
   Continuous-pres-EndF = niHelper record
     { η = λ X → E.id
     ; η⁻¹ = λ Y → E.id
@@ -172,9 +189,9 @@ module _ {C : Category o ℓ e}
       id ∘ Functor.F₁ (F ∘F EndF J {ω}) f ≈⟨ identityˡ ⟩
       Functor.F₁ (F ∘F EndF J {ω}) f      ≡⟨⟩
       F₁ (end-η (appˡJ.₁ f) ⦃ ω p ⦄ ⦃ ω q ⦄)
-        ≈⟨ ω'.unique′ q (λ {A} → begin
-          ω'.dinatural.α q A ∘ F₁ (end-η (appˡJ.₁ f) ⦃ ω p ⦄ ⦃ ω q ⦄)
-            ≈⟨ lemma ⟩∘⟨refl ⟩
+        ≈⟨ Fω.unique′ q (λ {A} → begin
+          Fω.dinatural.α q A ∘ F₁ (end-η (appˡJ.₁ f) ⦃ ω p ⦄ ⦃ ω q ⦄)
+            ≈⟨ Fω≈Fω ⟩∘⟨refl ⟩
           F₁ (ω.dinatural.α q A) ∘ F₁ (end-η (appˡJ.₁ f) ⦃ ω p ⦄ ⦃ ω q ⦄)
             ≈˘⟨ F.homomorphism ⟩
           F₁ (ω.dinatural.α q A D.∘ end-η (appˡJ.₁ f) ⦃ ω p ⦄ ⦃ ω q ⦄)
@@ -182,18 +199,18 @@ module _ {C : Category o ℓ e}
           F₁ ((appˡJ.₁ f) .η (A , A) D.∘ (ω.dinatural.α p A))
             ≈⟨ F.homomorphism ⟩
           F₁ ((appˡJ.₁ f) .η (A , A)) ∘ F₁ (ω.dinatural.α p A)
-            ≈˘⟨ refl⟩∘⟨ lemma ⟩
-          F₁ ((appˡJ.₁ f) .η (A , A)) ∘ (ω'.dinatural.α p A)
+            ≈˘⟨ refl⟩∘⟨ Fω≈Fω ⟩
+          F₁ ((appˡJ.₁ f) .η (A , A)) ∘ (Fω.dinatural.α p A)
             ≡⟨⟩
-          appˡFJ.₁ f .η (A , A) ∘ ω'.dinatural.α p A
-            ≈˘⟨ end-η-commute ⦃ ω' p ⦄ ⦃ ω' q ⦄ (appˡFJ.₁ f) A ⟩
-          ω'.dinatural.α q A ∘ end-η (appˡFJ.₁ f) ⦃ ω' p ⦄ ⦃ ω' q ⦄
+          appˡFJ.₁ f .η (A , A) ∘ Fω.dinatural.α p A
+            ≈˘⟨ end-η-commute ⦃ Fω p ⦄ ⦃ Fω q ⦄ (appˡFJ.₁ f) A ⟩
+          Fω.dinatural.α q A ∘ end-η (appˡFJ.₁ f) ⦃ Fω p ⦄ ⦃ Fω q ⦄
             ∎
         )⟩
-      end-η (appˡFJ.₁ f) ⦃ ω' p ⦄ ⦃ ω' q ⦄
+      end-η (appˡFJ.₁ f) ⦃ Fω p ⦄ ⦃ Fω q ⦄
         ≡⟨⟩
-      Functor.F₁ (EndF (F ∘F J) {ω'}) f   ≈˘⟨ identityʳ ⟩
-      Functor.F₁ (EndF (F ∘F J) {ω'}) f ∘ id
+      Functor.F₁ (EndF (F ∘F J) {Fω}) f   ≈˘⟨ identityʳ ⟩
+      Functor.F₁ (EndF (F ∘F J) {Fω}) f ∘ id
         ∎
     ; iso = λ Y → record
       { isoˡ = E.identity²
@@ -201,23 +218,3 @@ module _ {C : Category o ℓ e}
       }
     }
     where open E.HomReasoning
-          lemma : ∀ {q A} → ω'.dinatural.α q A ≈ F₁ (ω.dinatural.α q A)
-          lemma {q} {A} = begin
-            ω'.dinatural.α q A
-              ≡⟨⟩
-            id ∘ F₁ (J₁ (P.id , C.id , C.id)) ∘
-            id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α q A)
-              ≈⟨ identityˡ ⟩
-            F₁ (J₁ (P.id , C.id , C.id)) ∘
-            id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α q A)
-              ≈⟨ F-resp-≈ J.identity ⟩∘⟨refl ⟩
-            F₁ (D.id) ∘ id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α q A)
-              ≈⟨ elimˡ F.identity ⟩
-            id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α q A)
-              ≈⟨ identityˡ ⟩
-            F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α q A)
-              ≈⟨ F-resp-≈ (D.∘-resp-≈ˡ J.identity) ⟩
-            F₁ (D.id D.∘ ω.dinatural.α q A)
-              ≈⟨ F-resp-≈ D.identityˡ ⟩
-            F₁ (ω.dinatural.α q A) 
-              ∎

--- a/src/Categories/Diagram/End/Parameterized.agda
+++ b/src/Categories/Diagram/End/Parameterized.agda
@@ -1,0 +1,223 @@
+{-# OPTIONS --without-K #-}
+module Categories.Diagram.End.Parameterized where
+
+open import Level
+open import Function using (_$_)
+open import Data.Product using (Σ; _,_)
+
+open import Categories.Category
+open import Categories.Category.Construction.Functors
+open import Categories.Category.Product renaming (Product to _×ᶜ_)
+open import Categories.Diagram.End renaming (End to ∫)
+open import Categories.Diagram.End.Properties
+open import Categories.Diagram.Wedge
+open import Categories.Functor hiding (id)
+open import Categories.Functor.Bifunctor
+open import Categories.Functor.Bifunctor.Properties
+open import Categories.Functor.Limits
+open import Categories.NaturalTransformation renaming (_∘ʳ_ to _▹ⁿ_; id to idN)
+open import Categories.NaturalTransformation.Dinatural hiding (_≃_)
+open import Categories.NaturalTransformation.NaturalIsomorphism renaming (_≃_ to _≃ⁱ_)
+open import Categories.NaturalTransformation.Equivalence
+
+import Categories.Category.Construction.Wedges as Wedges
+import Categories.Morphism as M
+import Categories.Morphism.Reasoning as MR
+
+-- The following conventions are taken in this file: C is the 'source' category
+-- and D is the destination. If two source categories are needed, the other is
+-- called 'P' for "parameter", following MacLane. F, G and H are functors and ef,
+-- eg and eh are witnesses of their respective ends.
+
+private
+  variable
+    o ℓ e : Level
+    P C D E : Category o ℓ e
+
+-- we use MacLane's notation for paramaterized ends (CWM §IX.5)
+_♯ : Functor (P ×ᶜ (Category.op C ×ᶜ C)) D → Functor (Category.op C ×ᶜ C) (Functors P D)
+F ♯ = curry.₀ F.flip
+  where module F = Bifunctor F
+
+end-η♯ : {F G : Functor (P ×ᶜ (Category.op C ×ᶜ C)) D} (η : NaturalTransformation F G)
+         ⦃ ef : ∫ (F ♯) ⦄ ⦃ eg : ∫ (G ♯) ⦄ → NaturalTransformation (∫.E ef) (∫.E eg)
+end-η♯ η ⦃ ef ⦄ ⦃ eg ⦄ = end-η (curry.₁ (η ▹ⁿ Swap))
+
+module _ (F : Functor (P ×ᶜ ((Category.op C) ×ᶜ C)) D) {ω : ∀ X → ∫ (appˡ F X)} where
+  private
+    module F = Functor F
+
+    module C = Category C
+    module D = Category D
+    module P = Category P
+    module NT = NaturalTransformation
+    F′ = curry.₀ F
+    module ω (p : P.Obj) = ∫ (ω p)
+  open D
+  open HomReasoning
+
+  open MR D
+  open module F′ = Functor F′
+  open ∫ hiding (E)
+  open NT using (η)
+
+  EndF : Functor P D
+  EndF = record
+    { F₀           = λ X → ω.E X
+    ; F₁           = λ {X} {Y} f → end-η (curry.₀.₁ F f) ⦃ ω X ⦄ ⦃ ω Y ⦄
+    ; identity     = λ {A} → begin
+      end-η (curry.₀.₁ F P.id) ⦃ ω A ⦄ ⦃ ω A ⦄ ≈⟨ end-η-resp-≈ ⦃ ω A ⦄ ⦃ ω A ⦄ (curry.₀.identity F) ⟩
+      end-η idN ⦃ ω A ⦄ ⦃ ω A ⦄                ≈⟨ end-identity ⦃ ω A ⦄ ⟩
+      id                                       ∎
+    ; homomorphism = λ {A B C} {f g} → begin
+      end-η (curry.₀.₁ F (P [ g ∘ f ])) ⦃ ω A ⦄ ⦃ ω C ⦄ 
+        ≈⟨ end-η-resp-≈ ⦃ ω A ⦄ ⦃ ω C ⦄ (curry.₀.homomorphism F) ⟩
+      end-η (curry.₀.₁ F g ∘ᵥ curry.₀.₁ F f ) ⦃ ω A ⦄ ⦃ ω C ⦄
+        ≈⟨  end-η-resp-∘ (curry.₀.₁ F f) (curry.₀.₁ F g) ⦃ ω A ⦄ ⦃ ω B ⦄ ⦃ ω C ⦄ ⟩
+      end-η (curry.₀.₁ F g) ⦃ ω B ⦄ ⦃ ω C ⦄ ∘ end-η (curry.₀.₁ F f) ⦃ ω A ⦄ ⦃ ω B ⦄
+        ∎
+    ; F-resp-≈     = λ {A B f g} eq → end-η-resp-≈ ⦃ ω A ⦄ ⦃ ω B ⦄ (curry.₀.F-resp-≈ F eq)
+    }
+
+
+  -- The parameter theorem
+  EndF-is-End : ∫ (F ♯)
+  EndF-is-End .∫.wedge .Wedge.E = EndF
+  EndF-is-End .∫.wedge .Wedge.dinatural = dtHelper record
+    { α = λ c → ntHelper record
+      { η = λ p → ω.dinatural.α p c
+      ; commute = λ {p} {q} f → begin
+        ω.dinatural.α q c ∘ end-η (curry.₀.₁ F f) ⦃ ω p ⦄ ⦃ ω q ⦄
+        ≈⟨ end-η-commute ⦃ ω p ⦄ ⦃ ω q ⦄ (curry.₀.₁ F f) c ⟩
+        (curry.₀.₁ F f) .η (c , c) ∘ ω.dinatural.α p c
+        ∎
+      }
+    ; commute = λ f {p} → ω.dinatural.commute p f
+    }
+  EndF-is-End .∫.factor W = ntHelper record
+    { η = λ p → ω.factor p (W' p)
+    ; commute = λ {p} {q} f → ω.unique′ q $ λ {c} → begin
+      ω.dinatural.α q c ∘ ω.factor q (W' q) ∘ F'.₁ f
+      ≈⟨ pullˡ (ω.universal q) ⟩
+      W.dinatural.α c .η q ∘ F'.₁ f 
+      ≈⟨ W.dinatural.α c .NaturalTransformation.commute f  ⟩
+      (curry.₀.₁ F f) .η (c , c) ∘ W.dinatural.α c .η p
+      ≈˘⟨ refl⟩∘⟨ ω.universal p ⟩
+      (curry.₀.₁ F f) .η (c , c) ∘ ω.dinatural.α p c ∘ factor (ω p) (W' p)
+      ≈˘⟨ extendʳ  (end-η-commute ⦃ ω p ⦄ ⦃ ω q ⦄ (curry.₀.₁ F f) c) ⟩
+      ω.dinatural.α q c ∘ end-η (curry.₀.₁ F f) ⦃ ω p ⦄ ⦃ ω q ⦄ ∘ ω.factor p (W' p)
+      ∎
+    }
+    where module W = Wedge W
+          F' = W.E
+          module F' = Functor F'
+          W' : (p : P.Obj) → Wedge (appˡ F p)
+          W' p = record
+            { E = F'.₀ p
+            ; dinatural = dtHelper record
+              { α = λ c → W.dinatural.α c .η p
+              ; commute = λ f → W.dinatural.commute f
+              }
+            }
+          module W' p = Wedge (W' p)
+  EndF-is-End .∫.universal {W} {c} {p} = ω.universal p
+  EndF-is-End .∫.unique h {p} = ω.unique p h
+
+-- Continuous functors preserve EndF
+-- this takes way too much time to check for some reason
+module _ {C : Category o ℓ e}
+         (J : Functor (P ×ᶜ ((Category.op C) ×ᶜ C)) D)
+         (F : Functor D E) {ω : ∀ X → ∫ (appˡ J X)} {cont : Continuous (o ⊔ ℓ) (ℓ ⊔ e) e F} where
+  private
+    module D = Category D
+    module P = Category P
+    module C = Category C
+    module E = Category E
+    open module F = Functor F using (F₀; F₁; F-resp-≈)
+    open module J = Functor J using () renaming (F₀ to J₀; F₁ to J₁)
+    module ω (X : P.Obj) = ∫ (ω X)
+    module appˡJ  = curry.₀ J
+    module appˡFJ  = curry.₀ (F ∘F J)
+
+  open E
+  open HomReasoning
+  appˡ-resp-∘ : ∀ X → F ∘F appˡ J X ≃ⁱ appˡ (F ∘F J) X
+  appˡ-resp-∘ X = niHelper record
+    { η = λ Y → id
+    ; η⁻¹ = λ Y → id
+    ; commute = λ f → identityˡ ○ ⟺ identityʳ
+    ; iso = λ Y → record
+      { isoˡ = identity²
+      ; isoʳ = identity²
+      }
+    }
+  --module appˡ-resp-∘ X = NaturalIsomorphism (appˡ-resp-∘ X)
+
+  Continuous-preserve-endf-motive : ∀ X → ∫ (appˡ (F ∘F J) X)
+  Continuous-preserve-endf-motive X = ≅-yields-end (appˡ-resp-∘ X) (contF-as-end (appˡ J X) F {cont} (ω X))
+
+  open NaturalTransformation using (η)
+
+  private
+    ω' = Continuous-preserve-endf-motive
+    module ω' (X : P.Obj) = ∫ (ω' X)
+    --module EndF {A B} (J : Functor A B) {ω} = Functor (EndF J {ω})
+
+  open MR E
+  Continuous-pres-EndF :  F ∘F (EndF J {ω}) ≃ⁱ EndF (F ∘F J) {ω'}
+  Continuous-pres-EndF = niHelper record
+    { η = λ X → E.id
+    ; η⁻¹ = λ Y → E.id
+    ; commute = λ {p} {q} f → begin
+      id ∘ Functor.F₁ (F ∘F EndF J {ω}) f ≈⟨ identityˡ ⟩
+      Functor.F₁ (F ∘F EndF J {ω}) f      ≡⟨⟩
+      F₁ (end-η (appˡJ.₁ f) ⦃ ω p ⦄ ⦃ ω q ⦄)
+        ≈⟨ ω'.unique′ q (λ {A} → begin
+          ω'.dinatural.α q A ∘ F₁ (end-η (appˡJ.₁ f) ⦃ ω p ⦄ ⦃ ω q ⦄)
+            ≈⟨ lemma ⟩∘⟨refl ⟩
+          F₁ (ω.dinatural.α q A) ∘ F₁ (end-η (appˡJ.₁ f) ⦃ ω p ⦄ ⦃ ω q ⦄)
+            ≈˘⟨ F.homomorphism ⟩
+          F₁ (ω.dinatural.α q A D.∘ end-η (appˡJ.₁ f) ⦃ ω p ⦄ ⦃ ω q ⦄)
+            ≈⟨ F-resp-≈ (end-η-commute ⦃ ω p ⦄ ⦃ ω q ⦄ (appˡJ.₁ f) A ) ⟩
+          F₁ ((appˡJ.₁ f) .η (A , A) D.∘ (ω.dinatural.α p A))
+            ≈⟨ F.homomorphism ⟩
+          F₁ ((appˡJ.₁ f) .η (A , A)) ∘ F₁ (ω.dinatural.α p A)
+            ≈˘⟨ refl⟩∘⟨ lemma ⟩
+          F₁ ((appˡJ.₁ f) .η (A , A)) ∘ (ω'.dinatural.α p A)
+            ≡⟨⟩
+          appˡFJ.₁ f .η (A , A) ∘ ω'.dinatural.α p A
+            ≈˘⟨ end-η-commute ⦃ ω' p ⦄ ⦃ ω' q ⦄ (appˡFJ.₁ f) A ⟩
+          ω'.dinatural.α q A ∘ end-η (appˡFJ.₁ f) ⦃ ω' p ⦄ ⦃ ω' q ⦄
+            ∎
+        )⟩
+      end-η (appˡFJ.₁ f) ⦃ ω' p ⦄ ⦃ ω' q ⦄
+        ≡⟨⟩
+      Functor.F₁ (EndF (F ∘F J) {ω'}) f   ≈˘⟨ identityʳ ⟩
+      Functor.F₁ (EndF (F ∘F J) {ω'}) f ∘ id
+        ∎
+    ; iso = λ Y → record
+      { isoˡ = E.identity²
+      ; isoʳ = E.identity²
+      }
+    }
+    where open E.HomReasoning
+          lemma : ∀ {q A} → ω'.dinatural.α q A ≈ F₁ (ω.dinatural.α q A)
+          lemma {q} {A} = begin
+            ω'.dinatural.α q A
+              ≡⟨⟩
+            id ∘ F₁ (J₁ (P.id , C.id , C.id)) ∘
+            id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α q A)
+              ≈⟨ identityˡ ⟩
+            F₁ (J₁ (P.id , C.id , C.id)) ∘
+            id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α q A)
+              ≈⟨ F-resp-≈ J.identity ⟩∘⟨refl ⟩
+            F₁ (D.id) ∘ id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α q A)
+              ≈⟨ elimˡ F.identity ⟩
+            id ∘ F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α q A)
+              ≈⟨ identityˡ ⟩
+            F₁ (J₁ (P.id , C.id , C.id) D.∘ ω.dinatural.α q A)
+              ≈⟨ F-resp-≈ (D.∘-resp-≈ˡ J.identity) ⟩
+            F₁ (D.id D.∘ ω.dinatural.α q A)
+              ≈⟨ F-resp-≈ D.identityˡ ⟩
+            F₁ (ω.dinatural.α q A) 
+              ∎

--- a/src/Categories/Diagram/End/Properties.agda
+++ b/src/Categories/Diagram/End/Properties.agda
@@ -2,42 +2,39 @@
 
 module Categories.Diagram.End.Properties where
 
+-- The following conventions are taken in this file: C is the 'source' category
+-- and D is the destination. If two source categories are needed, the other is
+-- called 'P' for "parameter", following MacLane. F, G and H are functors and ef,
+-- eg and eh are witnesses of their respective ends.
+
 open import Level
 open import Data.Product using (Σ; _,_)
 open import Function using (_$_)
 
-open import Categories.Category
-open import Categories.Category.Construction.Functors
-open import Categories.Category.Construction.TwistedArrow
+open import Categories.Category using (Category)
+open import Categories.Category.Construction.Functors using (Functors)
+open import Categories.Category.Construction.TwistedArrow using (Codomain)
 open import Categories.Category.Equivalence as SE using (StrongEquivalence)
-open import Categories.Category.Equivalence.Preserves
-open import Categories.Category.Product renaming (Product to _×ᶜ_)
-open import Categories.Diagram.Cone
-open import Categories.Diagram.End renaming (End to ∫)
-open import Categories.Diagram.Limit
-open import Categories.Diagram.Limit.Properties
-open import Categories.Diagram.Wedge
-open import Categories.Diagram.Wedge.Properties
-open import Categories.Functor hiding (id)
-open import Categories.Functor.Bifunctor
-open import Categories.Functor.Bifunctor.Properties
-open import Categories.Functor.Instance.Twisted
-open import Categories.Functor.Limits
-open import Categories.NaturalTransformation renaming (_∘ʳ_ to _▹ⁿ_; id to idN)
+open import Categories.Category.Equivalence.Preserves using (pres-Terminal)
+open import Categories.Category.Product using () renaming (Product to _×ᶜ_)
+open import Categories.Diagram.End using () renaming (End to ∫)
+open import Categories.Diagram.Limit using (Limit)
+open import Categories.Diagram.Limit.Properties using (≃-resp-lim)
+open import Categories.Diagram.Wedge using (Wedge; module Wedge-Morphism)
+open import Categories.Diagram.Wedge.Properties using (ConesTwist≅Wedges)
+open import Categories.Functor using (Functor; _∘F_)
+open import Categories.Functor.Bifunctor using (Bifunctor)
+open import Categories.Functor.Instance.Twisted using (Twist; Twistⁿⁱ)
+open import Categories.Functor.Limits using (Continuous)
+open import Categories.NaturalTransformation using (NaturalTransformation; _∘ᵥ_) renaming (_∘ʳ_ to _▹ⁿ_; id to idN)
 open import Categories.NaturalTransformation.Dinatural hiding (_≃_)
-open import Categories.NaturalTransformation.Equivalence renaming (_≃_ to _≃ⁿ_)
-open import Categories.NaturalTransformation.NaturalIsomorphism renaming (_≃_ to _≃ⁱ_)
-open import Categories.NaturalTransformation.NaturalIsomorphism.Properties
+open import Categories.NaturalTransformation.Equivalence using () renaming (_≃_ to _≃ⁿ_)
+open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism; sym-associator) renaming (_≃_ to _≃ⁱ_)
 open import Categories.Object.Terminal as Terminal
 
 import Categories.Category.Construction.Wedges as Wedges
 import Categories.Morphism as M
 import Categories.Morphism.Reasoning as MR
-
--- The following conventions are taken in this file: C is the 'source' category
--- and D is the destination. If two source categories are needed, the other is
--- called 'P' for "parameter", following MacLane. F, G and H are functors and ef,
--- eg and eh are witnesses of their respective ends.
 
 private
   variable
@@ -236,14 +233,14 @@ module _ {C : Category o ℓ e}
       j-limit : Limit (Twist C D J)
       j-limit = End-yields-limit J ej
       --new-limit
-      f-limit : Limit (F ∘F (J ∘F Forget C))
+      f-limit : Limit (F ∘F (J ∘F Codomain C))
       f-limit .Limit.terminal = record
         { ⊤ = F-map-Coneˡ F (Limit.limit j-limit)
         ; ⊤-is-terminal = cont j-limit
         }
       -- for this we merely need to transport across the associator
       f-limit′ : Limit (Twist C E (F ∘F J))
-      f-limit′ = ≃-resp-lim (sym-associator (Forget C) J F) f-limit
+      f-limit′ = ≃-resp-lim (sym-associator (Codomain C) J F) f-limit
 
     -- really we want IsEnd `F.₀ (∫.E ej)` (F ∘F J)
     contF-as-end : ∫ (F ∘F J)

--- a/src/Categories/Functor/Bifunctor.agda
+++ b/src/Categories/Functor/Bifunctor.agda
@@ -1,4 +1,8 @@
 {-# OPTIONS --without-K --safe #-}
+
+-- Bifunctor, aka a Functor from C × D to E
+module Categories.Functor.Bifunctor where
+
 open import Level
 open import Data.Product using (_,_)
 
@@ -6,10 +10,6 @@ open import Categories.Category
 open import Categories.Functor
 open import Categories.Functor.Construction.Constant
 open import Categories.Category.Product
-
-module Categories.Functor.Bifunctor where
-
--- Bifunctor, aka a Functor from C × D to E
 
 private
   variable

--- a/src/Categories/Functor/Bifunctor.agda
+++ b/src/Categories/Functor/Bifunctor.agda
@@ -1,7 +1,4 @@
 {-# OPTIONS --without-K --safe #-}
-module Categories.Functor.Bifunctor where
-
--- Bifunctor, aka a Functor from C × D to E
 open import Level
 open import Data.Product using (_,_)
 
@@ -9,6 +6,10 @@ open import Categories.Category
 open import Categories.Functor
 open import Categories.Functor.Construction.Constant
 open import Categories.Category.Product
+
+module Categories.Functor.Bifunctor where
+
+-- Bifunctor, aka a Functor from C × D to E
 
 private
   variable

--- a/src/Categories/Functor/Bifunctor/Properties.agda
+++ b/src/Categories/Functor/Bifunctor/Properties.agda
@@ -6,8 +6,12 @@ open import Level
 open import Data.Product using (Σ; _,_)
 
 open import Categories.Category
+open import Categories.Category.Product
 open import Categories.Functor
 open import Categories.Functor.Bifunctor
+open import Categories.Functor.Construction.Constant
+open import Categories.NaturalTransformation using (NaturalTransformation; _∘ˡ_) renaming (id to idN)
+
 import Categories.Morphism.Reasoning as MR
 
 private

--- a/src/Categories/Functor/Bifunctor/Properties.agda
+++ b/src/Categories/Functor/Bifunctor/Properties.agda
@@ -6,11 +6,8 @@ open import Level
 open import Data.Product using (Σ; _,_)
 
 open import Categories.Category
-open import Categories.Category.Product
 open import Categories.Functor
 open import Categories.Functor.Bifunctor
-open import Categories.Functor.Construction.Constant
-open import Categories.NaturalTransformation using (NaturalTransformation; _∘ˡ_) renaming (id to idN)
 
 import Categories.Morphism.Reasoning as MR
 

--- a/src/Categories/Functor/Instance/Twisted.agda
+++ b/src/Categories/Functor/Instance/Twisted.agda
@@ -1,22 +1,21 @@
 {-# OPTIONS --without-K --safe #-}
 
-open import Level
-open import Data.Product using (_,_)
-
 open import Categories.Category using (Category; module Definitions)
-
-open import Categories.Category.Construction.TwistedArrow
-open import Categories.Category.Product renaming (Product to _×ᶜ_)
-open import Categories.Category.Construction.Functors
-open import Categories.Functor
-open import Categories.Functor.Bifunctor
-open import Categories.NaturalTransformation using (NaturalTransformation; ntHelper)
-open import Categories.NaturalTransformation.NaturalIsomorphism using (_≃_; _ⓘʳ_)
-open import Categories.Functor.Limits using (Continuous)
-
 
 -- Definition of the "Twisted" Functor between certain Functor Categories
 module Categories.Functor.Instance.Twisted {o ℓ e o′ ℓ′ e′} (C : Category o ℓ e) (D : Category o′ ℓ′ e′)where
+
+open import Level
+open import Data.Product using (_,_)
+
+open import Categories.Category.Construction.Functors using (Functors; product)
+open import Categories.Category.Construction.TwistedArrow using (TwistedArrow; Morphism; Morphism⇒; Codomain)
+open import Categories.Category.Product using () renaming (Product to _×ᶜ_)
+open import Categories.Functor using (Functor; _∘F_)
+open import Categories.Functor.Bifunctor using (appʳ)
+open import Categories.Functor.Limits using (Continuous)
+open import Categories.NaturalTransformation using (NaturalTransformation; ntHelper)
+open import Categories.NaturalTransformation.NaturalIsomorphism using (_≃_; _ⓘʳ_)
 
 private
   module C = Category C
@@ -24,16 +23,17 @@ private
 
 open Morphism
 open Morphism⇒
+
 -- precomposition with the forgetful functor
 Twist : Functor (C.op ×ᶜ C) D → Functor (TwistedArrow C) D
-Twist F = F ∘F Forget C
+Twist F = F ∘F Codomain C
 
 Twist′ : Functor (C.op ×ᶜ C) D → Functor (Category.op (TwistedArrow C.op)) D
-Twist′ F = F ∘F (Functor.op (Forget C.op))
+Twist′ F = F ∘F (Functor.op (Codomain C.op))
 
 -- precomposition is functorial
 Twisted : Functor (Functors (C.op ×ᶜ C) D) (Functors (TwistedArrow C) D)
-Twisted = appʳ product (Forget C)
+Twisted = appʳ product (Codomain C)
 
 Twistⁿⁱ : ∀ {F G : Functor (C.op ×ᶜ C) D } → (F ≃ G) → Twist F ≃ Twist G
-Twistⁿⁱ α = α ⓘʳ Forget C
+Twistⁿⁱ α = α ⓘʳ Codomain C

--- a/src/Categories/Functor/Instance/Twisted.agda
+++ b/src/Categories/Functor/Instance/Twisted.agda
@@ -1,62 +1,39 @@
 {-# OPTIONS --without-K --safe #-}
-open import Categories.Category using (Category; module Definitions)
 
--- Definition of the "Twisted" Functor between certain Functor Categories
-module Categories.Functor.Instance.Twisted {o ℓ e o′ ℓ′ e′} (𝒞 : Category o ℓ e) (𝒟 : Category o′ ℓ′ e′) where
-
-import Categories.Category.Construction.TwistedArrow as TW
-open import Categories.Category.Product
-open import Categories.Category.Construction.Functors
-open import Categories.Functor
-open import Categories.NaturalTransformation using (NaturalTransformation; ntHelper)
-
+open import Level
 open import Data.Product using (_,_)
 
+open import Categories.Category using (Category; module Definitions)
+
+open import Categories.Category.Construction.TwistedArrow
+open import Categories.Category.Product renaming (Product to _×ᶜ_)
+open import Categories.Category.Construction.Functors
+open import Categories.Functor
+open import Categories.Functor.Bifunctor
+open import Categories.NaturalTransformation using (NaturalTransformation; ntHelper)
+open import Categories.NaturalTransformation.NaturalIsomorphism using (_≃_; _ⓘʳ_)
+open import Categories.Functor.Limits using (Continuous)
+
+
+-- Definition of the "Twisted" Functor between certain Functor Categories
+module Categories.Functor.Instance.Twisted {o ℓ e o′ ℓ′ e′} (C : Category o ℓ e) (D : Category o′ ℓ′ e′)where
+
 private
-  module C = Category 𝒞
+  module C = Category C
+  module D = Category D
 
-Twist : Functor (Product C.op 𝒞) 𝒟 → Functor (TW.TwistedArrow 𝒞) 𝒟
-Twist F = record
-  { F₀ = λ x → F₀ (dom x , cod x)
-  ; F₁ = λ f → F₁ (dom⇐ f , cod⇒ f)
-  ; identity = identity
-  ; homomorphism = homomorphism
-  ; F-resp-≈ = F-resp-≈
-  }
-  where
-  open Functor F
-  open TW.Morphism
-  open TW.Morphism⇒
+open Morphism
+open Morphism⇒
+-- precomposition with the forgetful functor
+Twist : Functor (C.op ×ᶜ C) D → Functor (TwistedArrow C) D
+Twist F = F ∘F Forget C
 
-Twist′ : Functor (Product C.op 𝒞) 𝒟 → Functor (Category.op (TW.TwistedArrow C.op)) 𝒟
-Twist′ F = record
-  { F₀ = λ x → F₀ (dom x , cod x)
-  ; F₁ = λ f → F₁ (dom⇐ f , cod⇒ f)
-  ; identity = identity
-  ; homomorphism = homomorphism
-  ; F-resp-≈ = F-resp-≈
-  }
-  where
-  open Functor F
-  open TW.Morphism
-  open TW.Morphism⇒
+Twist′ : Functor (C.op ×ᶜ C) D → Functor (Category.op (TwistedArrow C.op)) D
+Twist′ F = F ∘F (Functor.op (Forget C.op))
 
-Twisted : Functor (Functors (Product C.op 𝒞) 𝒟) (Functors (TW.TwistedArrow 𝒞) 𝒟)
-Twisted = record
-  { F₀ = Twist
-  ; F₁ = Nat
-  ; identity = D.Equiv.refl
-  ; homomorphism = D.Equiv.refl
-  ; F-resp-≈ = λ f≈g → f≈g
-  }
-  where
-  open TW.Morphism
-  open TW.Morphism⇒
-  module D = Category 𝒟
-  Nat : {F G : Functor (Product C.op 𝒞) 𝒟} → NaturalTransformation F G → NaturalTransformation (Twist F) (Twist G)
-  Nat nt = ntHelper record
-    { η = λ x → η nt (dom x , cod x)
-    ; commute = λ f → commute nt (dom⇐ f , cod⇒ f)
-    }
-    where
-    open NaturalTransformation
+-- precomposition is functorial
+Twisted : Functor (Functors (C.op ×ᶜ C) D) (Functors (TwistedArrow C) D)
+Twisted = appʳ product (Forget C)
+
+Twistⁿⁱ : ∀ {F G : Functor (C.op ×ᶜ C) D } → (F ≃ G) → Twist F ≃ Twist G
+Twistⁿⁱ α = α ⓘʳ Forget C

--- a/src/Categories/NaturalTransformation/Equivalence.agda
+++ b/src/Categories/NaturalTransformation/Equivalence.agda
@@ -1,15 +1,16 @@
 {-# OPTIONS --without-K --safe #-}
 
+open import Categories.Category
+
+-- define a less-than-great equivalence on natural transformations
+module Categories.NaturalTransformation.Equivalence {o ℓ e o′ ℓ′ e′}
+    {C : Category o ℓ e} {D : Category o′ ℓ′ e′} where
+
 open import Level
 open import Relation.Binary using (Rel; IsEquivalence; Setoid)
 
-open import Categories.Category
-open import Categories.Functor
-open import Categories.NaturalTransformation.Core
-
--- define a less-than-great equivalence on natural transformations
-module Categories.NaturalTransformation.Equivalence {o ℓ e o′ ℓ′ e′ : Level}
-    {C : Category o ℓ e} {D : Category o′ ℓ′ e′} where
+open import Categories.Functor using (Functor)
+open import Categories.NaturalTransformation.Core using (NaturalTransformation)
 
 module _ {F G : Functor C D} where
   infix 4 _≃_

--- a/src/Categories/NaturalTransformation/Equivalence.agda
+++ b/src/Categories/NaturalTransformation/Equivalence.agda
@@ -1,8 +1,5 @@
 {-# OPTIONS --without-K --safe #-}
 
--- define a less-than-great equivalence on natural transformations
-module Categories.NaturalTransformation.Equivalence where
-
 open import Level
 open import Relation.Binary using (Rel; IsEquivalence; Setoid)
 
@@ -10,27 +7,27 @@ open import Categories.Category
 open import Categories.Functor
 open import Categories.NaturalTransformation.Core
 
-private
-  variable
-    o ℓ e o′ ℓ′ e′ : Level
-    C D E : Category o ℓ e
+-- define a less-than-great equivalence on natural transformations
+module Categories.NaturalTransformation.Equivalence {o ℓ e o′ ℓ′ e′ : Level}
+    {C : Category o ℓ e} {D : Category o′ ℓ′ e′} where
 
--- This ad hoc equivalence for NaturalTransformation should really be 'modification'
---  (yep, tricategories!). What is below is only part of the definition of a 'modification'.  TODO
-infix 4 _≃_
+module _ {F G : Functor C D} where
+  infix 4 _≃_
+  open Category.Equiv D
 
-_≃_ : ∀ {F G : Functor C D} → Rel (NaturalTransformation F G) _
-_≃_ {D = D} X Y = ∀ {x} → D [ NaturalTransformation.η X x ≈ NaturalTransformation.η Y x ]
+  -- This ad hoc equivalence for NaturalTransformation should really be 'modification'
+  --  (yep, tricategories!). What is below is only part of the definition of a 'modification'.  TODO
+  _≃_ : Rel (NaturalTransformation F G) (o ⊔ e′)
+  _≃_ X Y = ∀ {x} → D [ NaturalTransformation.η X x ≈ NaturalTransformation.η Y x ]
 
-≃-isEquivalence : ∀ {F G : Functor C D} → IsEquivalence (_≃_ {F = F} {G})
-≃-isEquivalence {D = D} {F} {G} = record
-  { refl  = refl
-  ; sym   = λ f → sym f -- need to eta-expand to get things to line up properly
-  ; trans = λ f g → trans f g
-  }
-  where open Category.Equiv D
+  ≃-isEquivalence : IsEquivalence _≃_
+  ≃-isEquivalence = record
+    { refl  = refl
+    ; sym   = λ f → sym f -- need to eta-expand to get things to line up properly
+    ; trans = λ f g → trans f g
+    }
 
-≃-setoid : ∀ (F G : Functor C D) → Setoid _ _
+≃-setoid : ∀ (F G : Functor C D) → Setoid (o ⊔ ℓ ⊔ ℓ′ ⊔ e′) (o ⊔ e′)
 ≃-setoid F G = record
   { Carrier       = NaturalTransformation F G
   ; _≈_           = _≃_


### PR DESCRIPTION
This PR is a collection of theorems and refactorings that were developed during my master's thesis.

This includes
* Initial objects
  * are colimits
* Strict initial objects
  * Initial objects in a Cartesian category are strict
* The category of twisted arrows
  * has a forgetful functor
  * `Twist (F ∘ J)` is iso to `F ∘ Twist J`
* End calculus
  * Ends are preserved by continuous functors
  * The setoid of natural transformations is an end (given size constraints)
  * Parameterized ends  (`EndF`)
    * are ends 
    * are preserved by continuous functors
  * The end of a parameterized end is an end in the product category (Fubini)


Many definitions could be simplified if #419 is resolved.

## Considerations

`--lossy-unification` is currently necessary for `Categories.Diagram.End.Fubini`. I was hoping that refactoring `EndF` to use an opaque `end-η` could fix this, but it does not.