### PR TITLE
Fix typo in product of functors distributive law

### DIFF
--- a/src/Categories/Category/Product/Properties.agda
+++ b/src/Categories/Category/Product/Properties.agda
@@ -97,7 +97,7 @@ module _ (C : Category o ℓ e) (D : Category o′ ℓ′ e′) where
     }
 
   ※-distrib₂ : {o₁ ℓ₁ e₁ o₂ ℓ₂ e₂ : Level} {A : Category o₁ ℓ₁ e₁} {B : Category o₂ ℓ₂ e₂}
-    → (F : Functor B C) → (G : Functor B D)
+    → (F : Functor A C) → (G : Functor B D)
     → ((F ∘F πˡ) ※ (G ∘F πʳ)) ≃ (F ⁂ G)
   ※-distrib₂ F G = record
     { F⇒G = ntHelper record { η = λ X → C.id , D.id ; commute = λ _ → MR.id-comm-sym C , MR.id-comm-sym D }


### PR DESCRIPTION
The domain of the first functor is preventing this from being as general as it should be. I noticed this when I tried to use this property and agda couldn't infer the unused implicit argument.