### PR TITLE
Fix type of exported natural isomorphisms

### DIFF
--- a/src/Categories/Category/Cocartesian.agda
+++ b/src/Categories/Category/Cocartesian.agda
@@ -29,6 +29,7 @@ open import Categories.Morphism 𝒞
 open import Categories.Morphism.Properties 𝒞
 open import Categories.Morphism.Duality 𝒞
 open import Categories.Morphism.Reasoning 𝒞
+open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism)
 open import Categories.Object.Initial 𝒞 using (Initial)
 open import Categories.Object.Coproduct 𝒞
 open import Categories.Object.Duality 𝒞
@@ -149,11 +150,14 @@ module CocartesianMonoidal (cocartesian : Cocartesian) where
   A+⊥≅A : A + ⊥ ≅ A
   A+⊥≅A = op-≅⇒≅ (op-cartesianMonoidal.A×⊤≅A)
 
-  open op-cartesianMonoidal
-    using (monoidal)
-    -- both are natural isomorphism
-    renaming (⊤×--id to ⊥+--id; -×⊤-id to -+⊥-id)
-    public
+  open op-cartesianMonoidal using (monoidal; ⊤×--id; -×⊤-id)
+  open NaturalIsomorphism using (op′)
+
+  ⊥+--id : NaturalIsomorphism (⊥ +-) idF
+  ⊥+--id = op′ ⊤×--id
+
+  -+⊥-id : NaturalIsomorphism (-+ ⊥) idF
+  -+⊥-id = op′ -×⊤-id
 
   open Monoidal monoidal using (unit; unitorˡ-commute-to; unitorˡ-commute-from; unitorʳ-commute-to;
     unitorʳ-commute-from; assoc-commute-to; assoc-commute-from; triangle; pentagon)


### PR DESCRIPTION
These two natural isomorphisms are not `op`ed enough

```
{-# OPTIONS --without-K --safe #-}

open import Categories.Category.Core using (Category)
open import Categories.Category.Cocartesian using (Cocartesian)

module Minimal {o ℓ e} {𝒞 : Category o ℓ e} (cocartesian : Cocartesian 𝒞) where

open import Categories.Category.Cocartesian using (module CocartesianMonoidal)
open import Categories.Functor using (id; Functor)
open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism)

open Cocartesian cocartesian using (⊥; _+-; -+_)
open CocartesianMonoidal 𝒞 cocartesian using () renaming (⊥+--id to ⊥+--id′; -+⊥-id to -+⊥-id′)

module Bad where

  open Functor using (op)

  ⊥+--id : NaturalIsomorphism (op (⊥ +-)) id
  ⊥+--id = ⊥+--id′

  -+⊥-id : NaturalIsomorphism (op (-+ ⊥)) id
  -+⊥-id = -+⊥-id′

module Good where

  open NaturalIsomorphism using (op′)

  ⊥+--id : NaturalIsomorphism (⊥ +-) id
  ⊥+--id = op′ ⊥+--id′

  -+⊥-id : NaturalIsomorphism (-+ ⊥) id
  -+⊥-id = op′ -+⊥-id′
```