### PR TITLE
Minor reasoning combinator updates

### DIFF
--- a/src/Categories/Category/Monoidal/Reasoning.agda
+++ b/src/Categories/Category/Monoidal/Reasoning.agda
@@ -135,7 +135,15 @@ split₂ˡ {f = f} {g} {h} = begin
   id ⊗₁ g ∘ f ⊗₁ h      ∎
 
 -- The opposite, i.e. merge
-merge₂ʳ :  ∀ {X₁ Y₁ X₂ Y₂ Z₂} {f : X₁ ⇒ Y₁} {g : Y₂ ⇒ Z₂} {h : X₂ ⇒ Y₂} →
+merge₁ʳ : ∀ {X₁ Y₁ Z₁ X₂ Y₂} {f : Y₁ ⇒ Z₁} {g : X₁ ⇒ Y₁} {h : X₂ ⇒ Y₂} →
+          f ⊗₁ h ∘ g ⊗₁ id ≈ (f ∘ g) ⊗₁ h
+merge₁ʳ = Equiv.sym split₁ʳ
+
+merge₁ˡ : ∀ {X₁ Y₁ Z₁ X₂ Y₂} {f : Y₁ ⇒ Z₁} {g : X₁ ⇒ Y₁} {h : X₂ ⇒ Y₂} →
+          f ⊗₁ id ∘ g ⊗₁ h ≈ (f ∘ g) ⊗₁ h
+merge₁ˡ = Equiv.sym split₁ˡ
+
+merge₂ʳ : ∀ {X₁ Y₁ X₂ Y₂ Z₂} {f : X₁ ⇒ Y₁} {g : Y₂ ⇒ Z₂} {h : X₂ ⇒ Y₂} →
           f ⊗₁ g ∘ id ⊗₁ h ≈ f ⊗₁ (g ∘ h)
 merge₂ʳ = Equiv.sym split₂ʳ
 

--- a/src/Categories/Morphism/Reasoning/Core.agda
+++ b/src/Categories/Morphism/Reasoning/Core.agda
@@ -309,8 +309,8 @@ pull-first {f = f} {g = g} {a = a} {h = h} {i = i} eq = begin
 pull-center : g ∘ h ≈ a → f ∘ (g ∘ (h ∘ i)) ≈ f ∘ (a ∘ i)
 pull-center eq = ∘-resp-≈ʳ (pullˡ eq)
 
-push-center : g ∘ h ≈ a → f ∘ (a ∘ i) ≈ f ∘ (g ∘ (h ∘ i))
-push-center eq = Equiv.sym (pull-center eq)
+push-center : a ≈ g ∘ h → f ∘ (a ∘ i) ≈ f ∘ (g ∘ (h ∘ i))
+push-center eq = Equiv.sym (pull-center (Equiv.sym eq))
 
 intro-first : a ∘ b ≈ id → f ∘ g ≈ a ∘ ((b ∘ f) ∘ g)
 intro-first {a = a} {b = b} {f = f} {g = g} eq = begin


### PR DESCRIPTION
Hi, a few more tweaks from using the library. Having the first argument of `push-center` be of the form `c≈a∘b` would make it consistent with the other "pushes" in that module. Also, added `merge₁ʳ` and `merge₁ˡ` to complement `merge₂ʳ` and `merge₂ˡ`.