### PR TITLE
Adjoint equivalences preserve colimits

### DIFF
--- a/src/Categories/Adjoint/Equivalence/Properties.agda
+++ b/src/Categories/Adjoint/Equivalence/Properties.agda
@@ -6,6 +6,7 @@ open import Level
 
 open import Categories.Category
 open import Categories.Adjoint.Equivalence
+open import Categories.Diagram.Duality using (coLimit⇒Colimit; Colimit⇒coLimit)
 open import Categories.Functor renaming (id to idF)
 open import Categories.Functor.Properties
 open import Categories.NaturalTransformation.NaturalIsomorphism as ≃ using (_≃_; NaturalIsomorphism)
@@ -13,6 +14,7 @@ open import Categories.NaturalTransformation.NaturalIsomorphism as ≃ using (_�
 import Categories.Morphism.Reasoning as MR
 import Categories.Category.Construction.Cones as Co
 import Categories.Diagram.Limit as Lim
+import Categories.Diagram.Colimit as Colim
 
 private
   variable
@@ -99,8 +101,8 @@ module _  (⊣equiv : ⊣Equivalence C D) (F : Functor C E) where
                   F.₁ (unit.⇐.η c) ∘ proj (R.₀ (L.₀ c)) ∘ f.arr ≈⟨ refl⟩∘⟨ f.commute ⟩
                   F.₁ (unit.⇐.η c) ∘ K.ψ (L.₀ c)                ∎
 
-    ⊣equiv-preserves-diagram : Lim.Limit FR
-    ⊣equiv-preserves-diagram = record
+    ⊣equiv-preserves-limit : Lim.Limit FR
+    ⊣equiv-preserves-limit = record
       { terminal = record
         { ⊤             = ⊤cone
         ; ⊤-is-terminal = record
@@ -110,3 +112,22 @@ module _  (⊣equiv : ⊣Equivalence C D) (F : Functor C E) where
         }
       }
   
+-- ditto for colimits, by duality
+module _ (⊣equiv : ⊣Equivalence C D) (F : Functor C E) where
+
+  private
+    module C = Category C
+    module D = Category D
+    module F = Functor F
+    module ⊣equiv = ⊣Equivalence ⊣equiv
+
+    opEquiv : ⊣Equivalence C.op D.op
+    opEquiv = sym record
+      { L = ⊣equiv.R.op
+      ; R = ⊣equiv.L.op
+      ; L⊣⊢R = ⊣equiv.op₁
+      }
+
+  ⊣equiv-preserves-colimit : Colim.Colimit F → Colim.Colimit (F ∘F ⊣equiv.R)
+  ⊣equiv-preserves-colimit colim = coLimit⇒Colimit E (⊣equiv-preserves-limit opEquiv F.op (Colimit⇒coLimit E colim))
+

--- a/src/Categories/Category/Finite.agda
+++ b/src/Categories/Category/Finite.agda
@@ -21,7 +21,7 @@ open import Categories.Category.Finite.Fin
 -- Answer: probably yes. adjoint equivalence seems necessary as the notion needs to
 -- show that shapes are preserved.
 --
--- c.f. Categories.Adjoint.Equivalence.Properties.⊣equiv-preserves-diagram
+-- c.f. Categories.Adjoint.Equivalence.Properties.⊣equiv-preserves-limit
 record Finite {o ℓ e} (C : Category o ℓ e) : Set (o ⊔ ℓ ⊔ e) where
   field
     shape : FinCatShape


### PR DESCRIPTION
I feel it should be possible to show a weaker version of this, that if `C -| D` then `R` preserves limits and `L` preserves colimits. c.f. https://ncatlab.org/nlab/show/adjoints+preserve+(co-)limits (which would justify the feeling of the author of `Categories.Category.Finite` that the right adjoint is enough there)