### PR TITLE
Bump standard library dependency to 2.1

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -46,7 +46,7 @@ on:
 
 env:
   AGDA_COMMIT: tags/v2.6.4
-  STDLIB_VERSION: "2.0"
+  STDLIB_VERSION: "2.1"
 
   GHC_VERSION: 8.10.7
   CABAL_VERSION: 3.6.2.0

--- a/agda-categories.agda-lib
+++ b/agda-categories.agda-lib
@@ -1,3 +1,3 @@
 name: agda-categories
-depend: standard-library-2.0
+depend: standard-library-2.1
 include: src/


### PR DESCRIPTION
Closes #437 

No code changes are necessary but i think this unlocks `Function.Relation.Binary.Equality` for us: do we want to alter `Categories.Category.Instance.Setoids` to use this at the same time?