### PR TITLE
Bicategory of Monads and Bimodules

### DIFF
--- a/src/Categories/Bicategory/Construction/Bimodules.agda
+++ b/src/Categories/Bicategory/Construction/Bimodules.agda
@@ -1,0 +1,82 @@
+{-# OPTIONS --without-K --safe --lossy-unification  #-}
+-- lossy unification speeds up type checking by preventing Agda from unfolding all definitions
+
+open import Categories.Bicategory
+open import Categories.Bicategory.LocalCoequalizers
+
+module Categories.Bicategory.Construction.Bimodules {o ℓ e t} {𝒞 : Bicategory o ℓ e t} {localCoeq : LocalCoequalizers 𝒞} where
+
+open import Categories.Bicategory.Monad
+open import Level
+
+open import Categories.Bicategory.Monad.Bimodule
+import Categories.Category.Construction.Bimodules
+open Categories.Category.Construction.Bimodules {o} {ℓ} {e} {t} {𝒞} renaming (Bimodules to Bimodules₁)
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+open import Categories.Category
+
+
+private
+  module Bimodules₁ M₁ M₂ = Category (Bimodules₁ M₁ M₂)
+
+Bimodules : Bicategory (o ⊔ ℓ ⊔ e) (ℓ ⊔ e) e (o ⊔ ℓ ⊔ e ⊔ t)
+Bimodules = record
+  { enriched = record
+    { Obj = Monad 𝒞
+    ; hom = Bimodules₁
+    ; id = λ {M} → record
+    { F₀ = λ _ → id-bimodule M
+    ; F₁ = λ _ → Bimodules₁.id M M
+    ; identity = hom.Equiv.refl
+    ; homomorphism = hom.Equiv.sym (Bimodules₁.identity² M M)
+    ; F-resp-≈ = λ _ → hom.Equiv.refl
+    }
+    ; ⊚ = record
+      { F₀ = λ (B₂ , B₁) → B₂ ⊗₀ B₁
+      ; F₁ = λ (h₂ , h₁) → h₂ ⊗₁ h₁
+      ; identity = λ {(B₂ , B₁)} → Identity.⊗₁-resp-id₂ B₂ B₁
+      ; homomorphism = λ {_} {_} {_} {(g₂ , g₁)} {(h₂ , h₁)} → Composition.⊗₁-distr-∘ᵥ h₂ h₁ g₂ g₁
+      ; F-resp-≈ = λ {_} {_} {(h₂ , h₁)} {(h'₂ , h'₁)} (e₂ , e₁) → ≈Preservation.⊗₁-resp-≈ h₂ h'₂ h₁ h'₁ e₂ e₁
+      }
+    ; ⊚-assoc = niHelper record
+      { η = λ ((B₃ , B₂) , B₁) → _≅_.from (Associator⊗ {B₃ = B₃} {B₂} {B₁})
+      ; η⁻¹ = λ ((B₃ , B₂) , B₁) → _≅_.to (Associator⊗ {B₃ = B₃} {B₂} {B₁})
+      ; commute = λ ((f₃ , f₂) , f₁) → α⇒⊗-natural f₃ f₂ f₁
+      ; iso = λ ((B₃ , B₂) , B₁) → _≅_.iso (Associator⊗ {B₃ = B₃} {B₂} {B₁})
+      }
+    ; unitˡ = niHelper record
+      { η = λ (_ , B) → _≅_.from (Unitorˡ⊗ {B = B})
+      ; η⁻¹ = λ (_ , B) → _≅_.to (Unitorˡ⊗ {B = B})
+      ; commute = λ (_ , f) → λ⇒⊗-natural f
+      ; iso = λ (_ , B) → _≅_.iso (Unitorˡ⊗ {B = B})
+      }
+    ; unitʳ = niHelper record
+      { η = λ (B , _) → _≅_.from (Unitorʳ⊗ {B = B})
+      ; η⁻¹ = λ (B , _) → _≅_.to (Unitorʳ⊗ {B = B})
+      ; commute = λ (f , _) → ρ⇒⊗-natural f
+      ; iso = λ (B , _) → _≅_.iso (Unitorʳ⊗ {B = B})
+      }
+    }
+  ; triangle = λ {_} {_} {_} {B₁} {B₂} → triangle⊗ {B₂ = B₂} {B₁}
+  ; pentagon = λ {_} {_} {_} {_} {_}{B₁} {B₂} {B₃} {B₄} → pentagon⊗ {B₄ = B₄} {B₃} {B₂} {B₁}
+  }
+  where
+    open import Data.Product using (_,_)
+    open import Categories.NaturalTransformation.NaturalIsomorphism using (niHelper)
+    open import Categories.Morphism using (_≅_)
+    open import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Functorial {𝒞 = 𝒞} {localCoeq}
+    open import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Associator {𝒞 = 𝒞} {localCoeq}
+      using (Associator⊗)
+    open import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Associator.Naturality {𝒞 = 𝒞} {localCoeq}
+      using (α⇒⊗-natural)
+    import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Unitor {𝒞 = 𝒞} {localCoeq} as Unitor
+    open Unitor.Left-Unitor using (Unitorˡ⊗)
+    open Unitor.Right-Unitor using (Unitorʳ⊗)
+    import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Unitor.Naturality {𝒞 = 𝒞} {localCoeq} as Unitor-Naturality
+    open Unitor-Naturality.Left-Unitor-natural using (λ⇒⊗-natural)
+    open Unitor-Naturality.Right-Unitor-natural using (ρ⇒⊗-natural)
+    open import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Coherence.Pentagon {𝒞 = 𝒞} {localCoeq}
+      using (pentagon⊗)
+    open import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Coherence.Triangle {𝒞 = 𝒞} {localCoeq}
+      using (triangle⊗)

--- a/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct.agda
+++ b/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct.agda
@@ -1,0 +1,727 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+
+open import Categories.Bicategory
+open import Categories.Bicategory.LocalCoequalizers
+
+module Categories.Bicategory.Construction.Bimodules.Tensorproduct
+  {o ℓ e t} {𝒞 : Bicategory o ℓ e t} {localCoeq : LocalCoequalizers 𝒞} where
+
+open import Categories.Bicategory.Monad
+open import Level
+open import Categories.Bicategory.Monad.Bimodule
+import Categories.Category.Construction.Bimodules
+open Categories.Category.Construction.Bimodules {o} {ℓ} {e} {t} {𝒞} renaming (Bimodules to Bimodules₁)
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+open import Categories.Category
+open import Categories.Diagram.Coequalizer
+import Categories.Diagram.Coequalizer.Properties as CoeqProperties
+
+private
+  module Bimodules₁ M₁ M₂ = Category (Bimodules₁ M₁ M₂)
+
+  open LocalCoequalizers localCoeq
+
+
+module TensorproductOfBimodules {M₁ M₂ M₃ : Monad 𝒞} (B₂ : Bimodule M₂ M₃) (B₁ : Bimodule M₁ M₂) where
+
+  open Monad M₁ using () renaming (C to C₁; T to T₁; μ to μ₁; η to η₁)
+  open Monad M₂ using () renaming (C to C₂; T to T₂; μ to μ₂; η to η₂)
+  open Monad M₃ using () renaming (C to C₃; T to T₃; μ to μ₃; η to η₃)
+  open Bimodule B₁ using ()
+    renaming (F to F₁; actionˡ to actionˡ₁; actionʳ to actionʳ₁; assoc to action-assoc₁;
+              sym-assoc to action-sym-assoc₁; assoc-actionˡ to assoc-actionˡ₁; identityˡ to identityˡ₁)
+  open Bimodule B₂ using ()
+    renaming (F to F₂; actionˡ to actionˡ₂; actionʳ to actionʳ₂; assoc to action-assoc₂;
+              sym-assoc to action-sym-assoc₂; assoc-actionʳ to assoc-actionʳ₂; identityʳ to identityʳ₂)
+
+  {-
+  To construct the tensorproduct B₂⊗B₁ we will define its underlying 1-cell
+  to be the coequalizer of the following parallel pair in hom C₁ C₃:
+  
+                         F₂ ▷ actionʳ₁
+  F₂ ∘₁ T₂ ∘ F₁ ==============================> F₂ ∘₁ F₁
+                actionˡ₂ ◁ F₁ ∘ᵥ associator.to
+  -}
+
+  -- We itroduce names to the two parallel morphism in the above diagram --
+  act-to-the-left act-to-the-right : F₂ ∘₁ T₂ ∘₁ F₁ ⇒₂ F₂ ∘₁ F₁
+  act-to-the-left = F₂ ▷ actionʳ₁
+  act-to-the-right = actionˡ₂ ◁ F₁ ∘ᵥ associator.to
+
+
+  -- The coequalizer that defines the composite bimodule --
+  F₂⊗F₁ : Coequalizer (hom C₁ C₃) (act-to-the-left) (act-to-the-right)
+  F₂⊗F₁ = localCoequalizers C₁ C₃ (act-to-the-left) (act-to-the-right)
+  -- coequalizer {_} {_} {F₂ ∘₁ T₂ ∘₁ F₁} {F₂ ∘₁ F₁} (act-to-the-left) (act-to-the-right)
+
+  -- The underlying object of that coequalizer is the underlying 1-cell of the bimodule B₂⊗B₁ --
+  F : C₁ ⇒₁ C₃
+  F = Coequalizer.obj F₂⊗F₁
+
+
+  module Left-Action where
+
+    -- To define the left-action we need that F ∘₁ T₁ is a coequalizer --
+    F∘T₁Coequalizer : Coequalizer (hom C₁ C₃) ((act-to-the-left) ◁ T₁) ((act-to-the-right) ◁ T₁)
+    F∘T₁Coequalizer = precompCoequalizer F₂⊗F₁ T₁
+    
+    F₂∘₁T₂▷actionˡ₁ : (F₂ ∘₁ T₂ ∘₁ F₁) ∘₁ T₁ ⇒₂ F₂ ∘₁ T₂ ∘₁ F₁
+    F₂∘₁T₂▷actionˡ₁ = associator.from ∘ᵥ (F₂ ∘₁ T₂) ▷ actionˡ₁ ∘ᵥ associator.from  ∘ᵥ associator.to ◁ T₁
+
+    F₂▷actionˡ₁ : (F₂ ∘₁ F₁) ∘₁ T₁ ⇒₂  F₂ ∘₁ F₁
+    F₂▷actionˡ₁ = F₂ ▷ actionˡ₁ ∘ᵥ associator.from
+
+    -- for CommutativeSquare --
+    open Definitions (hom C₁ C₃)
+
+    abstract
+      sq₁ : CommutativeSquare (F₂∘₁T₂▷actionˡ₁) ((act-to-the-left) ◁ T₁) (act-to-the-left) (F₂▷actionˡ₁)
+      sq₁ = begin
+        act-to-the-left ∘ᵥ F₂∘₁T₂▷actionˡ₁                                     ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        F₂ ▷ actionʳ₁ ∘ᵥ (associator.from ∘ᵥ (F₂ ∘₁ T₂) ▷ actionˡ₁)
+          ∘ᵥ associator.from  ∘ᵥ associator.to ◁ T₁                          ≈⟨ refl⟩∘⟨ α⇒-▷-∘₁ ⟩∘⟨refl ⟩
+        F₂ ▷ actionʳ₁ ∘ᵥ (F₂ ▷ T₂ ▷ actionˡ₁ ∘ᵥ associator.from)
+          ∘ᵥ associator.from  ∘ᵥ associator.to ◁ T₁                          ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁ ∘ᵥ associator.from
+          ∘ᵥ associator.from  ∘ᵥ associator.to ◁ T₁                          ≈⟨ sym-assoc₂ ⟩
+        (F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁) ∘ᵥ associator.from
+          ∘ᵥ associator.from  ∘ᵥ associator.to ◁ T₁                          ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        (F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁) ∘ᵥ (associator.from
+          ∘ᵥ associator.from)  ∘ᵥ associator.to ◁ T₁                         ≈⟨ refl⟩∘⟨ ⟺ pentagon ⟩∘⟨refl ⟩
+        -- maybe this can be shortened using conjugate --
+        (F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁) ∘ᵥ (F₂ ▷ associator.from
+          ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁) ∘ᵥ associator.to ◁ T₁  ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        (F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁) ∘ᵥ F₂ ▷ associator.from
+          ∘ᵥ (associator.from ∘ᵥ associator.from ◁ T₁) ∘ᵥ associator.to ◁ T₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc₂ ⟩
+        (F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁) ∘ᵥ F₂ ▷ associator.from
+          ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁ ∘ᵥ associator.to ◁ T₁   ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+        (F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁) ∘ᵥ F₂ ▷ associator.from
+          ∘ᵥ associator.from ∘ᵥ (associator.from ∘ᵥ associator.to) ◁ T₁      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ ◁-resp-≈ associator.isoʳ ⟩
+        (F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁) ∘ᵥ F₂ ▷ associator.from
+          ∘ᵥ associator.from ∘ᵥ id₂ ◁ T₁                                     ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ id₂◁ ⟩
+        (F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁) ∘ᵥ F₂ ▷ associator.from
+          ∘ᵥ associator.from ∘ᵥ id₂                                          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ identity₂ʳ ⟩
+        (F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁) ∘ᵥ F₂ ▷ associator.from
+          ∘ᵥ associator.from                                                 ≈⟨ sym-assoc₂ ⟩
+        ((F₂ ▷ actionʳ₁ ∘ᵥ F₂ ▷ T₂ ▷ actionˡ₁) ∘ᵥ F₂ ▷ associator.from)
+          ∘ᵥ associator.from                                                 ≈⟨ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩∘⟨refl ⟩
+        (F₂ ▷ (actionʳ₁ ∘ᵥ T₂ ▷ actionˡ₁) ∘ᵥ F₂ ▷ associator.from)
+          ∘ᵥ associator.from                                                 ≈⟨ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+        F₂ ▷ ((actionʳ₁ ∘ᵥ T₂ ▷ actionˡ₁) ∘ᵥ associator.from)
+          ∘ᵥ associator.from                                                 ≈⟨ ▷-resp-≈ assoc₂ ⟩∘⟨ refl ⟩
+        F₂ ▷ (actionʳ₁ ∘ᵥ T₂ ▷ actionˡ₁ ∘ᵥ associator.from)
+          ∘ᵥ associator.from ≈⟨ ▷-resp-≈ action-assoc₁ ⟩∘⟨refl ⟩
+        F₂ ▷ (actionˡ₁ ∘ᵥ actionʳ₁ ◁ T₁) ∘ᵥ associator.from                  ≈⟨ ⟺ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+        (F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ (actionʳ₁ ◁ T₁)) ∘ᵥ associator.from           ≈⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ (actionʳ₁ ◁ T₁) ∘ᵥ associator.from             ≈⟨ refl⟩∘⟨ ⟺ α⇒-▷-◁ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ associator.from ∘ᵥ (F₂ ▷ actionʳ₁) ◁ T₁             ≈⟨ ⟺ assoc₂ ⟩
+        F₂▷actionˡ₁ ∘ᵥ (act-to-the-left) ◁ T₁ ∎
+        where
+          open hom.HomReasoning
+          open hom.Equiv
+
+      sq₂ : CommutativeSquare (F₂∘₁T₂▷actionˡ₁) ((act-to-the-right) ◁ T₁) (act-to-the-right) (F₂▷actionˡ₁)
+      sq₂ = begin
+        (act-to-the-right) ∘ᵥ F₂∘₁T₂▷actionˡ₁                               ≈⟨ sym-assoc₂ ⟩
+        ((actionˡ₂ ◁ F₁ ∘ᵥ associator.to) ∘ᵥ associator.from) ∘ᵥ (F₂ ∘₁ T₂) ▷ actionˡ₁
+          ∘ᵥ associator.from ∘ᵥ associator.to ◁ T₁                                        ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+        (actionˡ₂ ◁ F₁ ∘ᵥ associator.to ∘ᵥ associator.from) ∘ᵥ (F₂ ∘₁ T₂) ▷ actionˡ₁
+          ∘ᵥ associator.from ∘ᵥ associator.to ◁ T₁                                        ≈⟨ (refl⟩∘⟨ associator.isoˡ) ⟩∘⟨refl ⟩
+        (actionˡ₂ ◁ F₁ ∘ᵥ id₂) ∘ᵥ (F₂ ∘₁ T₂) ▷ actionˡ₁
+          ∘ᵥ associator.from ∘ᵥ associator.to ◁ T₁                                        ≈⟨ identity₂ʳ ⟩∘⟨refl ⟩
+        actionˡ₂ ◁ F₁ ∘ᵥ (F₂ ∘₁ T₂) ▷ actionˡ₁ ∘ᵥ associator.from ∘ᵥ associator.to ◁ T₁   ≈⟨ sym-assoc₂ ⟩
+        (actionˡ₂ ◁ F₁ ∘ᵥ (F₂ ∘₁ T₂) ▷ actionˡ₁) ∘ᵥ associator.from ∘ᵥ associator.to ◁ T₁ ≈⟨ ⟺ ◁-▷-exchg ⟩∘⟨refl ⟩
+        (F₂ ▷ actionˡ₁ ∘ᵥ actionˡ₂ ◁ (F₁ ∘₁ T₁)) ∘ᵥ associator.from ∘ᵥ associator.to ◁ T₁ ≈⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ actionˡ₂ ◁ (F₁ ∘₁ T₁) ∘ᵥ associator.from ∘ᵥ associator.to ◁ T₁   ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ (actionˡ₂ ◁ (F₁ ∘₁ T₁) ∘ᵥ associator.from) ∘ᵥ associator.to ◁ T₁ ≈⟨ refl⟩∘⟨ ⟺ α⇒-◁-∘₁ ⟩∘⟨refl ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ (associator.from ∘ᵥ actionˡ₂ ◁ F₁ ◁ T₁) ∘ᵥ associator.to ◁ T₁    ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ associator.from ∘ᵥ actionˡ₂ ◁ F₁ ◁ T₁ ∘ᵥ associator.to ◁ T₁      ≈⟨ sym-assoc₂ ⟩
+        F₂▷actionˡ₁ ∘ᵥ actionˡ₂ ◁ F₁ ◁ T₁ ∘ᵥ associator.to ◁ T₁                           ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+        F₂▷actionˡ₁ ∘ᵥ (act-to-the-right) ◁ T₁ ∎
+        where
+          open hom.HomReasoning
+          open hom.Equiv
+    -- end abstract --
+    
+    -- left-action --
+    actionˡ : F ∘₁ T₁ ⇒₂ F
+    actionˡ = ⇒MapBetweenCoeq F₂∘₁T₂▷actionˡ₁ F₂▷actionˡ₁ sq₁ sq₂ F∘T₁Coequalizer F₂⊗F₁
+      where
+        open CoeqProperties (hom C₁ C₃)
+        
+    abstract    
+      -- the left-action fits into the following commutaitve square --
+      actionˡSq : CommutativeSquare (F₂▷actionˡ₁) (Coequalizer.arr F∘T₁Coequalizer) (Coequalizer.arr F₂⊗F₁) (actionˡ)
+      actionˡSq = ⇒MapBetweenCoeqSq F₂∘₁T₂▷actionˡ₁ F₂▷actionˡ₁ sq₁ sq₂ F∘T₁Coequalizer F₂⊗F₁
+        where
+          open CoeqProperties (hom C₁ C₃)
+    -- end abstract --
+
+  module Right-Action where
+
+    -- To define the right-action we need that T₃ ∘₁ F is a coequalizer --
+    T₃∘FCoequalizer : Coequalizer (hom C₁ C₃) (T₃ ▷ (act-to-the-left)) (T₃ ▷ (act-to-the-right))
+    T₃∘FCoequalizer = postcompCoequalizer F₂⊗F₁ T₃
+
+    -- to define a map between the coequalizers T₃ ∘₁ F ⇒₂ F we define a map of diagrams --
+    actionʳ₂◁T₂∘₁F₁ : T₃ ∘₁ F₂ ∘₁ T₂ ∘₁ F₁ ⇒₂  F₂ ∘₁ T₂ ∘₁ F₁
+    actionʳ₂◁T₂∘₁F₁ = actionʳ₂ ◁ (T₂ ∘₁ F₁) ∘ᵥ associator.to
+
+    actionʳ₂◁F₁ : T₃ ∘₁ F₂ ∘₁ F₁ ⇒₂  F₂ ∘₁ F₁
+    actionʳ₂◁F₁ = actionʳ₂ ◁ F₁ ∘ᵥ associator.to
+
+    -- for CommutativeSquare --
+    open Definitions (hom C₁ C₃)
+ 
+    -- to get a map of diagrams two squares have to commute --
+    abstract
+      sq₁ : CommutativeSquare (actionʳ₂◁T₂∘₁F₁) (T₃ ▷ act-to-the-left) (act-to-the-left) (actionʳ₂◁F₁)
+      sq₁ = glue′ sq₁bottom sq₁top
+        where
+          open hom.HomReasoning
+          open import Categories.Morphism.Reasoning.Core (hom C₁ C₃)
+          sq₁top : CommutativeSquare (associator.to) (T₃ ▷ F₂ ▷ actionʳ₁) ((T₃ ∘₁ F₂) ▷ actionʳ₁) (associator.to)
+          sq₁top = ⟺ α⇐-▷-∘₁
+          sq₁bottom : CommutativeSquare (actionʳ₂ ◁ (T₂ ∘₁ F₁)) ((T₃ ∘₁ F₂) ▷ actionʳ₁) (F₂ ▷ actionʳ₁) (actionʳ₂ ◁ F₁)
+          sq₁bottom = ◁-▷-exchg
+  
+      sq₂ : CommutativeSquare (actionʳ₂◁T₂∘₁F₁) (T₃ ▷ (act-to-the-right)) (act-to-the-right) (actionʳ₂◁F₁)
+      sq₂ = begin
+        (act-to-the-right) ∘ᵥ (actionʳ₂◁T₂∘₁F₁)                            ≈⟨ sym-assoc₂ ⟩
+        ((actionˡ₂ ◁ F₁ ∘ᵥ associator.to) ∘ᵥ actionʳ₂ ◁  (T₂ ∘₁ F₁)) ∘ᵥ associator.to    ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+        (actionˡ₂ ◁ F₁ ∘ᵥ (associator.to ∘ᵥ actionʳ₂ ◁  (T₂ ∘₁ F₁))) ∘ᵥ associator.to    ≈⟨ (refl⟩∘⟨ α⇐-◁-∘₁) ⟩∘⟨refl ⟩
+        (actionˡ₂ ◁ F₁ ∘ᵥ (actionʳ₂ ◁ T₂ ◁ F₁ ∘ᵥ associator.to)) ∘ᵥ associator.to        ≈⟨ assoc₂ ⟩
+        actionˡ₂ ◁ F₁ ∘ᵥ ((actionʳ₂ ◁ T₂ ◁ F₁ ∘ᵥ associator.to) ∘ᵥ associator.to)        ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionˡ₂ ◁ F₁ ∘ᵥ actionʳ₂ ◁ T₂ ◁ F₁ ∘ᵥ associator.to ∘ᵥ associator.to            ≈⟨ refl⟩∘⟨ refl⟩∘⟨ sym pentagon-inv ⟩
+        actionˡ₂ ◁ F₁ ∘ᵥ actionʳ₂ ◁ T₂ ◁ F₁ ∘ᵥ (associator.to ◁ F₁ ∘ᵥ associator.to)
+          ∘ᵥ T₃ ▷ associator.to                                                          ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionˡ₂ ◁ F₁ ∘ᵥ (actionʳ₂ ◁ T₂ ◁ F₁ ∘ᵥ (associator.to ◁ F₁ ∘ᵥ associator.to))
+          ∘ᵥ T₃ ▷ associator.to                                                          ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+        actionˡ₂ ◁ F₁ ∘ᵥ ((actionʳ₂ ◁ T₂ ◁ F₁ ∘ᵥ associator.to ◁ F₁) ∘ᵥ associator.to)
+          ∘ᵥ T₃ ▷ associator.to                                                          ≈⟨ sym-assoc₂ ⟩
+        (actionˡ₂ ◁ F₁ ∘ᵥ (actionʳ₂ ◁ T₂ ◁ F₁ ∘ᵥ associator.to ◁ F₁) ∘ᵥ associator.to)
+          ∘ᵥ T₃ ▷ associator.to                                                          ≈⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+        ((actionˡ₂ ◁ F₁ ∘ᵥ actionʳ₂ ◁ T₂ ◁ F₁ ∘ᵥ associator.to ◁ F₁) ∘ᵥ associator.to)
+          ∘ᵥ T₃ ▷ associator.to                                                          ≈⟨ ((refl⟩∘⟨ ∘ᵥ-distr-◁) ⟩∘⟨refl) ⟩∘⟨refl ⟩
+        ((actionˡ₂ ◁ F₁ ∘ᵥ (actionʳ₂ ◁ T₂ ∘ᵥ associator.to) ◁ F₁) ∘ᵥ associator.to)
+          ∘ᵥ T₃ ▷ associator.to                                                          ≈⟨ ∘ᵥ-distr-◁ ⟩∘⟨refl ⟩∘⟨refl ⟩
+        ((actionˡ₂ ∘ᵥ actionʳ₂ ◁ T₂ ∘ᵥ associator.to) ◁ F₁ ∘ᵥ associator.to)
+          ∘ᵥ T₃ ▷ associator.to                                                          ≈⟨ ◁-resp-≈ action-sym-assoc₂ ⟩∘⟨refl ⟩∘⟨refl ⟩
+        ((actionʳ₂ ∘ᵥ (T₃ ▷ actionˡ₂)) ◁ F₁ ∘ᵥ associator.to) ∘ᵥ T₃ ▷ associator.to      ≈⟨ ⟺ ∘ᵥ-distr-◁ ⟩∘⟨refl ⟩∘⟨refl ⟩
+        ((actionʳ₂ ◁ F₁ ∘ᵥ (T₃ ▷ actionˡ₂) ◁ F₁) ∘ᵥ associator.to) ∘ᵥ T₃ ▷ associator.to ≈⟨ (assoc₂ ⟩∘⟨refl) ⟩
+        (actionʳ₂ ◁ F₁ ∘ᵥ (T₃ ▷ actionˡ₂) ◁ F₁ ∘ᵥ associator.to) ∘ᵥ T₃ ▷ associator.to   ≈⟨ (refl⟩∘⟨ ⟺ α⇐-▷-◁) ⟩∘⟨refl ⟩
+        (actionʳ₂ ◁ F₁ ∘ᵥ associator.to ∘ᵥ T₃ ▷ (actionˡ₂ ◁ F₁)) ∘ᵥ T₃ ▷ associator.to   ≈⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+        ((actionʳ₂ ◁ F₁ ∘ᵥ associator.to) ∘ᵥ T₃ ▷ (actionˡ₂ ◁ F₁)) ∘ᵥ T₃ ▷ associator.to ≈⟨ assoc₂ ⟩
+        (actionʳ₂ ◁ F₁ ∘ᵥ associator.to) ∘ᵥ T₃ ▷ (actionˡ₂ ◁ F₁) ∘ᵥ T₃ ▷ associator.to   ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+        actionʳ₂◁F₁ ∘ᵥ T₃ ▷ (act-to-the-right)                             ∎
+          where
+            open hom.HomReasoning
+            open hom.Equiv
+    -- end abstract --
+      
+    -- right-action --
+    actionʳ : T₃ ∘₁ F ⇒₂ F
+    actionʳ = ⇒MapBetweenCoeq actionʳ₂◁T₂∘₁F₁ actionʳ₂◁F₁ sq₁ sq₂ T₃∘FCoequalizer F₂⊗F₁
+      where
+        open CoeqProperties (hom C₁ C₃)
+
+    abstract
+      -- the right-action fits into the following commutaitve square --
+      actionʳSq : CommutativeSquare (actionʳ₂◁F₁) (Coequalizer.arr T₃∘FCoequalizer) (Coequalizer.arr F₂⊗F₁) (actionʳ)
+      actionʳSq = ⇒MapBetweenCoeqSq actionʳ₂◁T₂∘₁F₁ actionʳ₂◁F₁ sq₁ sq₂ T₃∘FCoequalizer F₂⊗F₁
+        where
+          open CoeqProperties (hom C₁ C₃)
+    -- end abstract --
+
+  module Associativity where
+    open Left-Action using (actionˡ; actionˡSq; F₂▷actionˡ₁; F∘T₁Coequalizer)
+    open Right-Action using (actionʳ; actionʳSq; actionʳ₂◁F₁; T₃∘FCoequalizer)
+
+    -- we need that T₃∘(F∘T₁) is a coequalizer --
+    T₃∘[F∘T₁]Coequalizer : Coequalizer (hom C₁ C₃) (T₃ ▷ ((act-to-the-left) ◁ T₁))  (T₃ ▷ ((act-to-the-right) ◁ T₁))
+    T₃∘[F∘T₁]Coequalizer = postcompCoequalizer F∘T₁Coequalizer T₃
+
+    -- we need that (T₃∘F)∘T₁ is a coequalizer --
+    [T₃∘F]∘T₁Coequalizer : Coequalizer (hom C₁ C₃) ((T₃ ▷ (act-to-the-left)) ◁ T₁) ((T₃ ▷ (act-to-the-right)) ◁ T₁)
+    [T₃∘F]∘T₁Coequalizer = precompCoequalizer T₃∘FCoequalizer T₁
+
+    abstract
+      assoc-pentagon : actionʳ₂◁F₁ ∘ᵥ T₃ ▷ F₂▷actionˡ₁ ∘ᵥ associator.from ≈ F₂▷actionˡ₁ ∘ᵥ actionʳ₂◁F₁ ◁ T₁
+      assoc-pentagon = begin
+        actionʳ₂◁F₁ ∘ᵥ T₃ ▷ F₂▷actionˡ₁ ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ (⟺ ∘ᵥ-distr-▷ ⟩∘⟨refl) ⟩
+        actionʳ₂◁F₁ ∘ᵥ (T₃ ▷ F₂ ▷ actionˡ₁ ∘ᵥ T₃ ▷ associator.from) ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ associator.to ∘ᵥ (T₃ ▷ F₂ ▷ actionˡ₁ ∘ᵥ T₃ ▷ associator.from) ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ (associator.to ∘ᵥ (T₃ ▷ F₂ ▷ actionˡ₁ ∘ᵥ T₃ ▷ associator.from)) ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ ((associator.to ∘ᵥ T₃ ▷ F₂ ▷ actionˡ₁) ∘ᵥ T₃ ▷ associator.from) ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ (associator.to ∘ᵥ T₃ ▷ F₂ ▷ actionˡ₁) ∘ᵥ T₃ ▷ associator.from ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ α⇐-▷-∘₁ ⟩∘⟨refl ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ ((T₃ ∘₁ F₂) ▷ actionˡ₁ ∘ᵥ associator.to) ∘ᵥ T₃ ▷ associator.from ∘ᵥ associator.from ≈⟨ sym-assoc₂ ⟩
+        (actionʳ₂ ◁ F₁ ∘ᵥ ((T₃ ∘₁ F₂) ▷ actionˡ₁ ∘ᵥ associator.to)) ∘ᵥ T₃ ▷ associator.from ∘ᵥ associator.from ≈⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+        ((actionʳ₂ ◁ F₁ ∘ᵥ (T₃ ∘₁ F₂) ▷ actionˡ₁) ∘ᵥ associator.to) ∘ᵥ T₃ ▷ associator.from ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+        (actionʳ₂ ◁ F₁ ∘ᵥ (T₃ ∘₁ F₂) ▷ actionˡ₁) ∘ᵥ associator.to ∘ᵥ T₃ ▷ associator.from ∘ᵥ associator.from ≈⟨ ⟺ ◁-▷-exchg ⟩∘⟨refl ⟩
+        (F₂ ▷ actionˡ₁ ∘ᵥ actionʳ₂ ◁ (F₁ ∘₁ T₁)) ∘ᵥ associator.to ∘ᵥ T₃ ▷ associator.from ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ pentagon-conjugate₁ ⟩
+        (F₂ ▷ actionˡ₁ ∘ᵥ actionʳ₂ ◁ (F₁ ∘₁ T₁)) ∘ᵥ associator.from ∘ᵥ associator.to ◁ T₁ ≈⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ actionʳ₂ ◁ (F₁ ∘₁ T₁) ∘ᵥ associator.from ∘ᵥ associator.to ◁ T₁ ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ (actionʳ₂ ◁ (F₁ ∘₁ T₁) ∘ᵥ associator.from) ∘ᵥ associator.to ◁ T₁ ≈⟨ refl⟩∘⟨ ⟺ α⇒-◁-∘₁ ⟩∘⟨refl ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ (associator.from ∘ᵥ actionʳ₂ ◁ F₁ ◁ T₁) ∘ᵥ associator.to ◁ T₁ ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ associator.from ∘ᵥ actionʳ₂ ◁ F₁ ◁ T₁ ∘ᵥ associator.to ◁ T₁ ≈⟨ sym-assoc₂ ⟩
+        (F₂ ▷ actionˡ₁ ∘ᵥ associator.from) ∘ᵥ actionʳ₂ ◁ F₁ ◁ T₁ ∘ᵥ associator.to ◁ T₁ ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+        F₂▷actionˡ₁ ∘ᵥ actionʳ₂◁F₁ ◁ T₁ ∎
+        where
+          open hom.HomReasoning
+
+      assoc∘arr : (actionʳ ∘ᵥ (T₃ ▷ actionˡ) ∘ᵥ associator.from) ∘ᵥ (Coequalizer.arr [T₃∘F]∘T₁Coequalizer)
+                  ≈ (actionˡ ∘ᵥ (actionʳ ◁ T₁)) ∘ᵥ (Coequalizer.arr [T₃∘F]∘T₁Coequalizer)
+      assoc∘arr = begin
+        (actionʳ ∘ᵥ (T₃ ▷ actionˡ) ∘ᵥ associator.from) ∘ᵥ (Coequalizer.arr [T₃∘F]∘T₁Coequalizer) ≈⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+        ((actionʳ ∘ᵥ (T₃ ▷ actionˡ)) ∘ᵥ associator.from) ∘ᵥ (Coequalizer.arr [T₃∘F]∘T₁Coequalizer) ≈⟨ assoc₂ ⟩
+        (actionʳ ∘ᵥ (T₃ ▷ actionˡ)) ∘ᵥ associator.from ∘ᵥ (Coequalizer.arr [T₃∘F]∘T₁Coequalizer) ≈⟨ refl⟩∘⟨ α⇒-▷-◁ ⟩
+        (actionʳ ∘ᵥ (T₃ ▷ actionˡ)) ∘ᵥ Coequalizer.arr T₃∘[F∘T₁]Coequalizer ∘ᵥ associator.from  ≈⟨ sym-assoc₂ ⟩
+        ((actionʳ ∘ᵥ (T₃ ▷ actionˡ)) ∘ᵥ Coequalizer.arr T₃∘[F∘T₁]Coequalizer) ∘ᵥ associator.from  ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+        (actionʳ ∘ᵥ (T₃ ▷ actionˡ) ∘ᵥ Coequalizer.arr T₃∘[F∘T₁]Coequalizer) ∘ᵥ associator.from  ≈⟨ (refl⟩∘⟨ ∘ᵥ-distr-▷) ⟩∘⟨refl ⟩
+        (actionʳ ∘ᵥ T₃ ▷ (actionˡ ∘ᵥ Coequalizer.arr F∘T₁Coequalizer)) ∘ᵥ associator.from  ≈⟨ (refl⟩∘⟨ ▷-resp-≈ (⟺ actionˡSq)) ⟩∘⟨refl ⟩
+        (actionʳ ∘ᵥ T₃ ▷ (Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁)) ∘ᵥ associator.from  ≈⟨ (refl⟩∘⟨(⟺ ∘ᵥ-distr-▷)) ⟩∘⟨refl ⟩
+        (actionʳ ∘ᵥ Coequalizer.arr T₃∘FCoequalizer ∘ᵥ T₃ ▷ F₂▷actionˡ₁) ∘ᵥ associator.from  ≈⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+        ((actionʳ ∘ᵥ Coequalizer.arr T₃∘FCoequalizer) ∘ᵥ T₃ ▷ F₂▷actionˡ₁) ∘ᵥ associator.from  ≈⟨ (⟺ actionʳSq) ⟩∘⟨refl ⟩∘⟨refl ⟩
+        ((Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁) ∘ᵥ T₃ ▷ F₂▷actionˡ₁) ∘ᵥ associator.from  ≈⟨ assoc₂ ⟩
+        (Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁) ∘ᵥ T₃ ▷ F₂▷actionˡ₁ ∘ᵥ associator.from  ≈⟨ assoc₂ ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁ ∘ᵥ T₃ ▷ F₂▷actionˡ₁ ∘ᵥ associator.from  ≈⟨ refl⟩∘⟨ assoc-pentagon ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁ ∘ᵥ actionʳ₂◁F₁ ◁ T₁  ≈⟨ sym-assoc₂ ⟩
+        (Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁) ∘ᵥ actionʳ₂◁F₁ ◁ T₁  ≈⟨ actionˡSq ⟩∘⟨refl ⟩
+        (actionˡ ∘ᵥ Coequalizer.arr F∘T₁Coequalizer) ∘ᵥ actionʳ₂◁F₁ ◁ T₁  ≈⟨ assoc₂ ⟩
+        actionˡ ∘ᵥ Coequalizer.arr F∘T₁Coequalizer ∘ᵥ actionʳ₂◁F₁ ◁ T₁  ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+        actionˡ ∘ᵥ (Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁) ◁ T₁ ≈⟨ refl⟩∘⟨ ◁-resp-≈ actionʳSq ⟩
+        actionˡ ∘ᵥ (actionʳ ∘ᵥ Coequalizer.arr T₃∘FCoequalizer) ◁ T₁ ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩
+        actionˡ ∘ᵥ actionʳ ◁ T₁ ∘ᵥ Coequalizer.arr [T₃∘F]∘T₁Coequalizer ≈⟨ sym-assoc₂ ⟩
+        (actionˡ ∘ᵥ (actionʳ ◁ T₁)) ∘ᵥ (Coequalizer.arr [T₃∘F]∘T₁Coequalizer) ∎
+        where
+          open hom.HomReasoning
+    
+      assoc : actionʳ ∘ᵥ (T₃ ▷ actionˡ) ∘ᵥ associator.from ≈ actionˡ ∘ᵥ (actionʳ ◁ T₁)
+      assoc = Coequalizer⇒Epi (hom C₁ C₃) [T₃∘F]∘T₁Coequalizer
+                              (actionʳ ∘ᵥ (T₃ ▷ actionˡ) ∘ᵥ associator.from)
+                              (actionˡ ∘ᵥ (actionʳ ◁ T₁))
+                              assoc∘arr
+
+      assoc-var : (actionʳ ∘ᵥ (T₃ ▷ actionˡ)) ∘ᵥ associator.from ≈ actionˡ ∘ᵥ (actionʳ ◁ T₁)
+      assoc-var = begin
+        (actionʳ ∘ᵥ (T₃ ▷ actionˡ)) ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+        actionʳ ∘ᵥ (T₃ ▷ actionˡ) ∘ᵥ associator.from ≈⟨ assoc ⟩
+        actionˡ ∘ᵥ (actionʳ ◁ T₁) ∎
+        where
+          open hom.HomReasoning
+
+      sym-assoc : actionˡ ∘ᵥ (actionʳ ◁ T₁) ∘ᵥ associator.to ≈ actionʳ ∘ᵥ (T₃ ▷ actionˡ)
+      sym-assoc = begin
+        actionˡ ∘ᵥ (actionʳ ◁ T₁) ∘ᵥ associator.to ≈⟨ sym-assoc₂ ⟩
+        (actionˡ ∘ᵥ (actionʳ ◁ T₁)) ∘ᵥ associator.to ≈⟨ ⟺ (switch-fromtoʳ associator assoc-var) ⟩
+        actionʳ ∘ᵥ (T₃ ▷ actionˡ) ∎
+        where
+          open hom.HomReasoning
+          open import Categories.Morphism.Reasoning.Iso (hom C₁ C₃)
+
+    -- end abstarct --
+
+    --  we need that (F∘T₁)∘T₁ is a coequalizer --
+    [F∘T₁]∘T₁Coequalizer : Coequalizer (hom C₁ C₃) (((act-to-the-left) ◁ T₁) ◁ T₁) (((act-to-the-right) ◁ T₁) ◁ T₁)
+    [F∘T₁]∘T₁Coequalizer = precompCoequalizer F∘T₁Coequalizer T₁
+
+    abstract
+      assoc-actionˡ-pentagon : F₂▷actionˡ₁ ∘ᵥ (F₂ ∘₁ F₁) ▷ μ₁ ∘ᵥ associator.from ≈ F₂▷actionˡ₁ ∘ᵥ F₂▷actionˡ₁ ◁ T₁
+      assoc-actionˡ-pentagon = begin
+        F₂▷actionˡ₁ ∘ᵥ (F₂ ∘₁ F₁) ▷ μ₁ ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ associator.from ∘ᵥ (F₂ ∘₁ F₁) ▷ μ₁ ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ (associator.from ∘ᵥ (F₂ ∘₁ F₁) ▷ μ₁) ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ α⇒-▷-∘₁ ⟩∘⟨refl ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ (F₂ ▷ F₁ ▷ μ₁ ∘ᵥ associator.from) ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ F₁ ▷ μ₁ ∘ᵥ associator.from ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ pentagon ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ F₁ ▷ μ₁ ∘ᵥ F₂ ▷ associator.from ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁ ≈⟨ sym-assoc₂ ⟩
+        (F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ F₁ ▷ μ₁) ∘ᵥ F₂ ▷ associator.from ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁ ≈⟨ sym-assoc₂ ⟩
+        ((F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ F₁ ▷ μ₁) ∘ᵥ F₂ ▷ associator.from) ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁ ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+        (F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ F₁ ▷ μ₁ ∘ᵥ F₂ ▷ associator.from) ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁ ≈⟨ (refl⟩∘⟨ ∘ᵥ-distr-▷) ⟩∘⟨refl ⟩
+        (F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ (F₁ ▷ μ₁ ∘ᵥ associator.from)) ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁ ≈⟨ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+        F₂ ▷ (actionˡ₁ ∘ᵥ F₁ ▷ μ₁ ∘ᵥ associator.from) ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁ ≈⟨ ▷-resp-≈ assoc-actionˡ₁ ⟩∘⟨refl ⟩
+        F₂ ▷ (actionˡ₁ ∘ᵥ actionˡ₁ ◁ T₁) ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁ ≈⟨ ⟺ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+        (F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ (actionˡ₁ ◁ T₁)) ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁ ≈⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ (actionˡ₁ ◁ T₁) ∘ᵥ associator.from ∘ᵥ associator.from ◁ T₁ ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ (F₂ ▷ (actionˡ₁ ◁ T₁) ∘ᵥ associator.from) ∘ᵥ associator.from ◁ T₁ ≈⟨ refl⟩∘⟨ ⟺ α⇒-▷-◁ ⟩∘⟨refl ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ (associator.from ∘ᵥ (F₂ ▷ actionˡ₁) ◁ T₁) ∘ᵥ associator.from ◁ T₁ ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ associator.from ∘ᵥ (F₂ ▷ actionˡ₁) ◁ T₁ ∘ᵥ associator.from ◁ T₁ ≈⟨ sym-assoc₂ ⟩
+        (F₂ ▷ actionˡ₁ ∘ᵥ associator.from) ∘ᵥ (F₂ ▷ actionˡ₁) ◁ T₁ ∘ᵥ associator.from ◁ T₁ ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+        F₂▷actionˡ₁ ∘ᵥ F₂▷actionˡ₁ ◁ T₁ ∎
+        where
+          open hom.HomReasoning
+
+      assoc-actionˡ∘arr : (actionˡ ∘ᵥ (F ▷ μ₁) ∘ᵥ associator.from) ∘ᵥ Coequalizer.arr [F∘T₁]∘T₁Coequalizer
+                          ≈ (actionˡ ∘ᵥ (actionˡ ◁ T₁)) ∘ᵥ Coequalizer.arr [F∘T₁]∘T₁Coequalizer
+      assoc-actionˡ∘arr = begin
+        (actionˡ ∘ᵥ (F ▷ μ₁) ∘ᵥ associator.from) ∘ᵥ Coequalizer.arr [F∘T₁]∘T₁Coequalizer ≈⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+        ((actionˡ ∘ᵥ (F ▷ μ₁)) ∘ᵥ associator.from) ∘ᵥ Coequalizer.arr [F∘T₁]∘T₁Coequalizer ≈⟨ assoc₂ ⟩
+        (actionˡ ∘ᵥ (F ▷ μ₁)) ∘ᵥ associator.from ∘ᵥ Coequalizer.arr [F∘T₁]∘T₁Coequalizer ≈⟨ refl⟩∘⟨ α⇒-◁-∘₁ ⟩
+        (actionˡ ∘ᵥ (F ▷ μ₁)) ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ (T₁ ∘₁ T₁) ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+        actionˡ ∘ᵥ (F ▷ μ₁) ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ (T₁ ∘₁ T₁) ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionˡ ∘ᵥ ((F ▷ μ₁) ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ (T₁ ∘₁ T₁)) ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ ◁-▷-exchg ⟩∘⟨refl ⟩
+        actionˡ ∘ᵥ (Coequalizer.arr F₂⊗F₁ ◁ T₁ ∘ᵥ (F₂ ∘₁ F₁) ▷ μ₁) ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionˡ ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ T₁ ∘ᵥ (F₂ ∘₁ F₁) ▷ μ₁ ∘ᵥ associator.from ≈⟨ sym-assoc₂ ⟩
+        (actionˡ ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ T₁) ∘ᵥ (F₂ ∘₁ F₁) ▷ μ₁ ∘ᵥ associator.from ≈⟨ ⟺ actionˡSq ⟩∘⟨refl ⟩
+        (Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁) ∘ᵥ (F₂ ∘₁ F₁) ▷ μ₁ ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁ ∘ᵥ (F₂ ∘₁ F₁) ▷ μ₁ ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ assoc-actionˡ-pentagon ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁ ∘ᵥ F₂▷actionˡ₁ ◁ T₁ ≈⟨ sym-assoc₂ ⟩
+        (Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁) ∘ᵥ F₂▷actionˡ₁ ◁ T₁ ≈⟨ actionˡSq ⟩∘⟨refl ⟩
+        (actionˡ ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ T₁) ∘ᵥ F₂▷actionˡ₁ ◁ T₁ ≈⟨ assoc₂ ⟩
+        actionˡ ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ T₁ ∘ᵥ F₂▷actionˡ₁ ◁ T₁ ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+        actionˡ ∘ᵥ (Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁) ◁ T₁ ≈⟨ refl⟩∘⟨ ◁-resp-≈ actionˡSq ⟩
+        actionˡ ∘ᵥ (actionˡ ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ T₁) ◁ T₁ ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩
+        actionˡ ∘ᵥ (actionˡ ◁ T₁) ∘ᵥ Coequalizer.arr [F∘T₁]∘T₁Coequalizer ≈⟨ sym-assoc₂ ⟩
+        (actionˡ ∘ᵥ (actionˡ ◁ T₁)) ∘ᵥ Coequalizer.arr [F∘T₁]∘T₁Coequalizer ∎
+        where
+          open hom.HomReasoning
+
+      assoc-actionˡ : actionˡ ∘ᵥ (F ▷ μ₁) ∘ᵥ associator.from ≈ actionˡ ∘ᵥ (actionˡ ◁ T₁)
+      assoc-actionˡ = Coequalizer⇒Epi ((hom C₁ C₃)) [F∘T₁]∘T₁Coequalizer
+                                      (actionˡ ∘ᵥ (F ▷ μ₁) ∘ᵥ associator.from)
+                                      (actionˡ ∘ᵥ (actionˡ ◁ T₁))
+                                      assoc-actionˡ∘arr
+
+      assoc-actionˡ-var : (actionˡ ∘ᵥ (F ▷ μ₁)) ∘ᵥ associator.from ≈ actionˡ ∘ᵥ (actionˡ ◁ T₁)
+      assoc-actionˡ-var = begin
+        (actionˡ ∘ᵥ (F ▷ μ₁)) ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+        actionˡ ∘ᵥ (F ▷ μ₁) ∘ᵥ associator.from ≈⟨ assoc-actionˡ ⟩
+        actionˡ ∘ᵥ (actionˡ ◁ T₁) ∎
+        where
+          open hom.HomReasoning
+
+      sym-assoc-actionˡ : actionˡ ∘ᵥ (actionˡ ◁ T₁) ∘ᵥ associator.to ≈ actionˡ ∘ᵥ (F ▷ μ₁)
+      sym-assoc-actionˡ = begin
+        actionˡ ∘ᵥ (actionˡ ◁ T₁) ∘ᵥ associator.to ≈⟨ sym-assoc₂ ⟩
+        (actionˡ ∘ᵥ (actionˡ ◁ T₁)) ∘ᵥ associator.to ≈⟨ ⟺ (switch-fromtoʳ associator assoc-actionˡ-var) ⟩
+        actionˡ ∘ᵥ (F ▷ μ₁) ∎
+        where
+          open hom.HomReasoning
+          open import Categories.Morphism.Reasoning.Iso (hom C₁ C₃)
+    -- end abstract --
+
+    --  we need that T₃∘(T₃∘F) is a coequalizer --
+    T₃∘[T₃∘F]Coequalizer : Coequalizer (hom C₁ C₃) (T₃ ▷ T₃ ▷ (act-to-the-left)) (T₃ ▷ T₃ ▷ (act-to-the-right))
+    T₃∘[T₃∘F]Coequalizer = postcompCoequalizer T₃∘FCoequalizer T₃
+
+    abstract
+      assoc-actionʳ-pentagon : actionʳ₂◁F₁ ∘ᵥ μ₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ associator.to ≈ actionʳ₂◁F₁ ∘ᵥ T₃ ▷ actionʳ₂◁F₁
+      assoc-actionʳ-pentagon = begin
+        actionʳ₂◁F₁ ∘ᵥ μ₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ associator.to ≈⟨ assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ associator.to ∘ᵥ μ₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ (associator.to ∘ᵥ μ₃ ◁ (F₂ ∘₁ F₁)) ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ α⇐-◁-∘₁ ⟩∘⟨refl ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ (μ₃ ◁ F₂ ◁ F₁ ∘ᵥ associator.to) ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ μ₃ ◁ F₂ ◁ F₁ ∘ᵥ associator.to ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ pentagon-inv ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ μ₃ ◁ F₂ ◁ F₁ ∘ᵥ (associator.to ◁ F₁ ∘ᵥ associator.to) ∘ᵥ T₃ ▷ associator.to ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ μ₃ ◁ F₂ ◁ F₁ ∘ᵥ associator.to ◁ F₁ ∘ᵥ associator.to ∘ᵥ T₃ ▷ associator.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ (μ₃ ◁ F₂ ◁ F₁ ∘ᵥ associator.to ◁ F₁) ∘ᵥ associator.to ∘ᵥ T₃ ▷ associator.to ≈⟨ sym-assoc₂ ⟩
+        (actionʳ₂ ◁ F₁ ∘ᵥ μ₃ ◁ F₂ ◁ F₁ ∘ᵥ associator.to ◁ F₁) ∘ᵥ associator.to ∘ᵥ T₃ ▷ associator.to ≈⟨ (refl⟩∘⟨ ∘ᵥ-distr-◁) ⟩∘⟨refl ⟩
+        (actionʳ₂ ◁ F₁ ∘ᵥ (μ₃ ◁ F₂ ∘ᵥ associator.to) ◁ F₁) ∘ᵥ associator.to ∘ᵥ T₃ ▷ associator.to ≈⟨ ∘ᵥ-distr-◁ ⟩∘⟨refl ⟩
+        (actionʳ₂ ∘ᵥ μ₃ ◁ F₂ ∘ᵥ associator.to) ◁ F₁ ∘ᵥ associator.to ∘ᵥ T₃ ▷ associator.to ≈⟨ ◁-resp-≈ assoc-actionʳ₂ ⟩∘⟨refl ⟩
+        (actionʳ₂ ∘ᵥ T₃ ▷ actionʳ₂) ◁ F₁ ∘ᵥ associator.to ∘ᵥ T₃ ▷ associator.to ≈⟨ ⟺ ∘ᵥ-distr-◁ ⟩∘⟨refl ⟩
+        (actionʳ₂ ◁ F₁ ∘ᵥ (T₃ ▷ actionʳ₂) ◁ F₁) ∘ᵥ associator.to ∘ᵥ T₃ ▷ associator.to ≈⟨ assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ (T₃ ▷ actionʳ₂) ◁ F₁ ∘ᵥ associator.to ∘ᵥ T₃ ▷ associator.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ ((T₃ ▷ actionʳ₂) ◁ F₁ ∘ᵥ associator.to) ∘ᵥ T₃ ▷ associator.to ≈⟨ refl⟩∘⟨ ⟺ α⇐-▷-◁ ⟩∘⟨refl ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ (associator.to ∘ᵥ T₃ ▷ (actionʳ₂ ◁ F₁)) ∘ᵥ T₃ ▷ associator.to ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ associator.to ∘ᵥ T₃ ▷ (actionʳ₂ ◁ F₁) ∘ᵥ T₃ ▷ associator.to ≈⟨ sym-assoc₂ ⟩
+        actionʳ₂◁F₁ ∘ᵥ T₃ ▷ (actionʳ₂ ◁ F₁) ∘ᵥ T₃ ▷ associator.to ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+        actionʳ₂◁F₁ ∘ᵥ T₃ ▷ actionʳ₂◁F₁ ∎
+        where
+          open hom.HomReasoning
+
+      assoc-actionʳ∘arr : (actionʳ ∘ᵥ μ₃ ◁ F ∘ᵥ associator.to) ∘ᵥ Coequalizer.arr T₃∘[T₃∘F]Coequalizer
+                          ≈ (actionʳ ∘ᵥ T₃ ▷ actionʳ) ∘ᵥ Coequalizer.arr T₃∘[T₃∘F]Coequalizer
+      assoc-actionʳ∘arr = begin
+        (actionʳ ∘ᵥ μ₃ ◁ F ∘ᵥ associator.to) ∘ᵥ Coequalizer.arr T₃∘[T₃∘F]Coequalizer ≈⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+        ((actionʳ ∘ᵥ μ₃ ◁ F) ∘ᵥ associator.to) ∘ᵥ Coequalizer.arr T₃∘[T₃∘F]Coequalizer ≈⟨ assoc₂ ⟩
+        (actionʳ ∘ᵥ μ₃ ◁ F) ∘ᵥ associator.to ∘ᵥ Coequalizer.arr T₃∘[T₃∘F]Coequalizer ≈⟨ refl⟩∘⟨ α⇐-▷-∘₁ ⟩
+        (actionʳ ∘ᵥ μ₃ ◁ F) ∘ᵥ (T₃ ∘₁ T₃) ▷ Coequalizer.arr F₂⊗F₁ ∘ᵥ associator.to ≈⟨ assoc₂ ⟩
+        actionʳ ∘ᵥ μ₃ ◁ F ∘ᵥ (T₃ ∘₁ T₃) ▷ Coequalizer.arr F₂⊗F₁ ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionʳ ∘ᵥ (μ₃ ◁ F ∘ᵥ (T₃ ∘₁ T₃) ▷ Coequalizer.arr F₂⊗F₁) ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ ⟺ ◁-▷-exchg ⟩∘⟨refl ⟩
+        actionʳ ∘ᵥ (T₃ ▷ Coequalizer.arr F₂⊗F₁ ∘ᵥ μ₃ ◁ (F₂ ∘₁ F₁)) ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionʳ ∘ᵥ T₃ ▷ Coequalizer.arr F₂⊗F₁ ∘ᵥ μ₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ associator.to ≈⟨ sym-assoc₂ ⟩
+        (actionʳ ∘ᵥ T₃ ▷ Coequalizer.arr F₂⊗F₁) ∘ᵥ μ₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ associator.to ≈⟨ ⟺ actionʳSq ⟩∘⟨refl ⟩
+        (Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁) ∘ᵥ μ₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ associator.to ≈⟨ assoc₂ ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁ ∘ᵥ μ₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ assoc-actionʳ-pentagon ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁ ∘ᵥ T₃ ▷ actionʳ₂◁F₁ ≈⟨ sym-assoc₂ ⟩
+        (Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁) ∘ᵥ T₃ ▷ actionʳ₂◁F₁ ≈⟨ actionʳSq ⟩∘⟨refl ⟩
+        (actionʳ ∘ᵥ T₃ ▷ Coequalizer.arr F₂⊗F₁) ∘ᵥ T₃ ▷ actionʳ₂◁F₁ ≈⟨ assoc₂ ⟩
+        actionʳ ∘ᵥ T₃ ▷ Coequalizer.arr F₂⊗F₁ ∘ᵥ T₃ ▷ actionʳ₂◁F₁ ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+        actionʳ ∘ᵥ T₃ ▷ (Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁) ≈⟨ refl⟩∘⟨ ▷-resp-≈ actionʳSq ⟩
+        actionʳ ∘ᵥ T₃ ▷ (actionʳ ∘ᵥ T₃ ▷ Coequalizer.arr F₂⊗F₁) ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-▷ ⟩
+        actionʳ ∘ᵥ T₃ ▷ actionʳ ∘ᵥ Coequalizer.arr T₃∘[T₃∘F]Coequalizer ≈⟨ sym-assoc₂ ⟩
+        (actionʳ ∘ᵥ T₃ ▷ actionʳ) ∘ᵥ Coequalizer.arr T₃∘[T₃∘F]Coequalizer ∎
+        where
+          open hom.HomReasoning
+
+      assoc-actionʳ : actionʳ ∘ᵥ μ₃ ◁ F ∘ᵥ associator.to ≈ actionʳ ∘ᵥ T₃ ▷ actionʳ
+      assoc-actionʳ = Coequalizer⇒Epi (hom C₁ C₃) T₃∘[T₃∘F]Coequalizer
+                                      (actionʳ ∘ᵥ μ₃ ◁ F ∘ᵥ associator.to)
+                                      (actionʳ ∘ᵥ T₃ ▷ actionʳ)
+                                      assoc-actionʳ∘arr
+
+      assoc-actionʳ-var : (actionʳ ∘ᵥ μ₃ ◁ F) ∘ᵥ associator.to ≈ actionʳ ∘ᵥ T₃ ▷ actionʳ
+      assoc-actionʳ-var = begin
+        (actionʳ ∘ᵥ μ₃ ◁ F) ∘ᵥ associator.to ≈⟨ assoc₂ ⟩
+        actionʳ ∘ᵥ μ₃ ◁ F ∘ᵥ associator.to ≈⟨ assoc-actionʳ ⟩
+        actionʳ ∘ᵥ T₃ ▷ actionʳ ∎
+        where
+          open hom.HomReasoning
+
+      sym-assoc-actionʳ : actionʳ ∘ᵥ T₃ ▷ actionʳ ∘ᵥ associator.from ≈ actionʳ ∘ᵥ μ₃ ◁ F
+      sym-assoc-actionʳ = begin
+        actionʳ ∘ᵥ T₃ ▷ actionʳ ∘ᵥ associator.from ≈⟨ sym-assoc₂ ⟩
+        (actionʳ ∘ᵥ T₃ ▷ actionʳ) ∘ᵥ associator.from ≈⟨ ⟺ (switch-tofromʳ associator assoc-actionʳ-var) ⟩
+        actionʳ ∘ᵥ μ₃ ◁ F ∎
+        where
+          open hom.HomReasoning
+          open import Categories.Morphism.Reasoning.Iso (hom C₁ C₃)
+    -- end abstract --
+
+  module Identity where
+    open Left-Action using (actionˡ; actionˡSq; F₂▷actionˡ₁; F∘T₁Coequalizer)
+    open Right-Action using (actionʳ; actionʳSq; actionʳ₂◁F₁; T₃∘FCoequalizer)
+
+    abstract
+      identityˡ-triangle : F₂▷actionˡ₁ ∘ᵥ (F₂ ∘₁ F₁) ▷ η₁ ∘ᵥ unitorʳ.to ≈ id₂
+      identityˡ-triangle = begin
+        F₂▷actionˡ₁ ∘ᵥ (F₂ ∘₁ F₁) ▷ η₁ ∘ᵥ unitorʳ.to ≈⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ associator.from ∘ᵥ (F₂ ∘₁ F₁) ▷ η₁ ∘ᵥ unitorʳ.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ (associator.from ∘ᵥ (F₂ ∘₁ F₁) ▷ η₁) ∘ᵥ unitorʳ.to ≈⟨ refl⟩∘⟨ α⇒-▷-∘₁ ⟩∘⟨refl ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ (F₂ ▷ F₁ ▷ η₁ ∘ᵥ associator.from) ∘ᵥ unitorʳ.to ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ F₁ ▷ η₁ ∘ᵥ associator.from ∘ᵥ unitorʳ.to ≈⟨ (refl⟩∘⟨ refl⟩∘⟨ ⟺ unitorʳ-coherence-var₂) ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ F₁ ▷ η₁ ∘ᵥ F₂ ▷ unitorʳ.to ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+        F₂ ▷ actionˡ₁ ∘ᵥ F₂ ▷ (F₁ ▷ η₁ ∘ᵥ unitorʳ.to) ≈⟨ ∘ᵥ-distr-▷ ⟩
+        F₂ ▷ (actionˡ₁ ∘ᵥ F₁ ▷ η₁ ∘ᵥ unitorʳ.to) ≈⟨ ▷-resp-≈ identityˡ₁ ⟩
+        F₂ ▷ id₂ ≈⟨ ▷id₂ ⟩
+        id₂ ∎
+        where
+          open hom.HomReasoning
+
+      identityˡ∘arr : (actionˡ ∘ᵥ F ▷ η₁ ∘ᵥ unitorʳ.to) ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈ id₂ ∘ᵥ Coequalizer.arr F₂⊗F₁
+      identityˡ∘arr = begin
+        (actionˡ ∘ᵥ F ▷ η₁ ∘ᵥ unitorʳ.to) ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈⟨ assoc₂ ⟩
+        actionˡ ∘ᵥ (F ▷ η₁ ∘ᵥ unitorʳ.to) ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionˡ ∘ᵥ F ▷ η₁ ∘ᵥ unitorʳ.to ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ ◁-∘ᵥ-ρ⇐ ⟩
+        actionˡ ∘ᵥ F ▷ η₁ ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ id₁ ∘ᵥ unitorʳ.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionˡ ∘ᵥ (F ▷ η₁ ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ id₁) ∘ᵥ unitorʳ.to ≈⟨ refl⟩∘⟨ ◁-▷-exchg ⟩∘⟨refl ⟩
+        actionˡ ∘ᵥ (Coequalizer.arr F₂⊗F₁ ◁ T₁ ∘ᵥ (F₂ ∘₁ F₁) ▷ η₁) ∘ᵥ unitorʳ.to ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionˡ ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ T₁ ∘ᵥ (F₂ ∘₁ F₁) ▷ η₁ ∘ᵥ unitorʳ.to ≈⟨ sym-assoc₂ ⟩
+        (actionˡ ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ T₁) ∘ᵥ (F₂ ∘₁ F₁) ▷ η₁ ∘ᵥ unitorʳ.to ≈⟨ ⟺ actionˡSq ⟩∘⟨refl ⟩
+        (Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁) ∘ᵥ (F₂ ∘₁ F₁) ▷ η₁ ∘ᵥ unitorʳ.to ≈⟨ assoc₂ ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁ ∘ᵥ (F₂ ∘₁ F₁) ▷ η₁ ∘ᵥ unitorʳ.to ≈⟨ refl⟩∘⟨ identityˡ-triangle ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ id₂ ≈⟨ identity₂ʳ ⟩
+        Coequalizer.arr F₂⊗F₁ ≈⟨ ⟺ identity₂ˡ ⟩
+        id₂ ∘ᵥ Coequalizer.arr F₂⊗F₁ ∎
+        where
+          open hom.HomReasoning
+
+      identityˡ : actionˡ ∘ᵥ F ▷ η₁ ∘ᵥ unitorʳ.to ≈ id₂
+      identityˡ = Coequalizer⇒Epi (hom C₁ C₃) F₂⊗F₁ (actionˡ ∘ᵥ F ▷ η₁ ∘ᵥ unitorʳ.to) id₂ identityˡ∘arr
+
+
+      identityʳ-triangle : actionʳ₂◁F₁ ∘ᵥ η₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ unitorˡ.to ≈ id₂
+      identityʳ-triangle = begin
+        actionʳ₂◁F₁ ∘ᵥ η₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ unitorˡ.to ≈⟨ assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ associator.to ∘ᵥ η₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ unitorˡ.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ (associator.to ∘ᵥ η₃ ◁ (F₂ ∘₁ F₁)) ∘ᵥ unitorˡ.to ≈⟨ refl⟩∘⟨ α⇐-◁-∘₁ ⟩∘⟨refl ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ (η₃ ◁ F₂ ◁ F₁ ∘ᵥ associator.to) ∘ᵥ unitorˡ.to ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ η₃ ◁ F₂ ◁ F₁ ∘ᵥ associator.to ∘ᵥ unitorˡ.to ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ unitorˡ-coherence-inv ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ η₃ ◁ F₂ ◁ F₁ ∘ᵥ unitorˡ.to ◁ F₁ ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+        actionʳ₂ ◁ F₁ ∘ᵥ (η₃ ◁ F₂ ∘ᵥ unitorˡ.to) ◁ F₁ ≈⟨ ∘ᵥ-distr-◁ ⟩
+        (actionʳ₂ ∘ᵥ η₃ ◁ F₂ ∘ᵥ unitorˡ.to) ◁ F₁ ≈⟨ ◁-resp-≈ identityʳ₂ ⟩
+        id₂ ◁ F₁ ≈⟨ id₂◁ ⟩
+        id₂ ∎
+        where
+          open hom.HomReasoning
+
+      identityʳ∘arr : (actionʳ ∘ᵥ η₃ ◁ F ∘ᵥ unitorˡ.to) ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈ id₂ ∘ᵥ Coequalizer.arr F₂⊗F₁
+      identityʳ∘arr = begin
+        (actionʳ ∘ᵥ η₃ ◁ F ∘ᵥ unitorˡ.to) ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈⟨ assoc₂ ⟩
+        actionʳ ∘ᵥ (η₃ ◁ F ∘ᵥ unitorˡ.to) ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionʳ ∘ᵥ η₃ ◁ F ∘ᵥ unitorˡ.to ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ ▷-∘ᵥ-λ⇐ ⟩
+        actionʳ ∘ᵥ η₃ ◁ F ∘ᵥ id₁ ▷ Coequalizer.arr F₂⊗F₁ ∘ᵥ unitorˡ.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionʳ ∘ᵥ (η₃ ◁ F ∘ᵥ id₁ ▷ Coequalizer.arr F₂⊗F₁) ∘ᵥ unitorˡ.to ≈⟨ refl⟩∘⟨ ⟺ ◁-▷-exchg ⟩∘⟨refl ⟩
+        actionʳ ∘ᵥ (T₃ ▷ Coequalizer.arr F₂⊗F₁ ∘ᵥ η₃ ◁ (F₂ ∘₁ F₁)) ∘ᵥ unitorˡ.to ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionʳ ∘ᵥ T₃ ▷ Coequalizer.arr F₂⊗F₁ ∘ᵥ η₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ unitorˡ.to ≈⟨ sym-assoc₂ ⟩
+        (actionʳ ∘ᵥ T₃ ▷ Coequalizer.arr F₂⊗F₁) ∘ᵥ η₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ unitorˡ.to ≈⟨ ⟺ actionʳSq ⟩∘⟨refl ⟩
+        (Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁) ∘ᵥ η₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ unitorˡ.to ≈⟨ assoc₂ ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁ ∘ᵥ η₃ ◁ (F₂ ∘₁ F₁) ∘ᵥ unitorˡ.to ≈⟨ refl⟩∘⟨ identityʳ-triangle ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ id₂ ≈⟨ identity₂ʳ ⟩
+        Coequalizer.arr F₂⊗F₁ ≈⟨ ⟺ identity₂ˡ ⟩
+        id₂ ∘ᵥ Coequalizer.arr F₂⊗F₁ ∎
+        where
+          open hom.HomReasoning
+
+      identityʳ : actionʳ ∘ᵥ (η₃ ◁ F) ∘ᵥ unitorˡ.to ≈ id₂
+      identityʳ = Coequalizer⇒Epi (hom C₁ C₃) F₂⊗F₁ (actionʳ ∘ᵥ (η₃ ◁ F) ∘ᵥ unitorˡ.to) id₂ identityʳ∘arr
+    -- end abstract --
+
+  B₂⊗B₁ : Bimodule M₁ M₃
+  B₂⊗B₁ = record
+    { F = F
+    ; actionˡ = Left-Action.actionˡ --: F ∘₁ T₁ ⇒₂ F  
+    ; actionʳ = Right-Action.actionʳ --: T₂ ∘₁ F ⇒₂ F 
+    ; assoc = Associativity.assoc    -- : actionʳ ∘ᵥ (T₂ ▷ actionˡ) ∘ᵥ associator.from ≈ actionˡ ∘ᵥ (actionʳ ◁ T₁)
+    ; sym-assoc = Associativity.sym-assoc --: actionˡ ∘ᵥ (actionʳ ◁ T₁)∘ᵥ associator.to ≈ actionʳ ∘ᵥ (T₂ ▷ actionˡ)
+    ; assoc-actionˡ = Associativity.assoc-actionˡ     --: actionˡ ∘ᵥ (F ▷ μ₁) ∘ᵥ associator.from ≈ actionˡ ∘ᵥ (actionˡ ◁ T₁)
+    ; sym-assoc-actionˡ = Associativity.sym-assoc-actionˡ --: actionˡ ∘ᵥ (actionˡ ◁ T₁) ∘ᵥ associator.to ≈ actionˡ ∘ᵥ (F ▷ μ₁)
+    ; assoc-actionʳ = Associativity.assoc-actionʳ     --: actionʳ ∘ᵥ (μ₂ ◁ F) ∘ᵥ associator.to ≈ actionʳ ∘ᵥ (T₂ ▷ actionʳ)
+    ; sym-assoc-actionʳ = Associativity.sym-assoc-actionʳ --: actionʳ ∘ᵥ (T₂ ▷ actionʳ) ∘ᵥ associator.from ≈ actionʳ ∘ᵥ (μ₂ ◁ F)
+    ; identityˡ = Identity.identityˡ --: actionˡ ∘ᵥ (F ▷ η₁) ∘ᵥ unitorʳ.to ≈ id₂
+    ; identityʳ = Identity.identityʳ --: actionʳ ∘ᵥ (η₂ ◁ F) ∘ᵥ unitorˡ.to ≈ id₂
+    }
+
+
+
+module TensorproductOfHomomorphisms {M₁ M₂ M₃ : Monad 𝒞} {B₂ B'₂ : Bimodule M₂ M₃} {B₁ B'₁ : Bimodule M₁ M₂}
+                                    (h₂ : Bimodulehomomorphism B₂ B'₂) (h₁ : Bimodulehomomorphism B₁ B'₁) where
+  open Monad M₁ using () renaming (C to C₁; T to T₁; μ to μ₁; η to η₁)
+  open Monad M₂ using () renaming (C to C₂; T to T₂; μ to μ₂; η to η₂)
+  open Monad M₃ using () renaming (C to C₃; T to T₃; μ to μ₃; η to η₃)
+  open Bimodule B₁ using () renaming (F to F₁; actionʳ to actionʳ₁; actionˡ to actionˡ₁)
+  open Bimodule B'₁ using () renaming (F to F'₁; actionʳ to actionʳ'₁; actionˡ to actionˡ'₁)
+  open Bimodule B₂ using () renaming (F to F₂; actionʳ to actionʳ₂; actionˡ to actionˡ₂)
+  open Bimodule B'₂ using () renaming (F to F'₂; actionʳ to actionʳ'₂; actionˡ to actionˡ'₂)
+  open TensorproductOfBimodules B₂ B₁ using (B₂⊗B₁; F₂⊗F₁; act-to-the-left; act-to-the-right)
+  open TensorproductOfBimodules B'₂ B'₁ using ()
+    renaming (B₂⊗B₁ to B'₂⊗B'₁; F₂⊗F₁ to F'₂⊗F'₁; act-to-the-left to act-to-the-left'; act-to-the-right to act-to-the-right')
+  open Bimodule B₂⊗B₁ using (F; actionˡ; actionʳ)
+  open Bimodule B'₂⊗B'₁ using () renaming (F to F'; actionˡ to actionˡ'; actionʳ to actionʳ')
+  open Bimodulehomomorphism h₁ using () renaming (α to α₁; linearˡ to linearˡ₁; linearʳ to linearʳ₁)
+  open Bimodulehomomorphism h₂ using () renaming (α to α₂; linearˡ to linearˡ₂; linearʳ to linearʳ₂)
+
+  open Definitions (hom C₁ C₃) -- for Commutative Squares
+
+  sq₁ : CommutativeSquare (α₂ ⊚₁ id₂ ⊚₁ α₁)
+                          (act-to-the-left)
+                          (act-to-the-left')
+                          (α₂ ⊚₁ α₁)
+  sq₁ = begin
+    act-to-the-left' ∘ᵥ α₂ ⊚₁ id₂ ⊚₁ α₁ ≈⟨ ⟺ ∘ᵥ-distr-⊚ ⟩
+    (id₂ ∘ᵥ α₂) ⊚₁ (actionʳ'₁ ∘ᵥ id₂ ⊚₁ α₁) ≈⟨ identity₂ˡ ⟩⊚⟨ linearʳ₁ ⟩
+    α₂ ⊚₁ (α₁ ∘ᵥ actionʳ₁) ≈⟨ ⟺ identity₂ʳ ⟩⊚⟨refl ⟩
+    (α₂ ∘ᵥ id₂) ⊚₁ (α₁ ∘ᵥ actionʳ₁) ≈⟨ ∘ᵥ-distr-⊚ ⟩
+    α₂ ⊚₁ α₁ ∘ᵥ act-to-the-left ∎
+    where
+      open hom.HomReasoning
+
+  sq₂ : CommutativeSquare (α₂ ⊚₁ id₂ ⊚₁ α₁)
+                          (act-to-the-right)
+                          (act-to-the-right')
+                          (α₂ ⊚₁ α₁)
+  sq₂ = begin
+    act-to-the-right' ∘ᵥ α₂ ⊚₁ id₂ ⊚₁ α₁ ≈⟨ assoc₂ ⟩
+    actionˡ'₂ ◁ F'₁ ∘ᵥ associator.to ∘ᵥ α₂ ⊚₁ id₂ ⊚₁ α₁ ≈⟨ refl⟩∘⟨ α⇐-⊚ ⟩
+    actionˡ'₂ ◁ F'₁ ∘ᵥ (α₂ ⊚₁ id₂) ⊚₁ α₁ ∘ᵥ associator.to ≈⟨ sym-assoc₂ ⟩
+    (actionˡ'₂ ◁ F'₁ ∘ᵥ (α₂ ⊚₁ id₂) ⊚₁ α₁) ∘ᵥ associator.to ≈⟨ ⟺ ∘ᵥ-distr-⊚ ⟩∘⟨refl ⟩
+    ((actionˡ'₂ ∘ᵥ (α₂ ⊚₁ id₂)) ⊚₁ (id₂ ∘ᵥ α₁)) ∘ᵥ associator.to ≈⟨ linearˡ₂ ⟩⊚⟨refl ⟩∘⟨refl ⟩
+    ((α₂ ∘ᵥ actionˡ₂) ⊚₁ (id₂ ∘ᵥ α₁)) ∘ᵥ associator.to ≈⟨ refl⟩⊚⟨ identity₂ˡ ⟩∘⟨refl ⟩
+    ((α₂ ∘ᵥ actionˡ₂) ⊚₁ α₁) ∘ᵥ associator.to ≈⟨ refl⟩⊚⟨ ⟺ identity₂ʳ ⟩∘⟨refl ⟩
+    ((α₂ ∘ᵥ actionˡ₂) ⊚₁ (α₁ ∘ᵥ id₂)) ∘ᵥ associator.to ≈⟨ ∘ᵥ-distr-⊚ ⟩∘⟨refl ⟩
+    (α₂ ⊚₁ α₁ ∘ᵥ actionˡ₂ ◁ F₁) ∘ᵥ associator.to ≈⟨ assoc₂ ⟩
+    α₂ ⊚₁ α₁ ∘ᵥ act-to-the-right ∎
+    where
+      open hom.HomReasoning
+
+  α : F ⇒₂ F'
+  α = ⇒MapBetweenCoeq (α₂ ⊚₁ id₂ ⊚₁  α₁) (α₂ ⊚₁ α₁) sq₁ sq₂ F₂⊗F₁ F'₂⊗F'₁
+    where
+      open CoeqProperties (hom C₁ C₃)
+
+  αSq : CommutativeSquare (α₂ ⊚₁ α₁) (Coequalizer.arr F₂⊗F₁) (Coequalizer.arr F'₂⊗F'₁) α
+  αSq = ⇒MapBetweenCoeqSq (α₂ ⊚₁ id₂ ⊚₁  α₁) (α₂ ⊚₁ α₁) sq₁ sq₂ F₂⊗F₁ F'₂⊗F'₁
+    where
+      open CoeqProperties (hom C₁ C₃)
+
+  open TensorproductOfBimodules.Left-Action B₂ B₁ using (F∘T₁Coequalizer; F₂▷actionˡ₁; actionˡSq)
+  open TensorproductOfBimodules.Left-Action B'₂ B'₁ using ()
+    renaming (F₂▷actionˡ₁ to F'₂▷actionˡ'₁; actionˡSq to actionˡ'Sq)
+
+  linearˡ-square :  F'₂▷actionˡ'₁ ∘ᵥ (α₂ ⊚₁ α₁) ◁ T₁ ≈ (α₂ ⊚₁ α₁) ∘ᵥ F₂▷actionˡ₁
+  linearˡ-square = begin
+    F'₂▷actionˡ'₁ ∘ᵥ (α₂ ⊚₁ α₁) ◁ T₁ ≈⟨ assoc₂ ⟩
+    F'₂ ▷ actionˡ'₁ ∘ᵥ associator.from ∘ᵥ (α₂ ⊚₁ α₁) ◁ T₁ ≈⟨ refl⟩∘⟨ α⇒-⊚ ⟩
+    F'₂ ▷ actionˡ'₁ ∘ᵥ α₂ ⊚₁ (α₁ ◁ T₁) ∘ᵥ associator.from ≈⟨ sym-assoc₂ ⟩
+    (F'₂ ▷ actionˡ'₁ ∘ᵥ α₂ ⊚₁ (α₁ ◁ T₁)) ∘ᵥ associator.from ≈⟨ ⟺ ∘ᵥ-distr-⊚ ⟩∘⟨refl ⟩
+    ((id₂ ∘ᵥ α₂) ⊚₁ (actionˡ'₁ ∘ᵥ α₁ ◁ T₁)) ∘ᵥ associator.from ≈⟨ identity₂ˡ ⟩⊚⟨ linearˡ₁ ⟩∘⟨refl ⟩
+    (α₂ ⊚₁ (α₁ ∘ᵥ actionˡ₁)) ∘ᵥ associator.from ≈⟨ ⟺ identity₂ʳ ⟩⊚⟨refl ⟩∘⟨refl ⟩
+    ((α₂ ∘ᵥ id₂) ⊚₁ (α₁ ∘ᵥ actionˡ₁)) ∘ᵥ associator.from ≈⟨ ∘ᵥ-distr-⊚ ⟩∘⟨refl ⟩
+    ((α₂ ⊚₁ α₁) ∘ᵥ F₂ ▷ actionˡ₁) ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+    (α₂ ⊚₁ α₁) ∘ᵥ F₂▷actionˡ₁ ∎
+    where
+      open hom.HomReasoning
+
+  linearˡ∘arr : (actionˡ' ∘ᵥ α ◁ T₁) ∘ᵥ Coequalizer.arr F∘T₁Coequalizer
+                ≈ (α ∘ᵥ actionˡ) ∘ᵥ Coequalizer.arr F∘T₁Coequalizer
+  linearˡ∘arr = begin
+    (actionˡ' ∘ᵥ α ◁ T₁) ∘ᵥ Coequalizer.arr F∘T₁Coequalizer ≈⟨ assoc₂ ⟩
+    actionˡ' ∘ᵥ α ◁ T₁ ∘ᵥ Coequalizer.arr F∘T₁Coequalizer ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+    actionˡ' ∘ᵥ (α ∘ᵥ Coequalizer.arr F₂⊗F₁) ◁ T₁ ≈⟨ refl⟩∘⟨ ◁-resp-≈ (⟺ αSq) ⟩
+    actionˡ' ∘ᵥ (Coequalizer.arr F'₂⊗F'₁ ∘ᵥ (α₂ ⊚₁ α₁)) ◁ T₁ ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩
+    actionˡ' ∘ᵥ Coequalizer.arr F'₂⊗F'₁ ◁ T₁ ∘ᵥ (α₂ ⊚₁ α₁) ◁ T₁ ≈⟨ sym-assoc₂ ⟩
+    (actionˡ' ∘ᵥ Coequalizer.arr F'₂⊗F'₁ ◁ T₁) ∘ᵥ (α₂ ⊚₁ α₁) ◁ T₁ ≈⟨ ⟺ actionˡ'Sq ⟩∘⟨refl ⟩
+    (Coequalizer.arr F'₂⊗F'₁ ∘ᵥ F'₂▷actionˡ'₁) ∘ᵥ (α₂ ⊚₁ α₁) ◁ T₁ ≈⟨ assoc₂ ⟩
+    Coequalizer.arr F'₂⊗F'₁ ∘ᵥ F'₂▷actionˡ'₁ ∘ᵥ (α₂ ⊚₁ α₁) ◁ T₁ ≈⟨ refl⟩∘⟨ linearˡ-square ⟩
+    Coequalizer.arr F'₂⊗F'₁ ∘ᵥ (α₂ ⊚₁ α₁) ∘ᵥ F₂▷actionˡ₁ ≈⟨ sym-assoc₂ ⟩
+    (Coequalizer.arr F'₂⊗F'₁ ∘ᵥ (α₂ ⊚₁ α₁)) ∘ᵥ F₂▷actionˡ₁ ≈⟨ αSq ⟩∘⟨refl ⟩
+    (α ∘ᵥ Coequalizer.arr F₂⊗F₁) ∘ᵥ F₂▷actionˡ₁ ≈⟨ assoc₂ ⟩
+    α ∘ᵥ Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂▷actionˡ₁ ≈⟨ refl⟩∘⟨ actionˡSq ⟩
+    α ∘ᵥ actionˡ ∘ᵥ Coequalizer.arr F∘T₁Coequalizer ≈⟨ sym-assoc₂ ⟩
+    (α ∘ᵥ actionˡ) ∘ᵥ Coequalizer.arr F∘T₁Coequalizer ∎
+    where
+      open hom.HomReasoning
+
+  linearˡ : actionˡ' ∘ᵥ α ◁ T₁ ≈ α ∘ᵥ actionˡ
+  linearˡ = Coequalizer⇒Epi (hom C₁ C₃) F∘T₁Coequalizer
+                            (actionˡ' ∘ᵥ α ◁ T₁) (α ∘ᵥ actionˡ)
+                            linearˡ∘arr
+
+
+  open TensorproductOfBimodules.Right-Action B₂ B₁ using (T₃∘FCoequalizer; actionʳ₂◁F₁; actionʳSq)
+  open TensorproductOfBimodules.Right-Action B'₂ B'₁ using () renaming (actionʳ₂◁F₁ to actionʳ'₂◁F'₁; actionʳSq to actionʳ'Sq)
+
+  linearʳ-square : actionʳ'₂◁F'₁ ∘ᵥ T₃ ▷ (α₂ ⊚₁ α₁) ≈ (α₂ ⊚₁ α₁) ∘ᵥ actionʳ₂◁F₁
+  linearʳ-square = begin
+    actionʳ'₂◁F'₁ ∘ᵥ T₃ ▷ (α₂ ⊚₁ α₁) ≈⟨ assoc₂ ⟩
+    actionʳ'₂ ◁ F'₁ ∘ᵥ associator.to ∘ᵥ T₃ ▷ (α₂ ⊚₁ α₁) ≈⟨ refl⟩∘⟨ α⇐-⊚ ⟩
+    actionʳ'₂ ◁ F'₁ ∘ᵥ ((T₃ ▷ α₂) ⊚₁ α₁) ∘ᵥ associator.to ≈⟨ sym-assoc₂ ⟩
+    (actionʳ'₂ ◁ F'₁ ∘ᵥ ((T₃ ▷ α₂) ⊚₁ α₁)) ∘ᵥ associator.to ≈⟨ ⟺ ∘ᵥ-distr-⊚ ⟩∘⟨refl ⟩
+    ((actionʳ'₂ ∘ᵥ T₃ ▷ α₂) ⊚₁ (id₂ ∘ᵥ α₁)) ∘ᵥ associator.to ≈⟨ linearʳ₂ ⟩⊚⟨ identity₂ˡ ⟩∘⟨refl ⟩
+    ((α₂ ∘ᵥ actionʳ₂) ⊚₁ α₁) ∘ᵥ associator.to ≈⟨ refl⟩⊚⟨ ⟺ identity₂ʳ ⟩∘⟨refl ⟩
+    ((α₂ ∘ᵥ actionʳ₂) ⊚₁ (α₁ ∘ᵥ id₂)) ∘ᵥ associator.to ≈⟨ ∘ᵥ-distr-⊚ ⟩∘⟨refl ⟩
+    ((α₂ ⊚₁ α₁) ∘ᵥ actionʳ₂ ◁ F₁) ∘ᵥ associator.to ≈⟨ assoc₂ ⟩
+    (α₂ ⊚₁ α₁) ∘ᵥ actionʳ₂◁F₁ ∎
+    where
+      open hom.HomReasoning
+
+  linearʳ∘arr : (actionʳ' ∘ᵥ T₃ ▷ α) ∘ᵥ Coequalizer.arr T₃∘FCoequalizer ≈ (α ∘ᵥ actionʳ) ∘ᵥ Coequalizer.arr T₃∘FCoequalizer
+  linearʳ∘arr = begin
+    (actionʳ' ∘ᵥ T₃ ▷ α) ∘ᵥ Coequalizer.arr T₃∘FCoequalizer ≈⟨ assoc₂ ⟩
+    actionʳ' ∘ᵥ T₃ ▷ α ∘ᵥ Coequalizer.arr T₃∘FCoequalizer ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+    actionʳ' ∘ᵥ T₃ ▷ (α ∘ᵥ Coequalizer.arr F₂⊗F₁) ≈⟨ refl⟩∘⟨ ▷-resp-≈ (⟺ αSq) ⟩
+    actionʳ' ∘ᵥ T₃ ▷ (Coequalizer.arr F'₂⊗F'₁ ∘ᵥ (α₂ ⊚₁ α₁)) ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-▷ ⟩
+    actionʳ' ∘ᵥ T₃ ▷ Coequalizer.arr F'₂⊗F'₁ ∘ᵥ T₃ ▷ (α₂ ⊚₁ α₁) ≈⟨ sym-assoc₂ ⟩
+    (actionʳ' ∘ᵥ T₃ ▷ Coequalizer.arr F'₂⊗F'₁) ∘ᵥ T₃ ▷ (α₂ ⊚₁ α₁) ≈⟨ ⟺ actionʳ'Sq ⟩∘⟨refl ⟩
+    (Coequalizer.arr F'₂⊗F'₁ ∘ᵥ actionʳ'₂◁F'₁) ∘ᵥ T₃ ▷ (α₂ ⊚₁ α₁) ≈⟨ assoc₂ ⟩
+    Coequalizer.arr F'₂⊗F'₁ ∘ᵥ actionʳ'₂◁F'₁ ∘ᵥ T₃ ▷ (α₂ ⊚₁ α₁) ≈⟨ refl⟩∘⟨ linearʳ-square ⟩
+    Coequalizer.arr F'₂⊗F'₁ ∘ᵥ (α₂ ⊚₁ α₁) ∘ᵥ actionʳ₂◁F₁ ≈⟨ sym-assoc₂ ⟩
+    (Coequalizer.arr F'₂⊗F'₁ ∘ᵥ (α₂ ⊚₁ α₁)) ∘ᵥ actionʳ₂◁F₁ ≈⟨ αSq ⟩∘⟨refl ⟩
+    (α ∘ᵥ Coequalizer.arr F₂⊗F₁) ∘ᵥ actionʳ₂◁F₁ ≈⟨ assoc₂ ⟩
+    α ∘ᵥ Coequalizer.arr F₂⊗F₁ ∘ᵥ actionʳ₂◁F₁ ≈⟨ refl⟩∘⟨ actionʳSq ⟩
+    α ∘ᵥ actionʳ ∘ᵥ Coequalizer.arr T₃∘FCoequalizer ≈⟨ sym-assoc₂ ⟩
+    (α ∘ᵥ actionʳ) ∘ᵥ Coequalizer.arr T₃∘FCoequalizer ∎
+    where
+      open hom.HomReasoning
+
+  linearʳ : actionʳ' ∘ᵥ T₃ ▷ α ≈ α ∘ᵥ actionʳ
+  linearʳ = Coequalizer⇒Epi (hom C₁ C₃) T₃∘FCoequalizer
+                            (actionʳ' ∘ᵥ T₃ ▷ α) (α ∘ᵥ actionʳ)
+                            linearʳ∘arr
+
+  h₂⊗h₁ : Bimodulehomomorphism B₂⊗B₁ B'₂⊗B'₁
+  h₂⊗h₁ = record
+    { α = α
+    ; linearˡ = linearˡ
+    ; linearʳ = linearʳ
+    }

--- a/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Associator.agda
+++ b/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Associator.agda
@@ -1,0 +1,1118 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+
+open import Categories.Bicategory
+open import Categories.Bicategory.LocalCoequalizers
+
+open import Categories.Bicategory.Monad
+open import Categories.Bicategory.Monad.Bimodule
+
+
+-- We will define the associator in the bicategory of monads and bimodules. --
+
+module Categories.Bicategory.Construction.Bimodules.Tensorproduct.Associator
+  {o ℓ e t} {𝒞 : Bicategory o ℓ e t} {localCoeq : LocalCoequalizers 𝒞} {M₁ M₂ M₃ M₄ : Monad 𝒞}
+  {B₃ : Bimodule M₃ M₄} {B₂ : Bimodule M₂ M₃} {B₁ : Bimodule M₁ M₂} where
+
+import Categories.Bicategory.LocalCoequalizers
+open LocalCoequalizers localCoeq
+open import Categories.Bicategory.Construction.Bimodules.Tensorproduct {o} {ℓ} {e} {t} {𝒞} {localCoeq}
+private
+  _⊗₀_ = TensorproductOfBimodules.B₂⊗B₁
+  _⊗₁_ = TensorproductOfHomomorphisms.h₂⊗h₁
+
+infixr 30 _⊗₀_ _⊗₁_
+
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+import Categories.Diagram.Coequalizer
+import Categories.Diagram.Coequalizer.Properties
+import Categories.Morphism
+import Categories.Category
+import Categories.Category.Construction.Core
+
+-- To get constructions of the hom-categories with implicit arguments into scope --
+private
+  module HomCat {X} {Y} where
+    open Categories.Morphism (hom X Y) public using (_≅_)
+    open Categories.Category.Definitions (hom X Y) public using (CommutativeSquare)
+    open Categories.Diagram.Coequalizer (hom X Y) public
+    open Categories.Diagram.Coequalizer.Properties (hom X Y) public
+    open CoequalizerOfCoequalizer using (CoeqsAreIsomorphic) public
+    open Categories.Category.Construction.Core.Shorthands (hom X Y) using (_∘ᵢ_; _⁻¹) public
+
+open HomCat
+
+
+  
+open Monad M₁ using () renaming (C to C₁; T to T₁)
+open Monad M₂ using () renaming (C to C₂; T to T₂)
+open Monad M₃ using () renaming (C to C₃; T to T₃)
+open Monad M₄ using () renaming (C to C₄; T to T₄)
+open Bimodule B₁ using () renaming (F to F₁; actionʳ to actionʳ₁)
+open Bimodule B₂ using () renaming (F to F₂; actionˡ to actionˡ₂; actionʳ to actionʳ₂)
+open Bimodule B₃ using () renaming (F to F₃; actionˡ to actionˡ₃; actionʳ to actionʳ₃)
+open TensorproductOfBimodules B₂ B₁ using (F₂⊗F₁)
+open TensorproductOfBimodules B₃ B₂ using ()
+  renaming (F₂⊗F₁ to F₃⊗F₂)
+open TensorproductOfBimodules B₃ (B₂ ⊗₀ B₁) using ()
+  renaming (F₂⊗F₁ to F₃⊗[F₂⊗F₁])
+open TensorproductOfBimodules (B₃ ⊗₀ B₂) B₁ using ()
+  renaming (F₂⊗F₁ to [F₃⊗F₂]⊗F₁)
+
+
+-- The associator is a bimodule. We start by constructing its underlying 2-cell. --
+
+module 2-cell where
+
+  -- We want to use that coequalizers commute with coeuqalizers --
+  -- c.f. Categories.Diagram.Coequalizer.Properties.CoequalizerOfCoequalizer --
+  -- To apply afformentioned module we need to define the appropriate diagram --
+  -- Note that we need to plug in the associators of 𝒞 at the apropriate points to define the diagram --
+  {-
+        f₁₂
+     A ====> B ----> coeqᶠ
+     ||      ||       ||
+  g₁₂||   h₁₂||  sqᶠⁱ ||
+     vv i₁₂  vv       vv        t
+     C ====> D ----> coeqⁱ ----------
+     |       |         |             |
+     | sqᵍʰ  |  arrSq  |             |
+     v       v         v             v
+   coeqᵍ==>coeqʰ --> coeqcoeqᵍʰ ···> T
+             .               coequalize
+             .                       ^
+             .                       .
+             .........................
+                          u
+
+  CoeqsAreIsomorphic : coeqcoeqᶠⁱ ≅ coeqcoeqᵍʰ
+
+-}
+
+  A B C D : C₁ ⇒₁ C₄
+  A = (F₃ ∘₁ T₃ ∘₁  F₂) ∘₁ T₂ ∘₁ F₁
+  B = (F₃ ∘₁ F₂) ∘₁ T₂ ∘₁ F₁
+  C = (F₃ ∘₁ T₃ ∘₁ F₂) ∘₁  F₁
+  D = (F₃ ∘₁ F₂) ∘₁ F₁
+
+  A' B' C' D' : C₁ ⇒₁ C₄
+  A' = F₃ ∘₁ T₃ ∘₁ F₂ ∘₁ T₂ ∘₁ F₁
+  B' = F₃ ∘₁ F₂ ∘₁ T₂ ∘₁ F₁
+  C' = F₃ ∘₁ T₃ ∘₁ F₂ ∘₁  F₁
+  D' = F₃ ∘₁ F₂ ∘₁ F₁
+
+  associatorA : A' ≅ A
+  associatorA = associator ⁻¹ ∘ᵢ F₃ ▷ᵢ (associator ⁻¹)
+  
+  associatorB : B' ≅ B
+  associatorB = associator ⁻¹
+  
+  associatorC : C' ≅ C
+  associatorC = associator ⁻¹ ∘ᵢ F₃ ▷ᵢ (associator ⁻¹)
+
+  associatorD : D' ≅ D
+  associatorD = associator ⁻¹
+
+  f₁ f₂ : A ⇒₂ B
+  f₁ = TensorproductOfBimodules.act-to-the-left B₃ B₂ ◁ (T₂ ∘₁ F₁)
+  f₂ = TensorproductOfBimodules.act-to-the-right B₃ B₂ ◁ (T₂ ∘₁ F₁)
+
+  g₁' g₂' : A' ⇒₂ C'
+  g₁' = F₃ ▷ T₃ ▷ TensorproductOfBimodules.act-to-the-left B₂ B₁
+  g₂' = F₃ ▷ T₃ ▷ TensorproductOfBimodules.act-to-the-right B₂ B₁
+
+  g₁ g₂ : A ⇒₂ C
+  g₁ = _≅_.from associatorC ∘ᵥ g₁' ∘ᵥ _≅_.to associatorA
+  g₂ = _≅_.from associatorC ∘ᵥ g₂' ∘ᵥ _≅_.to associatorA
+
+  h₁' h₂' : B' ⇒₂ D'
+  h₁' = F₃ ▷ TensorproductOfBimodules.act-to-the-left B₂ B₁
+  h₂' = F₃ ▷ TensorproductOfBimodules.act-to-the-right B₂ B₁
+
+  h₁ h₂ : B ⇒₂ D
+  h₁ = _≅_.from associatorD ∘ᵥ h₁' ∘ᵥ _≅_.to associatorB
+  h₂ = _≅_.from associatorD ∘ᵥ h₂' ∘ᵥ _≅_.to associatorB
+
+  i₁ i₂ : C ⇒₂ D
+  i₁ = TensorproductOfBimodules.act-to-the-left B₃ B₂ ◁ F₁
+  i₂ = TensorproductOfBimodules.act-to-the-right B₃ B₂ ◁ F₁
+
+
+
+  coeqᶠ : Coequalizer f₁ f₂
+  coeqᶠ = precompCoequalizer F₃⊗F₂ (T₂ ∘₁ F₁)
+
+  -- We would like to define
+  -- coeqᵍ = postcompCoequalizer (postcompCoequalizer F₂⊗F₁ T₃) F₃)
+  -- but we have to plug in associators at the appropriate positions.
+  coeqᵍ : Coequalizer g₁ g₂
+  coeqᵍ = CoeqOfIsomorphicDiagram
+            (postcompCoequalizer (postcompCoequalizer F₂⊗F₁ T₃) F₃)
+            associatorA
+            associatorC
+  
+  -- We would like to define
+  -- coeqʰ = postcompCoequalizer F₂⊗F₁ F₃
+  -- but we have to plug in associators at the appropriate positions.
+  coeqʰ : Coequalizer h₁ h₂
+  coeqʰ = CoeqOfIsomorphicDiagram
+            (postcompCoequalizer F₂⊗F₁ F₃)
+            associatorB
+            associatorD
+      
+  
+  coeqⁱ : Coequalizer i₁ i₂
+  coeqⁱ = precompCoequalizer F₃⊗F₂ F₁
+  
+  f⇒i₁ f⇒i₂ : Coequalizer.obj coeqᶠ ⇒₂ Coequalizer.obj coeqⁱ
+  f⇒i₁ = TensorproductOfBimodules.act-to-the-left (B₃ ⊗₀ B₂) B₁
+  f⇒i₂ = TensorproductOfBimodules.act-to-the-right (B₃ ⊗₀ B₂) B₁
+  
+  g⇒h₁ g⇒h₂ : Coequalizer.obj coeqᵍ ⇒₂ Coequalizer.obj coeqʰ
+  g⇒h₁ = TensorproductOfBimodules.act-to-the-left B₃ (B₂ ⊗₀ B₁)
+  g⇒h₂ = TensorproductOfBimodules.act-to-the-right B₃ (B₂ ⊗₀ B₁)
+
+  abstract
+    sq₁ᶠⁱ : CommutativeSquare (Coequalizer.arr coeqᶠ) h₁ f⇒i₁ (Coequalizer.arr coeqⁱ)
+    sq₁ᶠⁱ = begin
+
+      Coequalizer.obj F₃⊗F₂ ▷ actionʳ₁
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ (T₂ ∘₁ F₁) ≈⟨ ◁-▷-exchg ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (F₃ ∘₁ F₂) ▷ actionʳ₁              ≈⟨ refl⟩∘⟨
+                                                 switch-fromtoˡ associator α⇒-▷-∘₁ ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ associator.to
+        ∘ᵥ F₃ ▷ F₂ ▷ actionʳ₁
+        ∘ᵥ associator.from ∎
+
+      where
+        open hom.HomReasoning
+        open import Categories.Morphism.Reasoning.Iso (hom C₁ C₄)
+
+    sq₂ᶠⁱ : CommutativeSquare (Coequalizer.arr coeqᶠ) h₂ f⇒i₂ (Coequalizer.arr coeqⁱ)
+    sq₂ᶠⁱ = begin
+
+      (Bimodule.actionˡ (B₃ ⊗₀ B₂) ◁ F₁
+        ∘ᵥ associator.to)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ (T₂ ∘₁ F₁) ≈⟨ assoc₂ ⟩
+
+      Bimodule.actionˡ (B₃ ⊗₀ B₂) ◁ F₁
+        ∘ᵥ associator.to
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ (T₂ ∘₁ F₁) ≈⟨ refl⟩∘⟨ α⇐-◁-∘₁ ⟩
+
+      Bimodule.actionˡ (B₃ ⊗₀ B₂) ◁ F₁
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ T₂ ◁ F₁
+        ∘ᵥ associator.to                      ≈⟨ sym-assoc₂ ⟩
+
+      (Bimodule.actionˡ (B₃ ⊗₀ B₂) ◁ F₁
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ T₂ ◁ F₁)
+        ∘ᵥ associator.to                      ≈⟨ ∘ᵥ-distr-◁ ⟩∘⟨refl ⟩
+
+      (Bimodule.actionˡ (B₃ ⊗₀ B₂)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ T₂) ◁ F₁
+        ∘ᵥ associator.to                      ≈⟨ ◁-resp-≈ (⟺ actionˡSq) ⟩∘⟨refl ⟩
+
+      (Coequalizer.arr F₃⊗F₂
+        ∘ᵥ F₃ ▷ actionˡ₂
+        ∘ᵥ associator.from) ◁ F₁
+        ∘ᵥ associator.to                      ≈⟨ ⟺ ∘ᵥ-distr-◁ ⟩∘⟨refl ⟩
+
+      (Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (F₃ ▷ actionˡ₂
+        ∘ᵥ associator.from) ◁ F₁)
+        ∘ᵥ associator.to                      ≈⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (F₃ ▷ actionˡ₂
+        ∘ᵥ associator.from) ◁ F₁
+        ∘ᵥ associator.to                      ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ ((F₃ ▷ actionˡ₂) ◁ F₁
+        ∘ᵥ associator.from ◁ F₁)
+        ∘ᵥ associator.to                      ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (F₃ ▷ actionˡ₂) ◁ F₁
+        ∘ᵥ associator.from ◁ F₁
+        ∘ᵥ associator.to                      ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                 pentagon-conjugate₃ ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (F₃ ▷ actionˡ₂) ◁ F₁
+        ∘ᵥ (associator.to
+        ∘ᵥ F₃ ▷ associator.to)
+        ∘ᵥ associator.from                    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (F₃ ▷ actionˡ₂) ◁ F₁
+        ∘ᵥ associator.to
+        ∘ᵥ F₃ ▷ associator.to
+        ∘ᵥ associator.from                    ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ ((F₃ ▷ actionˡ₂) ◁ F₁
+        ∘ᵥ associator.to)
+        ∘ᵥ F₃ ▷ associator.to
+        ∘ᵥ associator.from                    ≈⟨ refl⟩∘⟨
+                                                 ⟺ α⇐-▷-◁
+                                               ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (associator.to
+        ∘ᵥ F₃ ▷ (actionˡ₂ ◁ F₁))
+        ∘ᵥ F₃ ▷ associator.to
+        ∘ᵥ associator.from                    ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ associator.to
+        ∘ᵥ F₃ ▷ (actionˡ₂ ◁ F₁)
+        ∘ᵥ F₃ ▷ associator.to
+        ∘ᵥ associator.from                    ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                 sym-assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ associator.to
+        ∘ᵥ (F₃ ▷ (actionˡ₂ ◁ F₁)
+        ∘ᵥ F₃ ▷ associator.to)
+        ∘ᵥ associator.from                    ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                 ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ associator.to
+        ∘ᵥ F₃ ▷ (actionˡ₂ ◁ F₁
+                 ∘ᵥ associator.to)
+        ∘ᵥ associator.from                    ∎
+
+      where
+        open hom.HomReasoning
+        open TensorproductOfBimodules.Left-Action B₃ B₂ using (actionˡSq)
+
+    sq₁ᵍʰ : CommutativeSquare i₁ (Coequalizer.arr coeqᵍ) (Coequalizer.arr coeqʰ) g⇒h₁
+    sq₁ᵍʰ = begin
+
+      (F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.from)
+        ∘ᵥ (F₃ ▷ actionʳ₂) ◁ F₁             ≈⟨ assoc₂ ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.from
+        ∘ᵥ (F₃ ▷ actionʳ₂) ◁ F₁             ≈⟨ refl⟩∘⟨ α⇒-▷-◁ ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ (actionʳ₂ ◁ F₁)
+        ∘ᵥ associator.from                  ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                               ⟺ identity₂ˡ ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ (actionʳ₂ ◁ F₁)
+        ∘ᵥ id₂
+        ∘ᵥ associator.from                  ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                               ⟺ (_≅_.isoˡ (F₃ ▷ᵢ associator))
+                                             ⟩∘⟨refl ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ (actionʳ₂ ◁ F₁)
+        ∘ᵥ (F₃ ▷ associator.to
+        ∘ᵥ F₃ ▷ associator.from)
+        ∘ᵥ associator.from                  ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ (actionʳ₂ ◁ F₁)
+        ∘ᵥ F₃ ▷ associator.to
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                  ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ (F₃ ▷ (actionʳ₂ ◁ F₁)
+        ∘ᵥ F₃ ▷ associator.to)
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                  ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ (actionʳ₂ ◁ F₁
+                 ∘ᵥ associator.to)
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                  ≈⟨ sym-assoc₂ ⟩
+
+      (F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ (actionʳ₂ ◁ F₁
+                 ∘ᵥ associator.to))
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                  ≈⟨ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+
+      F₃ ▷ (Coequalizer.arr F₂⊗F₁
+            ∘ᵥ actionʳ₂ ◁ F₁
+            ∘ᵥ associator.to)
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                  ≈⟨ ▷-resp-≈ actionʳSq ⟩∘⟨refl ⟩
+
+      F₃ ▷ (Bimodule.actionʳ (B₂ ⊗₀ B₁)
+        ∘ᵥ T₃ ▷ Coequalizer.arr F₂⊗F₁)
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                  ≈⟨ ⟺ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+
+      (F₃ ▷ Bimodule.actionʳ (B₂ ⊗₀ B₁)
+        ∘ᵥ F₃ ▷ T₃ ▷ Coequalizer.arr F₂⊗F₁)
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                  ≈⟨ assoc₂ ⟩
+
+      F₃ ▷ Bimodule.actionʳ (B₂ ⊗₀ B₁)
+        ∘ᵥ F₃ ▷ T₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                  ∎
+
+      where
+        open hom.HomReasoning
+        open TensorproductOfBimodules.Right-Action B₂ B₁ using (actionʳSq)
+
+    sq₂ᵍʰ : CommutativeSquare i₂ (Coequalizer.arr coeqᵍ) (Coequalizer.arr coeqʰ) g⇒h₂
+    sq₂ᵍʰ = begin
+
+      (F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.from)
+        ∘ᵥ (actionˡ₃ ◁ F₂
+            ∘ᵥ associator.to) ◁ F₁             ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩
+
+      (F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.from)
+        ∘ᵥ actionˡ₃ ◁ F₂ ◁ F₁
+        ∘ᵥ associator.to ◁ F₁                  ≈⟨ assoc₂ ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.from
+        ∘ᵥ actionˡ₃ ◁ F₂ ◁ F₁
+        ∘ᵥ associator.to ◁ F₁                  ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ (associator.from
+        ∘ᵥ actionˡ₃ ◁ F₂ ◁ F₁)
+        ∘ᵥ associator.to ◁ F₁                  ≈⟨ refl⟩∘⟨ α⇒-◁-∘₁ ⟩∘⟨refl ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ (actionˡ₃ ◁ (F₂ ∘₁ F₁)
+        ∘ᵥ associator.from)
+        ∘ᵥ associator.to ◁ F₁                  ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ actionˡ₃ ◁ (F₂ ∘₁ F₁)
+        ∘ᵥ associator.from
+        ∘ᵥ associator.to ◁ F₁                  ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                    pentagon-conjugate₄ ⟩
+
+      F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ actionˡ₃ ◁ (F₂ ∘₁ F₁)
+        ∘ᵥ associator.to
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                     ≈⟨ sym-assoc₂ ⟩
+
+      (F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ actionˡ₃ ◁ (F₂ ∘₁ F₁))
+        ∘ᵥ associator.to
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                     ≈⟨ ◁-▷-exchg ⟩∘⟨refl ⟩
+
+      (actionˡ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ (F₃ ∘₁ T₃) ▷ Coequalizer.arr F₂⊗F₁)
+        ∘ᵥ associator.to
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                     ≈⟨ assoc₂ ⟩
+
+      actionˡ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ (F₃ ∘₁ T₃) ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.to
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                     ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      actionˡ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ ((F₃ ∘₁ T₃) ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.to)
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                     ≈⟨ refl⟩∘⟨ ⟺ α⇐-▷-∘₁ ⟩∘⟨refl ⟩
+
+      actionˡ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ (associator.to
+        ∘ᵥ F₃ ▷ T₃ ▷ Coequalizer.arr F₂⊗F₁)
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                     ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      actionˡ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ associator.to
+        ∘ᵥ F₃ ▷ T₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                     ≈⟨ sym-assoc₂ ⟩
+
+      (actionˡ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ associator.to)
+        ∘ᵥ F₃ ▷ T₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from                     ∎
+
+      where
+        open hom.HomReasoning
+  -- end abstract --
+  
+  coeqcoeqᶠⁱ : Coequalizer f⇒i₁ f⇒i₂
+  coeqcoeqᶠⁱ = [F₃⊗F₂]⊗F₁
+  
+  coeqcoeqᵍʰ : Coequalizer g⇒h₁ g⇒h₂
+  coeqcoeqᵍʰ = F₃⊗[F₂⊗F₁]
+
+  
+
+  Associator⊗Iso : Bimodule.F ((B₃ ⊗₀ B₂) ⊗₀ B₁) ≅ Bimodule.F (B₃ ⊗₀ B₂ ⊗₀ B₁)
+  Associator⊗Iso = CoeqsAreIsomorphic
+                    coeqᶠ coeqᵍ coeqʰ coeqⁱ
+                    f⇒i₁ f⇒i₂ g⇒h₁ g⇒h₂
+                    sq₁ᶠⁱ sq₂ᶠⁱ sq₁ᵍʰ sq₂ᵍʰ
+                    coeqcoeqᵍʰ coeqcoeqᶠⁱ
+                    
+  α⇒⊗ : (Bimodule.F ((B₃ ⊗₀ B₂) ⊗₀ B₁)) ⇒₂ (Bimodule.F (B₃ ⊗₀ B₂ ⊗₀ B₁))
+  α⇒⊗ = _≅_.from Associator⊗Iso
+
+  hexagon : Coequalizer.arr F₃⊗[F₂⊗F₁] ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁ ∘ᵥ associator.from
+             ≈ α⇒⊗ ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁
+  hexagon = IsoFitsInPentagon
+                coeqᶠ coeqᵍ coeqʰ coeqⁱ
+                f⇒i₁ f⇒i₂ g⇒h₁ g⇒h₂
+                sq₁ᶠⁱ sq₂ᶠⁱ sq₁ᵍʰ sq₂ᵍʰ
+                coeqcoeqᵍʰ coeqcoeqᶠⁱ
+    where
+      open CoequalizerOfCoequalizer using (IsoFitsInPentagon)
+
+open 2-cell using (α⇒⊗; hexagon) public
+
+module Linear-Left where
+  open Bimodule B₁ using () renaming (actionˡ to actionˡ₁)
+
+  abstract
+    linearˡ∘arr∘arr : ((Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+                      ∘ᵥ α⇒⊗ ◁ T₁)
+                      ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁)
+                      ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁
+                      ≈ ((α⇒⊗
+                      ∘ᵥ Bimodule.actionˡ ((B₃ ⊗₀ B₂) ⊗₀ B₁))
+                      ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁)
+                      ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁
+    linearˡ∘arr∘arr = begin
+
+      ((Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ α⇒⊗ ◁ T₁)
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁ ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+
+      (Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ α⇒⊗ ◁ T₁
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁ ≈⟨ assoc₂ ⟩
+
+      Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ (α⇒⊗ ◁ T₁
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁ ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ α⇒⊗ ◁ T₁
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                              ∘ᵥ-distr-◁ ⟩
+
+      Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ α⇒⊗ ◁ T₁
+        ∘ᵥ (Coequalizer.arr [F₃⊗F₂]⊗F₁
+            ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁) ◁ T₁ ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+
+      Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ (α⇒⊗
+            ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+            ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁) ◁ T₁ ≈⟨ refl⟩∘⟨ ◁-resp-≈
+                                                   (⟺ hexagon) ⟩
+
+      Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ (Coequalizer.arr F₃⊗[F₂⊗F₁]
+            ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+            ∘ᵥ associator.from) ◁ T₁ ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩
+
+      Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ Coequalizer.arr F₃⊗[F₂⊗F₁] ◁ T₁
+        ∘ᵥ (F₃ ▷ Coequalizer.arr F₂⊗F₁
+            ∘ᵥ associator.from) ◁ T₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩
+
+      Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ Coequalizer.arr F₃⊗[F₂⊗F₁] ◁ T₁
+        ∘ᵥ (F₃ ▷ Coequalizer.arr F₂⊗F₁) ◁ T₁
+        ∘ᵥ associator.from ◁ T₁ ≈⟨ sym-assoc₂ ⟩
+
+      (Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ Coequalizer.arr F₃⊗[F₂⊗F₁] ◁ T₁)
+        ∘ᵥ (F₃ ▷ Coequalizer.arr F₂⊗F₁) ◁ T₁
+        ∘ᵥ associator.from ◁ T₁ ≈⟨ ⟺ actionˡSqB₃⊗[B₂⊗B₁] ⟩∘⟨refl ⟩
+
+      (Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Bimodule.actionˡ (B₂ ⊗₀ B₁)
+        ∘ᵥ associator.from)
+        ∘ᵥ (F₃ ▷ Coequalizer.arr F₂⊗F₁) ◁ T₁
+        ∘ᵥ associator.from ◁ T₁ ≈⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ (F₃ ▷ Bimodule.actionˡ (B₂ ⊗₀ B₁)
+        ∘ᵥ associator.from)
+        ∘ᵥ (F₃ ▷ Coequalizer.arr F₂⊗F₁) ◁ T₁
+        ∘ᵥ associator.from ◁ T₁ ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Bimodule.actionˡ (B₂ ⊗₀ B₁)
+        ∘ᵥ associator.from
+        ∘ᵥ (F₃ ▷ Coequalizer.arr F₂⊗F₁) ◁ T₁
+        ∘ᵥ associator.from ◁ T₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                   sym-assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Bimodule.actionˡ (B₂ ⊗₀ B₁)
+        ∘ᵥ (associator.from
+        ∘ᵥ (F₃ ▷ Coequalizer.arr F₂⊗F₁) ◁ T₁)
+        ∘ᵥ associator.from ◁ T₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                   α⇒-▷-◁ ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Bimodule.actionˡ (B₂ ⊗₀ B₁)
+        ∘ᵥ (F₃ ▷ (Coequalizer.arr F₂⊗F₁ ◁ T₁)
+        ∘ᵥ associator.from)
+        ∘ᵥ associator.from ◁ T₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                   assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Bimodule.actionˡ (B₂ ⊗₀ B₁)
+        ∘ᵥ F₃ ▷ (Coequalizer.arr F₂⊗F₁ ◁ T₁)
+        ∘ᵥ associator.from
+        ∘ᵥ associator.from ◁ T₁ ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ (F₃ ▷ Bimodule.actionˡ (B₂ ⊗₀ B₁)
+        ∘ᵥ F₃ ▷ (Coequalizer.arr F₂⊗F₁ ◁ T₁))
+        ∘ᵥ associator.from
+        ∘ᵥ associator.from ◁ T₁ ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ (Bimodule.actionˡ (B₂ ⊗₀ B₁)
+                 ∘ᵥ Coequalizer.arr F₂⊗F₁ ◁ T₁)
+        ∘ᵥ associator.from
+        ∘ᵥ associator.from ◁ T₁                 ≈⟨ refl⟩∘⟨ ▷-resp-≈
+                                                   (⟺ actionˡSqB₂⊗B₁)
+                                                 ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ (Coequalizer.arr F₂⊗F₁
+                 ∘ᵥ F₂ ▷ actionˡ₁
+                 ∘ᵥ associator.from)
+        ∘ᵥ associator.from
+        ∘ᵥ associator.from ◁ T₁                 ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ (F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ (F₂ ▷ actionˡ₁
+                 ∘ᵥ associator.from))
+        ∘ᵥ associator.from
+        ∘ᵥ associator.from ◁ T₁                 ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ (F₂ ▷ actionˡ₁
+                 ∘ᵥ associator.from)
+        ∘ᵥ associator.from
+        ∘ᵥ associator.from ◁ T₁                 ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                   ⟺ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ (F₃ ▷ F₂ ▷ actionˡ₁
+        ∘ᵥ F₃ ▷ associator.from)
+        ∘ᵥ associator.from
+        ∘ᵥ associator.from ◁ T₁                 ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ F₂ ▷ actionˡ₁
+        ∘ᵥ F₃ ▷ associator.from
+        ∘ᵥ associator.from
+        ∘ᵥ associator.from ◁ T₁                 ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                   refl⟩∘⟨ pentagon ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ F₃ ▷ F₂ ▷ actionˡ₁
+        ∘ᵥ associator.from
+        ∘ᵥ associator.from                      ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                   sym-assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ (F₃ ▷ F₂ ▷ actionˡ₁
+        ∘ᵥ associator.from)
+        ∘ᵥ associator.from                      ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                   ⟺ α⇒-▷-∘₁ ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ (associator.from
+        ∘ᵥ (F₃ ∘₁ F₂) ▷ actionˡ₁)
+        ∘ᵥ associator.from                      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.from
+        ∘ᵥ (F₃ ∘₁ F₂) ▷ actionˡ₁
+        ∘ᵥ associator.from                      ≈⟨ sym-assoc₂ ⟩
+
+      (Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+        ∘ᵥ associator.from
+        ∘ᵥ (F₃ ∘₁ F₂) ▷ actionˡ₁
+        ∘ᵥ associator.from                      ≈⟨ sym-assoc₂ ⟩
+
+      ((Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+        ∘ᵥ associator.from)
+        ∘ᵥ (F₃ ∘₁ F₂) ▷ actionˡ₁
+        ∘ᵥ associator.from                      ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+
+      (Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.from)
+        ∘ᵥ (F₃ ∘₁ F₂) ▷ actionˡ₁
+        ∘ᵥ associator.from                      ≈⟨ hexagon ⟩∘⟨refl ⟩
+
+      (α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁)
+        ∘ᵥ (F₃ ∘₁ F₂) ▷ actionˡ₁
+        ∘ᵥ associator.from                      ≈⟨ assoc₂ ⟩
+
+      α⇒⊗
+        ∘ᵥ (Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁)
+        ∘ᵥ (F₃ ∘₁ F₂) ▷ actionˡ₁
+        ∘ᵥ associator.from                      ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (F₃ ∘₁ F₂) ▷ actionˡ₁
+        ∘ᵥ associator.from                      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ (Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (F₃ ∘₁ F₂) ▷ actionˡ₁)
+        ∘ᵥ associator.from                      ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                   ⟺ ◁-▷-exchg ⟩∘⟨refl ⟩
+
+      α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ (Coequalizer.obj F₃⊗F₂ ▷ actionˡ₁
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ (F₁ ∘₁ T₁))
+        ∘ᵥ associator.from                      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ Coequalizer.obj F₃⊗F₂ ▷ actionˡ₁
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ (F₁ ∘₁ T₁)
+        ∘ᵥ associator.from                      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                   ⟺ α⇒-◁-∘₁ ⟩
+
+      α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ Coequalizer.obj F₃⊗F₂ ▷ actionˡ₁
+        ∘ᵥ associator.from
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ (Coequalizer.obj F₃⊗F₂ ▷ actionˡ₁
+        ∘ᵥ associator.from)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁      ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      α⇒⊗
+        ∘ᵥ (Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ Coequalizer.obj F₃⊗F₂ ▷ actionˡ₁
+        ∘ᵥ associator.from)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁      ≈⟨ refl⟩∘⟨ actionˡSq[B₃⊗B₂]⊗B₁
+                                                 ⟩∘⟨refl ⟩
+
+      α⇒⊗
+        ∘ᵥ (Bimodule.actionˡ ((B₃ ⊗₀ B₂) ⊗₀ B₁)
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁      ≈⟨ sym-assoc₂ ⟩
+
+      (α⇒⊗
+        ∘ᵥ (Bimodule.actionˡ ((B₃ ⊗₀ B₂) ⊗₀ B₁)
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁))
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁      ≈⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+
+      ((α⇒⊗
+        ∘ᵥ Bimodule.actionˡ ((B₃ ⊗₀ B₂) ⊗₀ B₁))
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ◁ T₁      ∎
+
+      where
+        open hom.HomReasoning
+        open TensorproductOfBimodules.Left-Action B₃ (B₂ ⊗₀ B₁)
+          using () renaming (actionˡSq to actionˡSqB₃⊗[B₂⊗B₁])
+        open TensorproductOfBimodules.Left-Action B₂ B₁
+          using () renaming (actionˡSq to actionˡSqB₂⊗B₁)
+        open TensorproductOfBimodules.Left-Action (B₃ ⊗₀ B₂) B₁
+          using () renaming (actionˡSq to actionˡSq[B₃⊗B₂]⊗B₁)
+
+    linearˡ∘arr : (Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+                      ∘ᵥ α⇒⊗ ◁ T₁)
+                      ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁
+                   ≈ (α⇒⊗
+                      ∘ᵥ Bimodule.actionˡ ((B₃ ⊗₀ B₂) ⊗₀ B₁))
+                      ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁
+    linearˡ∘arr = Coequalizer⇒Epi
+                    (precompCoequalizer (precompCoequalizer F₃⊗F₂ F₁) T₁)
+                    ((Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+                      ∘ᵥ α⇒⊗ ◁ T₁)
+                      ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁)
+                    ((α⇒⊗
+                      ∘ᵥ Bimodule.actionˡ ((B₃ ⊗₀ B₂) ⊗₀ B₁))
+                      ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁ ◁ T₁)
+                    linearˡ∘arr∘arr
+
+    linearˡ : Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁) ∘ᵥ α⇒⊗ ◁ T₁
+                      ≈ α⇒⊗ ∘ᵥ Bimodule.actionˡ ((B₃ ⊗₀ B₂) ⊗₀ B₁)
+    linearˡ = Coequalizer⇒Epi
+                    (precompCoequalizer [F₃⊗F₂]⊗F₁ T₁)
+                    (Bimodule.actionˡ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+                      ∘ᵥ α⇒⊗ ◁ T₁)
+                    (α⇒⊗
+                      ∘ᵥ Bimodule.actionˡ ((B₃ ⊗₀ B₂) ⊗₀ B₁))
+                    linearˡ∘arr
+  -- end abstract --
+
+module Linear-Right where
+  abstract
+    linearʳ∘arr∘arr : ((Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+                        ∘ᵥ T₄ ▷ α⇒⊗)
+                        ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+                        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁)
+                      ≈ ((α⇒⊗
+                        ∘ᵥ Bimodule.actionʳ ((B₃ ⊗₀ B₂) ⊗₀ B₁))
+                        ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+                        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁)
+    linearʳ∘arr∘arr = begin
+
+      ((Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ α⇒⊗)
+        ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ assoc₂ ⟩
+
+      (Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ α⇒⊗)
+        ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ assoc₂ ⟩
+
+      Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ α⇒⊗
+        ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                ∘ᵥ-distr-▷ ⟩
+
+      Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ α⇒⊗
+        ∘ᵥ T₄ ▷ (Coequalizer.arr [F₃⊗F₂]⊗F₁
+                 ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+
+      Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ (α⇒⊗
+                 ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+                 ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ refl⟩∘⟨ ▷-resp-≈
+                                                   (⟺ hexagon) ⟩
+
+      Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗[F₂⊗F₁]
+                 ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+                 ∘ᵥ associator.from) ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-▷ ⟩
+
+      Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ T₄ ▷ (F₃ ▷ Coequalizer.arr F₂⊗F₁
+                 ∘ᵥ associator.from) ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-▷ ⟩
+
+      Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ T₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ sym-assoc₂ ⟩
+
+      (Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ Coequalizer.arr F₃⊗[F₂⊗F₁])
+        ∘ᵥ T₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ ⟺ actionʳSqF₃⊗[F₂⊗F₁] ⟩∘⟨refl ⟩
+
+      (Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ actionʳ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ associator.to)
+        ∘ᵥ T₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ (actionʳ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ associator.to)
+        ∘ᵥ T₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ actionʳ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ associator.to
+        ∘ᵥ T₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ refl⟩∘⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ actionʳ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ (associator.to
+        ∘ᵥ T₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                   α⇐-▷-∘₁ ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ actionʳ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ ((T₄ ∘₁ F₃) ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.to)
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ actionʳ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ (T₄ ∘₁ F₃) ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.to
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ (actionʳ₃ ◁ Coequalizer.obj F₂⊗F₁
+        ∘ᵥ (T₄ ∘₁ F₃) ▷ Coequalizer.arr F₂⊗F₁)
+        ∘ᵥ associator.to
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ refl⟩∘⟨ ⟺ ◁-▷-exchg ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ (F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ actionʳ₃ ◁ (F₂ ∘₁ F₁))
+        ∘ᵥ associator.to
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ actionʳ₃ ◁ (F₂ ∘₁ F₁)
+        ∘ᵥ associator.to
+        ∘ᵥ T₄ ▷ associator.from ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨
+                                   pentagon-conjugate₅ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ actionʳ₃ ◁ (F₂ ∘₁ F₁)
+        ∘ᵥ associator.from
+        ∘ᵥ associator.to ◁ F₁
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ (actionʳ₃ ◁ (F₂ ∘₁ F₁)
+        ∘ᵥ associator.from)
+        ∘ᵥ associator.to ◁ F₁
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                            ⟺ α⇒-◁-∘₁ ⟩∘⟨refl ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ (associator.from
+        ∘ᵥ actionʳ₃ ◁ F₂ ◁ F₁)
+        ∘ᵥ associator.to ◁ F₁
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.from
+        ∘ᵥ actionʳ₃ ◁ F₂ ◁ F₁
+        ∘ᵥ associator.to ◁ F₁
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ (F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.from)
+        ∘ᵥ actionʳ₃ ◁ F₂ ◁ F₁
+        ∘ᵥ associator.to ◁ F₁
+        ∘ᵥ associator.to ≈⟨ sym-assoc₂ ⟩
+
+      (Coequalizer.arr F₃⊗[F₂⊗F₁]
+        ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+        ∘ᵥ associator.from)
+        ∘ᵥ actionʳ₃ ◁ F₂ ◁ F₁
+        ∘ᵥ associator.to ◁ F₁
+        ∘ᵥ associator.to ≈⟨ hexagon ⟩∘⟨refl ⟩
+
+      (α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁)
+        ∘ᵥ actionʳ₃ ◁ F₂ ◁ F₁
+        ∘ᵥ associator.to ◁ F₁
+        ∘ᵥ associator.to ≈⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+
+      ((α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁)
+        ∘ᵥ actionʳ₃ ◁ F₂ ◁ F₁
+        ∘ᵥ associator.to ◁ F₁
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      ((α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁)
+        ∘ᵥ (actionʳ₃ ◁ F₂ ◁ F₁
+        ∘ᵥ associator.to ◁ F₁)
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩∘⟨refl ⟩
+
+      ((α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁)
+        ∘ᵥ (actionʳ₃ ◁ F₂
+        ∘ᵥ associator.to) ◁ F₁
+        ∘ᵥ associator.to ≈⟨ assoc₂ ⟩
+
+      (α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (actionʳ₃ ◁ F₂
+        ∘ᵥ associator.to) ◁ F₁
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      (α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ (Coequalizer.arr F₃⊗F₂ ◁ F₁
+        ∘ᵥ (actionʳ₃ ◁ F₂
+        ∘ᵥ associator.to) ◁ F₁)
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩∘⟨refl ⟩
+
+      (α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ (Coequalizer.arr F₃⊗F₂
+        ∘ᵥ actionʳ₃ ◁ F₂
+        ∘ᵥ associator.to) ◁ F₁
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ ◁-resp-≈
+                            actionʳSqF₂⊗F₁ ⟩∘⟨refl ⟩
+
+      (α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ (Bimodule.actionʳ (B₃ ⊗₀ B₂)
+        ∘ᵥ T₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩∘⟨refl ⟩
+
+      (α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ (Bimodule.actionʳ (B₃ ⊗₀ B₂) ◁ F₁
+        ∘ᵥ (T₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁)
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+      (α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ Bimodule.actionʳ (B₃ ⊗₀ B₂) ◁ F₁
+        ∘ᵥ (T₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+        ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ α⇐-▷-◁ ⟩
+
+      (α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ Bimodule.actionʳ (B₃ ⊗₀ B₂) ◁ F₁
+        ∘ᵥ associator.to
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      (α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ (Bimodule.actionʳ (B₃ ⊗₀ B₂) ◁ F₁
+        ∘ᵥ associator.to)
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ assoc₂ ⟩
+
+      α⇒⊗
+        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ (Bimodule.actionʳ (B₃ ⊗₀ B₂) ◁ F₁
+        ∘ᵥ associator.to)
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+      α⇒⊗
+        ∘ᵥ (Coequalizer.arr [F₃⊗F₂]⊗F₁
+        ∘ᵥ Bimodule.actionʳ (B₃ ⊗₀ B₂) ◁ F₁
+        ∘ᵥ associator.to)
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ refl⟩∘⟨
+                                                actionʳSq[F₃⊗F₂]⊗F₁
+                                              ⟩∘⟨refl ⟩
+
+      α⇒⊗
+        ∘ᵥ (Bimodule.actionʳ ((B₃ ⊗₀ B₂) ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ sym-assoc₂ ⟩
+
+      (α⇒⊗
+        ∘ᵥ Bimodule.actionʳ ((B₃ ⊗₀ B₂) ⊗₀ B₁)
+        ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁) ≈⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+
+      ((α⇒⊗
+        ∘ᵥ Bimodule.actionʳ ((B₃ ⊗₀ B₂) ⊗₀ B₁))
+        ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+        ∘ᵥ T₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁) ∎
+
+      where
+        open hom.HomReasoning
+        open TensorproductOfBimodules.Right-Action B₃ (B₂ ⊗₀ B₁)
+          using () renaming (actionʳSq to actionʳSqF₃⊗[F₂⊗F₁])
+        open TensorproductOfBimodules.Right-Action B₃ B₂
+          using () renaming (actionʳSq to actionʳSqF₂⊗F₁)
+        open TensorproductOfBimodules.Right-Action (B₃ ⊗₀ B₂) B₁
+          using () renaming (actionʳSq to actionʳSq[F₃⊗F₂]⊗F₁)
+
+    linearʳ∘arr : (Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+                    ∘ᵥ T₄ ▷ α⇒⊗)
+                    ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+                  ≈ (α⇒⊗
+                    ∘ᵥ Bimodule.actionʳ ((B₃ ⊗₀ B₂) ⊗₀ B₁))
+                    ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    linearʳ∘arr = Coequalizer⇒Epi
+                    (postcompCoequalizer (precompCoequalizer F₃⊗F₂ F₁) T₄)
+                    ((Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+                      ∘ᵥ T₄ ▷ α⇒⊗)
+                      ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+                    ((α⇒⊗
+                      ∘ᵥ Bimodule.actionʳ ((B₃ ⊗₀ B₂) ⊗₀ B₁))
+                      ∘ᵥ T₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+                    linearʳ∘arr∘arr
+
+    linearʳ : Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁)
+              ∘ᵥ T₄ ▷ α⇒⊗
+              ≈ α⇒⊗
+              ∘ᵥ Bimodule.actionʳ ((B₃ ⊗₀ B₂) ⊗₀ B₁)
+    linearʳ = Coequalizer⇒Epi
+                (postcompCoequalizer [F₃⊗F₂]⊗F₁ T₄)
+                (Bimodule.actionʳ (B₃ ⊗₀ B₂ ⊗₀ B₁) ∘ᵥ T₄ ▷ α⇒⊗)
+                (α⇒⊗ ∘ᵥ Bimodule.actionʳ ((B₃ ⊗₀ B₂) ⊗₀ B₁))
+                linearʳ∘arr
+-- end abstract --
+
+Associator⊗From : Bimodulehomomorphism ((B₃ ⊗₀ B₂) ⊗₀ B₁) (B₃ ⊗₀ B₂ ⊗₀ B₁)
+Associator⊗From = record
+  { α = _≅_.from 2-cell.Associator⊗Iso
+  ; linearˡ = Linear-Left.linearˡ
+  ; linearʳ = Linear-Right.linearʳ
+  }
+
+open import Categories.Category.Construction.Bimodules
+  renaming (Bimodules to Bimodules₁)
+open import Categories.Category.Construction.Bimodules.Properties
+
+Associator⊗ : Categories.Morphism._≅_ (Bimodules₁ M₁ M₄) ((B₃ ⊗₀ B₂) ⊗₀ B₁) (B₃ ⊗₀ B₂ ⊗₀ B₁) 
+Associator⊗ = 2cellisIso⇒Iso Associator⊗From α⇒⊗isIso
+  where
+    open Bimodulehom-isIso
+    α⇒⊗isIso : Categories.Morphism.IsIso (hom C₁ C₄) α⇒⊗
+    α⇒⊗isIso = record
+     { inv = _≅_.to 2-cell.Associator⊗Iso
+     ; iso = _≅_.iso 2-cell.Associator⊗Iso
+     }

--- a/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Associator/Naturality.agda
+++ b/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Associator/Naturality.agda
@@ -1,0 +1,331 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+
+open import Categories.Bicategory
+open import Categories.Bicategory.LocalCoequalizers
+
+open import Categories.Bicategory.Monad
+open import Categories.Bicategory.Monad.Bimodule
+  renaming (Bimodulehomomorphism to Bimodhom)
+
+
+-- We will define the associator in the bicategory of monads and bimodules. --
+
+module Categories.Bicategory.Construction.Bimodules.Tensorproduct.Associator.Naturality
+  {o ℓ e t} {𝒞 : Bicategory o ℓ e t} {localCoeq : LocalCoequalizers 𝒞} {M₁ M₂ M₃ M₄ : Monad 𝒞}
+  {B₃ B₃' : Bimodule M₃ M₄} {B₂ B₂' : Bimodule M₂ M₃} {B₁ B₁' : Bimodule M₁ M₂}
+  (f₃ : Bimodhom B₃ B₃') (f₂ : Bimodhom B₂ B₂') (f₁ : Bimodhom B₁ B₁') where
+
+import Categories.Bicategory.LocalCoequalizers
+open LocalCoequalizers localCoeq
+open import Categories.Bicategory.Construction.Bimodules.Tensorproduct {o} {ℓ} {e} {t} {𝒞} {localCoeq}
+
+private
+  _⊗₀_ = TensorproductOfBimodules.B₂⊗B₁
+  _⊗₁_ = TensorproductOfHomomorphisms.h₂⊗h₁
+
+infixr 30 _⊗₀_ _⊗₁_
+
+
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+import Categories.Diagram.Coequalizer
+
+-- To get constructions of the hom-categories with implicit arguments into scope --
+private
+  module HomCat {X} {Y} where
+    open Categories.Diagram.Coequalizer (hom X Y) public
+
+open HomCat
+
+
+open Bimodule B₁ using () renaming (F to F₁)
+open Bimodule B₃ using () renaming (F to F₃)
+open Bimodule B₁' using () renaming (F to F₁')
+open Bimodule B₂' using () renaming (F to F₂')
+open Bimodule B₃' using () renaming (F to F₃')
+
+open TensorproductOfBimodules B₂ B₁ using (F₂⊗F₁)
+open TensorproductOfBimodules B₃ B₂ using () renaming (F₂⊗F₁ to F₃⊗F₂)
+open TensorproductOfBimodules B₃ (B₂ ⊗₀ B₁) using () renaming (F₂⊗F₁ to F₃⊗[F₂⊗F₁])
+open TensorproductOfBimodules (B₃ ⊗₀ B₂) B₁ using () renaming (F₂⊗F₁ to [F₃⊗F₂]⊗F₁)
+
+open TensorproductOfBimodules B₂' B₁' using () renaming (F₂⊗F₁ to F₂'⊗F₁')
+open TensorproductOfBimodules B₃' B₂' using () renaming (F₂⊗F₁ to F₃'⊗F₂')
+open TensorproductOfBimodules (B₃' ⊗₀ B₂') B₁' using () renaming (F₂⊗F₁ to [F₃'⊗F₂']⊗F₁')
+open TensorproductOfBimodules B₃' (B₂' ⊗₀ B₁') using () renaming (F₂⊗F₁ to F₃'⊗[F₂'⊗F₁'])
+
+
+open import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Associator
+  {o} {ℓ} {e} {t} {𝒞} {localCoeq} {M₁} {M₂} {M₃} {M₄}
+  using (Associator⊗; α⇒⊗; hexagon)
+  
+abstract
+  α⇒⊗-natural∘arr∘arr : ((α⇒⊗ {B₃'} {B₂'} {B₁'}
+                          ∘ᵥ Bimodhom.α ((f₃ ⊗₁ f₂) ⊗₁ f₁))
+                          ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+                          ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁
+                        ≈ ((Bimodhom.α (f₃ ⊗₁ (f₂ ⊗₁ f₁))
+                            ∘ᵥ α⇒⊗ {B₃} {B₂} {B₁})
+                            ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+                            ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁
+  α⇒⊗-natural∘arr∘arr = begin
+
+    ((α⇒⊗ {B₃'} {B₂'} {B₁'}
+      ∘ᵥ Bimodhom.α ((f₃ ⊗₁ f₂) ⊗₁ f₁))
+      ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+      ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ assoc₂ ⟩
+
+    (α⇒⊗ {B₃'} {B₂'} {B₁'}
+      ∘ᵥ Bimodhom.α ((f₃ ⊗₁ f₂) ⊗₁ f₁))
+      ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+      ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ assoc₂ ⟩
+
+    α⇒⊗ {B₃'} {B₂'} {B₁'}
+    ∘ᵥ Bimodhom.α ((f₃ ⊗₁ f₂) ⊗₁ f₁)
+    ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+    α⇒⊗
+    ∘ᵥ (Bimodhom.α ((f₃ ⊗₁ f₂) ⊗₁ f₁)
+    ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ refl⟩∘⟨ ⟺ αSq[f₃⊗f₂]⊗f₁ ⟩∘⟨refl ⟩
+
+    α⇒⊗
+    ∘ᵥ (Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ Bimodhom.α (f₃ ⊗₁ f₂) ⊚₁ Bimodhom.α f₁)
+    ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+    α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ Bimodhom.α (f₃ ⊗₁ f₂) ⊚₁ Bimodhom.α f₁
+    ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                     ⟺ identity₂ˡ ⟩⊚⟨ ⟺ identity₂ʳ
+                                   ⟩∘⟨refl ⟩
+
+    α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ (id₂ ∘ᵥ Bimodhom.α (f₃ ⊗₁ f₂))
+        ⊚₁ (Bimodhom.α f₁ ∘ᵥ id₂)
+    ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                     ∘ᵥ-distr-⊚ ⟩∘⟨refl ⟩
+
+    α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ (Coequalizer.obj F₃'⊗F₂' ▷ Bimodhom.α f₁
+    ∘ᵥ Bimodhom.α (f₃ ⊗₁ f₂) ◁ F₁)
+    ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc₂ ⟩
+
+    α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ Coequalizer.obj F₃'⊗F₂' ▷ Bimodhom.α f₁
+    ∘ᵥ Bimodhom.α (f₃ ⊗₁ f₂) ◁ F₁
+    ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨
+                                     ◁-resp-sq (⟺ αSqf₃⊗f₂) ⟩
+
+    α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ Coequalizer.obj F₃'⊗F₂' ▷ Bimodhom.α f₁
+    ∘ᵥ Coequalizer.arr F₃'⊗F₂' ◁ F₁
+    ∘ᵥ Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂ ◁ F₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                              sym-assoc₂ ⟩
+
+    α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ (Coequalizer.obj F₃'⊗F₂' ▷ Bimodhom.α f₁
+    ∘ᵥ Coequalizer.arr F₃'⊗F₂' ◁ F₁)
+    ∘ᵥ Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂ ◁ F₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                              ◁-▷-exchg ⟩∘⟨refl ⟩
+
+    α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ (Coequalizer.arr F₃'⊗F₂' ◁ F₁'
+    ∘ᵥ (F₃' ∘₁ F₂') ▷ Bimodhom.α f₁)
+    ∘ᵥ Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂ ◁ F₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                              assoc₂ ⟩
+
+    α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ Coequalizer.arr F₃'⊗F₂' ◁ F₁'
+    ∘ᵥ (F₃' ∘₁ F₂') ▷ Bimodhom.α f₁
+    ∘ᵥ Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂ ◁ F₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨
+                                              ⟺ ∘ᵥ-distr-⊚ ⟩
+
+    α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ Coequalizer.arr F₃'⊗F₂' ◁ F₁'
+    ∘ᵥ (id₂ ∘ᵥ Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂)
+        ⊚₁ (Bimodhom.α f₁ ∘ᵥ id₂) ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨
+                                     identity₂ˡ ⟩⊚⟨ identity₂ʳ ⟩
+
+    α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ Coequalizer.arr F₃'⊗F₂' ◁ F₁'
+    ∘ᵥ (Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂)
+        ⊚₁ Bimodhom.α f₁ ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+    α⇒⊗
+    ∘ᵥ (Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ Coequalizer.arr F₃'⊗F₂' ◁ F₁')
+    ∘ᵥ (Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂)
+        ⊚₁ Bimodhom.α f₁ ≈⟨ sym-assoc₂ ⟩
+
+    (α⇒⊗
+    ∘ᵥ Coequalizer.arr [F₃'⊗F₂']⊗F₁'
+    ∘ᵥ Coequalizer.arr F₃'⊗F₂' ◁ F₁')
+    ∘ᵥ (Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂)
+        ⊚₁ Bimodhom.α f₁ ≈⟨ ⟺ (hexagon {B₃'} {B₂'} {B₁'}) ⟩∘⟨refl ⟩
+
+    (Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ F₃' ▷ Coequalizer.arr F₂'⊗F₁'
+    ∘ᵥ associator.from)
+    ∘ᵥ (Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂)
+        ⊚₁ Bimodhom.α f₁ ≈⟨ assoc₂ ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ (F₃' ▷ Coequalizer.arr F₂'⊗F₁'
+    ∘ᵥ associator.from)
+    ∘ᵥ (Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂)
+        ⊚₁ Bimodhom.α f₁ ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ F₃' ▷ Coequalizer.arr F₂'⊗F₁'
+    ∘ᵥ associator.from
+    ∘ᵥ (Bimodhom.α f₃ ⊚₁ Bimodhom.α f₂)
+        ⊚₁ Bimodhom.α f₁ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ α⇒-⊚ ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ F₃' ▷ Coequalizer.arr F₂'⊗F₁'
+    ∘ᵥ Bimodhom.α f₃
+       ⊚₁ (Bimodhom.α f₂ ⊚₁ Bimodhom.α f₁)
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                          (⟺ identity₂ʳ) ⟩⊚⟨ (⟺ identity₂ˡ)
+                        ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ F₃' ▷ Coequalizer.arr F₂'⊗F₁'
+    ∘ᵥ (Bimodhom.α f₃ ∘ᵥ id₂)
+       ⊚₁ (id₂ ∘ᵥ Bimodhom.α f₂ ⊚₁ Bimodhom.α f₁)
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                          ∘ᵥ-distr-⊚ ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ F₃' ▷ Coequalizer.arr F₂'⊗F₁'
+    ∘ᵥ (Bimodhom.α f₃ ◁ (F₂' ∘₁ F₁')
+    ∘ᵥ F₃ ▷ Bimodhom.α f₂ ⊚₁ Bimodhom.α f₁)
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ (F₃' ▷ Coequalizer.arr F₂'⊗F₁'
+    ∘ᵥ Bimodhom.α f₃ ◁ (F₂' ∘₁ F₁')
+    ∘ᵥ F₃ ▷ Bimodhom.α f₂ ⊚₁ Bimodhom.α f₁)
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ ((F₃' ▷ Coequalizer.arr F₂'⊗F₁'
+    ∘ᵥ Bimodhom.α f₃ ◁ (F₂' ∘₁ F₁'))
+    ∘ᵥ F₃ ▷ Bimodhom.α f₂ ⊚₁ Bimodhom.α f₁)
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ (◁-▷-exchg ⟩∘⟨refl) ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ ((Bimodhom.α f₃ ◁ Coequalizer.obj F₂'⊗F₁'
+    ∘ᵥ F₃ ▷ Coequalizer.arr F₂'⊗F₁')
+    ∘ᵥ F₃ ▷ Bimodhom.α f₂ ⊚₁ Bimodhom.α f₁)
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ assoc₂ ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ (Bimodhom.α f₃ ◁ Coequalizer.obj F₂'⊗F₁'
+    ∘ᵥ F₃ ▷ Coequalizer.arr F₂'⊗F₁'
+    ∘ᵥ F₃ ▷ Bimodhom.α f₂ ⊚₁ Bimodhom.α f₁)
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ (refl⟩∘⟨
+                          ▷-resp-sq αSqf₂⊗f₁) ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ (Bimodhom.α f₃ ◁ Coequalizer.obj F₂'⊗F₁'
+    ∘ᵥ F₃ ▷ Bimodhom.α (f₂ ⊗₁ f₁)
+    ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ ((Bimodhom.α f₃ ◁ Coequalizer.obj F₂'⊗F₁'
+    ∘ᵥ F₃ ▷ Bimodhom.α (f₂ ⊗₁ f₁))
+    ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ (⟺ ∘ᵥ-distr-⊚ ⟩∘⟨refl) ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ ((Bimodhom.α f₃ ∘ᵥ id₂)
+        ⊚₁ (id₂ ∘ᵥ Bimodhom.α (f₂ ⊗₁ f₁))
+    ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ (identity₂ʳ ⟩⊚⟨ identity₂ˡ ⟩∘⟨refl) ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ (Bimodhom.α f₃ ⊚₁ Bimodhom.α (f₂ ⊗₁ f₁)
+    ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ associator.from ≈⟨ (refl⟩∘⟨ assoc₂) ⟩
+
+    Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ Bimodhom.α f₃ ⊚₁ Bimodhom.α (f₂ ⊗₁ f₁)
+    ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ associator.from ≈⟨ sym-assoc₂ ⟩
+
+    (Coequalizer.arr F₃'⊗[F₂'⊗F₁']
+    ∘ᵥ Bimodhom.α f₃ ⊚₁ Bimodhom.α (f₂ ⊗₁ f₁))
+    ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ associator.from ≈⟨ αSqf₃⊗[f₂⊗f₁] ⟩∘⟨refl ⟩
+
+    (Bimodhom.α (f₃ ⊗₁ (f₂ ⊗₁ f₁))
+    ∘ᵥ Coequalizer.arr F₃⊗[F₂⊗F₁])
+    ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+
+    Bimodhom.α (f₃ ⊗₁ (f₂ ⊗₁ f₁))
+    ∘ᵥ Coequalizer.arr F₃⊗[F₂⊗F₁]
+    ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ hexagon {B₃} {B₂} {B₁} ⟩
+
+    Bimodhom.α (f₃ ⊗₁ (f₂ ⊗₁ f₁))
+    ∘ᵥ α⇒⊗ {B₃} {B₂} {B₁}
+    ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ sym-assoc₂ ⟩
+
+    (Bimodhom.α (f₃ ⊗₁ (f₂ ⊗₁ f₁))
+    ∘ᵥ α⇒⊗ {B₃} {B₂} {B₁})
+    ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ≈⟨ sym-assoc₂ ⟩
+
+    ((Bimodhom.α (f₃ ⊗₁ (f₂ ⊗₁ f₁))
+    ∘ᵥ α⇒⊗ {B₃} {B₂} {B₁})
+    ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁ ∎
+
+    where
+      open hom.HomReasoning
+      open TensorproductOfHomomorphisms f₂ f₁ renaming (αSq to αSqf₂⊗f₁)
+      open TensorproductOfHomomorphisms f₃ f₂ renaming (αSq to αSqf₃⊗f₂)
+      open TensorproductOfHomomorphisms (f₃ ⊗₁ f₂) f₁ renaming (αSq to αSq[f₃⊗f₂]⊗f₁)
+      open TensorproductOfHomomorphisms f₃ (f₂ ⊗₁ f₁) renaming (αSq to αSqf₃⊗[f₂⊗f₁])
+
+  α⇒⊗-natural∘arr : (α⇒⊗ {B₃'} {B₂'} {B₁'}
+                     ∘ᵥ Bimodhom.α ((f₃ ⊗₁ f₂) ⊗₁ f₁))
+                     ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+                     ≈ (Bimodhom.α (f₃ ⊗₁ (f₂ ⊗₁ f₁)) ∘ᵥ α⇒⊗ {B₃} {B₂} {B₁})
+                        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+  α⇒⊗-natural∘arr = Coequalizer⇒Epi
+                      (precompCoequalizer F₃⊗F₂ F₁)
+                      ((α⇒⊗ {B₃'} {B₂'} {B₁'}
+                        ∘ᵥ Bimodhom.α ((f₃ ⊗₁ f₂) ⊗₁ f₁))
+                        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+                      ((Bimodhom.α (f₃ ⊗₁ (f₂ ⊗₁ f₁))
+                        ∘ᵥ α⇒⊗ {B₃} {B₂} {B₁})
+                        ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+                      α⇒⊗-natural∘arr∘arr
+
+  α⇒⊗-natural : α⇒⊗ {B₃'} {B₂'} {B₁'}
+                ∘ᵥ Bimodhom.α ((f₃ ⊗₁ f₂) ⊗₁ f₁)
+                ≈ Bimodhom.α (f₃ ⊗₁ (f₂ ⊗₁ f₁))
+                  ∘ᵥ α⇒⊗ {B₃} {B₂} {B₁}
+  α⇒⊗-natural = Coequalizer⇒Epi
+                      [F₃⊗F₂]⊗F₁
+                      (α⇒⊗ ∘ᵥ Bimodhom.α ((f₃ ⊗₁ f₂) ⊗₁ f₁))
+                      (Bimodhom.α (f₃ ⊗₁ f₂ ⊗₁ f₁) ∘ᵥ α⇒⊗)
+                      α⇒⊗-natural∘arr
+-- end abstract --

--- a/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Coherence/Pentagon.agda
+++ b/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Coherence/Pentagon.agda
@@ -1,0 +1,708 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+
+open import Categories.Bicategory
+open import Categories.Bicategory.LocalCoequalizers
+
+open import Categories.Bicategory.Monad
+open import Categories.Bicategory.Monad.Bimodule renaming (Bimodulehomomorphism to Bimodhom)
+
+
+-- We will prove that the associator in the bicategory of monads and bimodules --
+-- satisfies the pentagon law. --
+
+module Categories.Bicategory.Construction.Bimodules.Tensorproduct.Coherence.Pentagon
+  {o ℓ e t} {𝒞 : Bicategory o ℓ e t} {localCoeq : LocalCoequalizers 𝒞} {M₁ M₂ M₃ M₄ M₅ : Monad 𝒞}
+  {B₄ : Bimodule M₄ M₅} {B₃ : Bimodule M₃ M₄} {B₂ : Bimodule M₂ M₃} {B₁ : Bimodule M₁ M₂} where
+
+import Categories.Bicategory.LocalCoequalizers
+open LocalCoequalizers localCoeq
+open import Categories.Bicategory.Construction.Bimodules.Tensorproduct {o} {ℓ} {e} {t} {𝒞} {localCoeq}
+private
+  _⊗₀_ = TensorproductOfBimodules.B₂⊗B₁
+  _⊗₁_ = TensorproductOfHomomorphisms.h₂⊗h₁
+  
+infixr 30 _⊗₀_ _⊗₁_
+
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+
+import Categories.Diagram.Coequalizer
+import Categories.Morphism
+
+-- To get constructions of the hom-categories with implicit arguments into scope --
+private
+  module HomCat {X} {Y} where
+    open Categories.Morphism (hom X Y) public using (_≅_)
+    open Categories.Diagram.Coequalizer (hom X Y) public
+
+open HomCat
+
+open import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Associator
+  {𝒞 = 𝒞} {localCoeq}
+  using (Associator⊗From; hexagon)
+
+open TensorproductOfHomomorphisms using (αSq)
+
+open Bimodule B₁ using () renaming (F to F₁)
+open Bimodule B₂ using () renaming (F to F₂)
+open Bimodule B₃ using () renaming (F to F₃)
+open Bimodule B₄ using () renaming (F to F₄)
+open TensorproductOfBimodules B₂ B₁ using (F₂⊗F₁)
+open TensorproductOfBimodules B₃ B₂ using () renaming (F₂⊗F₁ to F₃⊗F₂)
+open TensorproductOfBimodules B₄ B₃ using () renaming (F₂⊗F₁ to F₄⊗F₃)
+open TensorproductOfBimodules B₃ (B₂ ⊗₀ B₁) using () renaming (F₂⊗F₁ to F₃⊗F₂⊗F₁)
+open TensorproductOfBimodules (B₃ ⊗₀ B₂) B₁ using () renaming (F₂⊗F₁ to [F₃⊗F₂]⊗F₁)
+open TensorproductOfBimodules (B₄ ⊗₀ B₃) B₂ using () renaming (F₂⊗F₁ to [F₄⊗F₃]⊗F₂ )
+open TensorproductOfBimodules B₄ (B₃ ⊗₀ B₂) using () renaming (F₂⊗F₁ to F₄⊗F₃⊗F₂ )
+open TensorproductOfBimodules ((B₄ ⊗₀ B₃) ⊗₀ B₂) B₁ using () renaming (F₂⊗F₁ to [[F₄⊗F₃]⊗F₂]⊗F₁)
+open TensorproductOfBimodules (B₄ ⊗₀ B₃) (B₂ ⊗₀ B₁) using () renaming (F₂⊗F₁ to [F₄⊗F₃]⊗F₂⊗F₁)
+open TensorproductOfBimodules (B₄ ⊗₀ B₃ ⊗₀ B₂) B₁ using () renaming (F₂⊗F₁ to [F₄⊗F₃⊗F₂]⊗F₁)
+open TensorproductOfBimodules B₄ ((B₃ ⊗₀ B₂) ⊗₀  B₁) using () renaming (F₂⊗F₁ to F₄⊗[F₃⊗F₂]⊗F₁)
+open TensorproductOfBimodules B₄ (B₃ ⊗₀ B₂ ⊗₀ B₁) using () renaming (F₂⊗F₁ to F₄⊗F₃⊗F₂⊗F₁)
+
+abstract
+  -- We reduce the pentagon law for the tensorproduct to the pentagon law in 𝒞 --
+  -- For this, we consider a prism with the following five faces. --
+
+  face[[43]2]1⇒[43]21 : Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁})
+                        ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+                        ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+                        ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+                        ≈ (Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+                          ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁
+                          ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ (F₂ ∘₁ F₁))
+                          ∘ᵥ associator.from {f = F₄ ∘₁ F₃} {F₂} {F₁}
+  face[[43]2]1⇒[43]21 = begin
+  
+    Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁})
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+  
+    (Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁})
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+  
+    ((Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁})
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁)
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+  
+    (Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁})
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁)
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ ⟺ (hexagon {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁}) ⟩∘⟨refl ⟩
+  
+    (Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+    ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ associator.from {f = Coequalizer.obj F₄⊗F₃} {F₂} {F₁})
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ assoc₂ ⟩
+  
+    Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+    ∘ᵥ (Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ associator.from {f = Coequalizer.obj F₄⊗F₃} {F₂} {F₁})
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+  
+    Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+    ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ associator.from {f = Coequalizer.obj F₄⊗F₃} {F₂} {F₁}
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ α⇒-◁-∘₁ ⟩
+  
+    Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+    ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ (F₂ ∘₁ F₁)
+    ∘ᵥ associator.from {f = F₄ ∘₁ F₃} {F₂} {F₁}
+    ≈⟨ sym-assoc₂ ⟩
+  
+    (Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+    ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ (F₂ ∘₁ F₁)
+    ∘ᵥ associator.from {f = F₄ ∘₁ F₃} {F₂} {F₁}
+    ≈⟨ sym-assoc₂ ⟩
+  
+    ((Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+    ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ (F₂ ∘₁ F₁))
+    ∘ᵥ associator.from {f = F₄ ∘₁ F₃} {F₂} {F₁}
+    ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+    
+    (Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+    ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ (F₂ ∘₁ F₁))
+    ∘ᵥ associator.from {f = F₄ ∘₁ F₃} {F₂} {F₁} ∎
+    
+    where
+      open hom.HomReasoning
+
+  face[43]21⇒4321 : Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+                    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+                    ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁
+                    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ (F₂ ∘₁ F₁)
+                    ≈ (Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+                      ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+                      ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+                      ∘ᵥ associator.from {f = F₄} {F₃} {F₂ ∘₁ F₁}
+  face[43]21⇒4321 = begin
+  
+    Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+    ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ (F₂ ∘₁ F₁)
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ◁-▷-exchg ⟩
+
+    Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ Coequalizer.obj F₂⊗F₁
+    ∘ᵥ (F₄ ∘₁ F₃) ▷ Coequalizer.arr F₂⊗F₁
+    ≈⟨ sym-assoc₂ ⟩
+
+    (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁)
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ Coequalizer.obj F₂⊗F₁
+    ∘ᵥ (F₄ ∘₁ F₃) ▷ Coequalizer.arr F₂⊗F₁
+    ≈⟨ sym-assoc₂ ⟩
+
+    ((Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁)
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ Coequalizer.obj F₂⊗F₁)
+    ∘ᵥ (F₄ ∘₁ F₃) ▷ Coequalizer.arr F₂⊗F₁
+    ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+
+    (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ Coequalizer.obj F₂⊗F₁)
+    ∘ᵥ (F₄ ∘₁ F₃) ▷ Coequalizer.arr F₂⊗F₁
+    ≈⟨ ⟺ (hexagon {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁}) ⟩∘⟨refl ⟩
+
+    (Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+    ∘ᵥ associator.from {f = F₄} {F₃} {Coequalizer.obj F₂⊗F₁})
+    ∘ᵥ (F₄ ∘₁ F₃) ▷ Coequalizer.arr F₂⊗F₁
+    ≈⟨ assoc₂ ⟩
+
+    Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+    ∘ᵥ associator.from {f = F₄} {F₃} {Coequalizer.obj F₂⊗F₁})
+    ∘ᵥ (F₄ ∘₁ F₃) ▷ Coequalizer.arr F₂⊗F₁
+    ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+
+    Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+    ∘ᵥ associator.from {f = F₄} {F₃} {Coequalizer.obj F₂⊗F₁}
+    ∘ᵥ (F₄ ∘₁ F₃) ▷ Coequalizer.arr F₂⊗F₁
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ α⇒-▷-∘₁ ⟩
+
+    Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂ ∘₁ F₁}
+    ≈⟨ sym-assoc₂ ⟩
+
+    (Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁)
+    ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂ ∘₁ F₁}
+    ≈⟨ sym-assoc₂ ⟩
+
+    ((Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁)
+    ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂ ∘₁ F₁}
+    ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+
+    (Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂ ∘₁ F₁} ∎
+    
+    where
+      open hom.HomReasoning
+
+  face[[43]2]1⇒[432]1 : Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁})
+                        ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+                        ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+                        ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+                        ≈ (Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+                          ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁
+                          ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁)
+                          ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+  face[[43]2]1⇒[432]1 = begin
+  
+    Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁})
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+  
+    (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁})
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ ⟺ (αSq (Associator⊗From {B₃ = B₄} {B₃} {B₂}) (id-bimodule-hom {B = B₁})) ⟩∘⟨refl ⟩
+  
+    (Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂}) ◁ F₁)
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ assoc₂ ⟩
+  
+    Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂}) ◁ F₁
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+  
+    Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂}) ◁ F₁
+    ∘ᵥ (Coequalizer.arr [F₄⊗F₃]⊗F₂
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂) ◁ F₁
+    ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+  
+    Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂})
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂) ◁ F₁
+    ≈⟨ refl⟩∘⟨ ◁-resp-≈ (⟺ (hexagon {B₃ = B₄} {B₃} {B₂})) ⟩
+  
+    Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ (Coequalizer.arr F₄⊗F₃⊗F₂
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂}) ◁ F₁
+    ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩
+  
+    Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂}) ◁ F₁
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩
+  
+    Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+  
+    (Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁)
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+  
+    ((Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁)
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁)
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+    ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+
+    (Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁)
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁ ∎
+    
+    where
+      open hom.HomReasoning
+
+  face[432]1⇒4[32]1 : Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+                      ∘ᵥ Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+                      ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁
+                      ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+                      ≈ (Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+                        ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+                        ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁))
+                        ∘ᵥ associator.from {f = F₄} {F₃ ∘₁ F₂} {F₁}
+  face[432]1⇒4[32]1 = begin
+  
+    Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+  
+    (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+  
+    ((Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁)
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+    ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+  
+    (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁)
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+    ≈⟨ ⟺ (hexagon {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁}) ⟩∘⟨refl ⟩
+  
+    (Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ associator.from {f = F₄} {Coequalizer.obj F₃⊗F₂} {F₁})
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+    ≈⟨ assoc₂ ⟩
+  
+    Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+    ∘ᵥ (F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ associator.from {f = F₄} {Coequalizer.obj F₃⊗F₂} {F₁})
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+    ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+  
+    Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ associator.from {f = F₄} {Coequalizer.obj F₃⊗F₂} {F₁}
+    ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ α⇒-▷-◁ ⟩
+  
+    Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁)
+    ∘ᵥ associator.from {f = F₄} {F₃ ∘₁ F₂} {F₁}
+    ≈⟨ sym-assoc₂ ⟩
+  
+    (Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+    ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁)
+    ∘ᵥ associator.from {f = F₄} {F₃ ∘₁ F₂} {F₁}
+    ≈⟨ sym-assoc₂ ⟩
+  
+    ((Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁)
+    ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁))
+    ∘ᵥ associator.from {f = F₄} {F₃ ∘₁ F₂} {F₁}
+    ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+    
+    (Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁))
+    ∘ᵥ associator.from {f = F₄} {F₃ ∘₁ F₂} {F₁} ∎
+    
+    where
+      open hom.HomReasoning
+
+  face4[32]1⇒4321 : Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+                    ∘ᵥ Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+                    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+                    ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁)
+                    ≈ (Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+                      ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+                      ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+                      ∘ᵥ F₄ ▷ associator.from {f = F₃} {F₂} {F₁}
+  face4[32]1⇒4321 = begin
+
+    Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+    ∘ᵥ Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁)
+    ≈⟨ sym-assoc₂ ⟩
+
+    (Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+    ∘ᵥ Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁)
+    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁)
+    ≈⟨ ⟺ (αSq (id-bimodule-hom {B = B₄}) (Associator⊗From {B₃ = B₃} {B₂} {B₁})) ⟩∘⟨refl ⟩
+
+    (Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Bimodhom.α (Associator⊗From {B₃ = B₃} {B₂} {B₁}))
+    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁)
+    ≈⟨ assoc₂ ⟩
+
+    Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Bimodhom.α (Associator⊗From {B₃ = B₃} {B₂} {B₁})
+    ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+    ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁)
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+
+    Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Bimodhom.α (Associator⊗From {B₃ = B₃} {B₂} {B₁})
+    ∘ᵥ F₄ ▷ (Coequalizer.arr [F₃⊗F₂]⊗F₁
+             ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁)
+    ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+
+    Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ (Bimodhom.α (Associator⊗From {B₃ = B₃} {B₂} {B₁})
+             ∘ᵥ Coequalizer.arr [F₃⊗F₂]⊗F₁
+             ∘ᵥ Coequalizer.arr F₃⊗F₂ ◁ F₁)
+    ≈⟨ refl⟩∘⟨ ▷-resp-≈ (⟺ (hexagon {B₃ = B₃} {B₂} {B₁})) ⟩
+
+    Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂⊗F₁
+             ∘ᵥ F₃ ▷ Coequalizer.arr F₂⊗F₁
+             ∘ᵥ associator.from {f = F₃} {F₂} {F₁})
+    ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-▷ ⟩
+
+    Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ (F₃ ▷ Coequalizer.arr F₂⊗F₁
+             ∘ᵥ associator.from {f = F₃} {F₂} {F₁})
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-▷ ⟩
+
+    Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ F₄ ▷ associator.from {f = F₃} {F₂} {F₁}
+    ≈⟨ sym-assoc₂ ⟩
+
+    (Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁)
+    ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁
+    ∘ᵥ F₄ ▷ associator.from {f = F₃} {F₂} {F₁}
+    ≈⟨ sym-assoc₂ ⟩
+
+    ((Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁)
+    ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ F₄ ▷ associator.from {f = F₃} {F₂} {F₁}
+    ≈⟨ assoc₂ ⟩∘⟨refl ⟩
+
+    (Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+    ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ F₄ ▷ associator.from {f = F₃} {F₂} {F₁} ∎
+
+    where
+      open hom.HomReasoning
+
+abstract
+  pentagon⊗∘arr³ : (((Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+                   ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+                   ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁}))
+                   ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+                   ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁)
+                   ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+                   ≈ (((Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+                     ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁}))
+                     ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+                     ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁)
+                     ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+  pentagon⊗∘arr³ = begin
+  
+    (((Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁}))
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁)
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ assoc₂ ⟩
+  
+    ((Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁}))
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ assoc₂ ⟩
+  
+    (Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁}))
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ assoc₂ ⟩
+  
+    Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+    ∘ᵥ (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁}))
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+  
+    Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+      ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁})
+      ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+      ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+      ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ face[[43]2]1⇒[432]1 ⟩
+  
+    Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+      ∘ᵥ (Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+      ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁
+      ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁)
+      ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+    ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+  
+    Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+      ∘ᵥ (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+      ∘ᵥ Coequalizer.arr [F₄⊗F₃⊗F₂]⊗F₁
+      ∘ᵥ Coequalizer.arr F₄⊗F₃⊗F₂ ◁ F₁
+      ∘ᵥ (F₄ ▷ Coequalizer.arr F₃⊗F₂) ◁ F₁)
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+    ≈⟨ refl⟩∘⟨ face[432]1⇒4[32]1 ⟩∘⟨refl ⟩
+  
+    Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+      ∘ᵥ ((Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+      ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+      ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁))
+      ∘ᵥ associator.from {f = F₄} {F₃ ∘₁ F₂} {F₁})
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+    ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+  
+    Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+      ∘ᵥ (Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+      ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+      ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁))
+    ∘ᵥ associator.from {f = F₄} {F₃ ∘₁ F₂} {F₁}
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+  
+      (Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+      ∘ᵥ Coequalizer.arr F₄⊗[F₃⊗F₂]⊗F₁
+      ∘ᵥ F₄ ▷ Coequalizer.arr [F₃⊗F₂]⊗F₁
+      ∘ᵥ F₄ ▷ (Coequalizer.arr F₃⊗F₂ ◁ F₁))
+    ∘ᵥ associator.from {f = F₄} {F₃ ∘₁ F₂} {F₁}
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+    ≈⟨ face4[32]1⇒4321 ⟩∘⟨refl ⟩
+  
+      ((Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+      ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+      ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+      ∘ᵥ F₄ ▷ associator.from {f = F₃} {F₂} {F₁})
+    ∘ᵥ associator.from {f = F₄} {F₃ ∘₁ F₂} {F₁}
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+    ≈⟨ assoc₂ ⟩
+  
+      (Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+      ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+      ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ F₄ ▷ associator.from {f = F₃} {F₂} {F₁}
+    ∘ᵥ associator.from {f = F₄} {F₃ ∘₁ F₂} {F₁}
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂} ◁ F₁
+    ≈⟨ refl⟩∘⟨ pentagon ⟩
+  
+      (Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+      ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+      ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+    ∘ᵥ associator.from {f = F₄} {F₃} {F₂ ∘₁ F₁}
+    ∘ᵥ associator.from {f = F₄ ∘₁ F₃} {F₂} {F₁}
+    ≈⟨ sym-assoc₂ ⟩
+  
+      ((Coequalizer.arr F₄⊗F₃⊗F₂⊗F₁
+      ∘ᵥ F₄ ▷ Coequalizer.arr F₃⊗F₂⊗F₁
+      ∘ᵥ F₄ ▷ F₃ ▷ Coequalizer.arr F₂⊗F₁)
+      ∘ᵥ associator.from {f = F₄} {F₃} {F₂ ∘₁ F₁})
+    ∘ᵥ associator.from {f = F₄ ∘₁ F₃} {F₂} {F₁}
+    ≈⟨ ⟺ face[43]21⇒4321 ⟩∘⟨refl ⟩
+  
+      (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+      ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+      ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁
+      ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ (F₂ ∘₁ F₁))
+    ∘ᵥ associator.from {f = F₄ ∘₁ F₃} {F₂} {F₁}
+    ≈⟨ assoc₂ ⟩
+  
+    Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+      ∘ᵥ (Coequalizer.arr [F₄⊗F₃]⊗F₂⊗F₁
+      ∘ᵥ Coequalizer.obj F₄⊗F₃ ▷ Coequalizer.arr F₂⊗F₁
+      ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ (F₂ ∘₁ F₁))
+      ∘ᵥ associator.from {f = F₄ ∘₁ F₃} {F₂} {F₁}
+    ≈⟨ refl⟩∘⟨ ⟺ face[[43]2]1⇒[43]21 ⟩
+  
+    Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+      ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁})
+      ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+      ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+      ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+  
+    (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁}))
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+  
+    ((Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁}))
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+      
+    (((Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁}))
+    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁)
+    ∘ᵥ Coequalizer.arr F₄⊗F₃ ◁ F₂ ◁ F₁ ∎
+      
+    where
+      open hom.HomReasoning
+
+abstract
+  pentagon⊗∘arr² : ((Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+                   ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+                   ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁}))
+                   ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+                   ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+                   ≈ ((Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+                     ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁}))
+                     ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+                     ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁
+  pentagon⊗∘arr² = Coequalizer⇒Epi
+  
+                     (precompCoequalizer (precompCoequalizer F₄⊗F₃ F₂) F₁)
+                     
+                     (((Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+                     ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+                     ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁}))
+                     ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+                     ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁)
+                     
+                     (((Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+                     ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁}))
+                     ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+                     ∘ᵥ Coequalizer.arr [F₄⊗F₃]⊗F₂ ◁ F₁)
+                     
+                     pentagon⊗∘arr³
+
+  pentagon⊗∘arr : (Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+                  ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+                  ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁}))
+                  ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+                   ≈ (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+                     ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁}))
+                     ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁
+  pentagon⊗∘arr = Coequalizer⇒Epi
+  
+                    (precompCoequalizer [F₄⊗F₃]⊗F₂ F₁)
+                     
+                    ((Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+                    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+                    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁}))
+                    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+                  
+                    ((Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+                    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁}))
+                    ∘ᵥ Coequalizer.arr [[F₄⊗F₃]⊗F₂]⊗F₁)
+                    
+                    pentagon⊗∘arr²
+
+  pentagon⊗ : Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+              ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+              ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁})
+              ≈ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+                ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁})
+  pentagon⊗ = Coequalizer⇒Epi
+  
+                [[F₄⊗F₃]⊗F₂]⊗F₁
+                     
+                (Bimodhom.α (id-bimodule-hom {B = B₄} ⊗₁ Associator⊗From {B₃ = B₃} {B₂} {B₁})
+                ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃ ⊗₀ B₂} {B₁})
+                ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂} ⊗₁ id-bimodule-hom {B = B₁}))
+                  
+                (Bimodhom.α (Associator⊗From {B₃ = B₄} {B₃} {B₂ ⊗₀ B₁})
+                ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₄ ⊗₀ B₃} {B₂} {B₁}))
+                    
+                pentagon⊗∘arr

--- a/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Coherence/Triangle.agda
+++ b/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Coherence/Triangle.agda
@@ -1,0 +1,197 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+
+open import Categories.Bicategory
+open import Categories.Bicategory.LocalCoequalizers
+
+open import Categories.Bicategory.Monad
+open import Categories.Bicategory.Monad.Bimodule renaming (Bimodulehomomorphism to Bimodhom)
+
+
+-- We will prove that the associator and unitor in the bicategory of monads and bimodules --
+-- satisfies the triangle law. --
+
+module Categories.Bicategory.Construction.Bimodules.Tensorproduct.Coherence.Triangle
+  {o ℓ e t} {𝒞 : Bicategory o ℓ e t} {localCoeq : LocalCoequalizers 𝒞} {M₁ M₂ M₃ : Monad 𝒞}
+  {B₂ : Bimodule M₂ M₃} {B₁ : Bimodule M₁ M₂} where
+
+import Categories.Bicategory.LocalCoequalizers
+open LocalCoequalizers localCoeq
+open import Categories.Bicategory.Construction.Bimodules.Tensorproduct {o} {ℓ} {e} {t} {𝒞} {localCoeq}
+private
+  _⊗₀_ = TensorproductOfBimodules.B₂⊗B₁
+  _⊗₁_ = TensorproductOfHomomorphisms.h₂⊗h₁
+  
+infixr 30 _⊗₀_ _⊗₁_
+
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+
+import Categories.Diagram.Coequalizer
+import Categories.Morphism
+import Categories.Morphism.Reasoning.Iso
+
+-- To get constructions of the hom-categories with implicit arguments into scope --
+private
+  module HomCat {X} {Y} where
+    open Categories.Morphism (hom X Y) public using (_≅_)
+    open Categories.Diagram.Coequalizer (hom X Y) public
+    open Categories.Morphism.Reasoning.Iso (hom X Y) public
+
+open HomCat
+
+open import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Associator
+  {𝒞 = 𝒞} {localCoeq}
+  using (Associator⊗From; hexagon)
+import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Unitor
+  {𝒞 = 𝒞} {localCoeq} as Unitor
+open Unitor.Left-Unitor using (Unitorˡ⊗From) renaming (triangle to left-unitor-triangle)
+open Unitor.Right-Unitor using (Unitorʳ⊗From) renaming (triangle to right-unitor-triangle)
+
+open TensorproductOfHomomorphisms using (αSq)
+
+open Monad M₂ using () renaming (T to T₂)
+open Bimodule B₁ using () renaming (F to F₁; actionʳ to actionʳ₁)
+open Bimodule B₂ using () renaming (F to F₂; actionˡ to actionˡ₂)
+
+
+open TensorproductOfBimodules B₂ B₁ using (F₂⊗F₁)
+open TensorproductOfBimodules (id-bimodule M₂) B₁ using () renaming (F₂⊗F₁ to T₂⊗F₁)
+open TensorproductOfBimodules B₂ (id-bimodule M₂) using () renaming (F₂⊗F₁ to F₂⊗T₂)
+open TensorproductOfBimodules B₂ (id-bimodule M₂ ⊗₀ B₁) using () renaming (F₂⊗F₁ to F₂⊗[T₂⊗F₁])
+open TensorproductOfBimodules (B₂ ⊗₀ id-bimodule M₂) B₁ using () renaming (F₂⊗F₁ to [F₂⊗T₂]⊗F₁)
+
+abstract
+  triangle⊗∘arr² : ((Bimodhom.α (id-bimodule-hom {B = B₂} ⊗₁ Unitorˡ⊗From {B = B₁})
+                   ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₂} {id-bimodule M₂} {B₁}))
+                   ∘ᵥ Coequalizer.arr [F₂⊗T₂]⊗F₁)
+                   ∘ᵥ Coequalizer.arr F₂⊗T₂ ◁ F₁
+                   ≈ (Bimodhom.α (Unitorʳ⊗From {B = B₂} ⊗₁ id-bimodule-hom {B = B₁})
+                     ∘ᵥ Coequalizer.arr [F₂⊗T₂]⊗F₁)
+                     ∘ᵥ Coequalizer.arr F₂⊗T₂ ◁ F₁
+  triangle⊗∘arr² = begin
+
+    ((Bimodhom.α (id-bimodule-hom {B = B₂} ⊗₁ Unitorˡ⊗From {B = B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₂} {id-bimodule M₂} {B₁}))
+    ∘ᵥ Coequalizer.arr [F₂⊗T₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr F₂⊗T₂ ◁ F₁
+    ≈⟨ assoc₂ ⟩
+
+    (Bimodhom.α (id-bimodule-hom {B = B₂} ⊗₁ Unitorˡ⊗From {B = B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₂} {id-bimodule M₂} {B₁}))
+    ∘ᵥ Coequalizer.arr [F₂⊗T₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₂⊗T₂ ◁ F₁
+    ≈⟨ assoc₂ ⟩
+
+    Bimodhom.α (id-bimodule-hom {B = B₂} ⊗₁ Unitorˡ⊗From {B = B₁})
+    ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₂} {id-bimodule M₂} {B₁})
+    ∘ᵥ Coequalizer.arr [F₂⊗T₂]⊗F₁
+    ∘ᵥ Coequalizer.arr F₂⊗T₂ ◁ F₁
+    ≈⟨ refl⟩∘⟨ ⟺ (hexagon {B₃ = B₂} {id-bimodule M₂} {B₁}) ⟩
+
+    Bimodhom.α (id-bimodule-hom {B = B₂} ⊗₁ Unitorˡ⊗From {B = B₁})
+    ∘ᵥ Coequalizer.arr F₂⊗[T₂⊗F₁]
+    ∘ᵥ F₂ ▷ Coequalizer.arr T₂⊗F₁
+    ∘ᵥ associator.from {f = F₂} {T₂} {F₁}
+    ≈⟨ sym-assoc₂ ⟩
+
+    (Bimodhom.α (id-bimodule-hom {B = B₂} ⊗₁ Unitorˡ⊗From {B = B₁})
+    ∘ᵥ Coequalizer.arr F₂⊗[T₂⊗F₁])
+    ∘ᵥ F₂ ▷ Coequalizer.arr T₂⊗F₁
+    ∘ᵥ associator.from {f = F₂} {T₂} {F₁}
+    ≈⟨ ⟺ (αSq (id-bimodule-hom {B = B₂}) (Unitorˡ⊗From {B = B₁})) ⟩∘⟨refl ⟩
+
+    (Coequalizer.arr F₂⊗F₁
+    ∘ᵥ F₂ ▷ Bimodhom.α (Unitorˡ⊗From {B = B₁}))
+    ∘ᵥ F₂ ▷ Coequalizer.arr T₂⊗F₁
+    ∘ᵥ associator.from {f = F₂} {T₂} {F₁}
+    ≈⟨ assoc₂ ⟩
+
+    Coequalizer.arr F₂⊗F₁
+    ∘ᵥ F₂ ▷ Bimodhom.α (Unitorˡ⊗From {B = B₁})
+    ∘ᵥ F₂ ▷ Coequalizer.arr T₂⊗F₁
+    ∘ᵥ associator.from {f = F₂} {T₂} {F₁}
+    ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+
+    Coequalizer.arr F₂⊗F₁
+    ∘ᵥ (F₂ ▷ Bimodhom.α (Unitorˡ⊗From {B = B₁})
+    ∘ᵥ F₂ ▷ Coequalizer.arr T₂⊗F₁)
+    ∘ᵥ associator.from {f = F₂} {T₂} {F₁}
+    ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₂⊗F₁
+    ∘ᵥ F₂ ▷ (Bimodhom.α (Unitorˡ⊗From {B = B₁})
+            ∘ᵥ Coequalizer.arr T₂⊗F₁)
+    ∘ᵥ associator.from {f = F₂} {T₂} {F₁}
+    ≈⟨ refl⟩∘⟨ ▷-resp-≈ (left-unitor-triangle {B = B₁}) ⟩∘⟨refl ⟩
+
+    Coequalizer.arr F₂⊗F₁
+    ∘ᵥ F₂ ▷ actionʳ₁
+    ∘ᵥ associator.from {f = F₂} {T₂} {F₁}
+    ≈⟨ sym-assoc₂ ⟩
+
+    (Coequalizer.arr F₂⊗F₁
+    ∘ᵥ F₂ ▷ actionʳ₁)
+    ∘ᵥ associator.from {f = F₂} {T₂} {F₁}
+    ≈⟨ ⟺ (switch-tofromʳ associator F₂⊗F₁equality-var) ⟩
+
+    Coequalizer.arr F₂⊗F₁
+    ∘ᵥ actionˡ₂ ◁ F₁
+    ≈⟨ refl⟩∘⟨ ◁-resp-≈ ( ⟺ (right-unitor-triangle {B = B₂})) ⟩
+
+    Coequalizer.arr F₂⊗F₁
+    ∘ᵥ (Bimodhom.α (Unitorʳ⊗From {B = B₂})
+        ∘ᵥ Coequalizer.arr F₂⊗T₂) ◁ F₁
+    ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩
+
+    Coequalizer.arr F₂⊗F₁
+    ∘ᵥ Bimodhom.α (Unitorʳ⊗From {B = B₂}) ◁ F₁
+    ∘ᵥ Coequalizer.arr F₂⊗T₂ ◁ F₁
+    ≈⟨ sym-assoc₂ ⟩
+
+    (Coequalizer.arr F₂⊗F₁
+    ∘ᵥ Bimodhom.α (Unitorʳ⊗From {B = B₂}) ◁ F₁)
+    ∘ᵥ Coequalizer.arr F₂⊗T₂ ◁ F₁
+    ≈⟨ αSq (Unitorʳ⊗From {B = B₂})(id-bimodule-hom {B = B₁}) ⟩∘⟨refl ⟩
+
+    (Bimodhom.α (Unitorʳ⊗From {B = B₂} ⊗₁ id-bimodule-hom {B = B₁})
+    ∘ᵥ Coequalizer.arr [F₂⊗T₂]⊗F₁)
+    ∘ᵥ Coequalizer.arr F₂⊗T₂ ◁ F₁ ∎
+
+    where
+      open hom.HomReasoning
+      
+      F₂⊗F₁equality-var : (Coequalizer.arr F₂⊗F₁
+                          ∘ᵥ actionˡ₂ ◁ F₁)
+                          ∘ᵥ associator.to {f = F₂} {T₂} {F₁}
+                          ≈ Coequalizer.arr F₂⊗F₁
+                            ∘ᵥ F₂ ▷ actionʳ₁
+      F₂⊗F₁equality-var = begin
+        (Coequalizer.arr F₂⊗F₁ ∘ᵥ actionˡ₂ ◁ F₁) ∘ᵥ associator.to ≈⟨ assoc₂ ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ actionˡ₂ ◁ F₁ ∘ᵥ associator.to ≈⟨ ⟺ (Coequalizer.equality F₂⊗F₁) ⟩
+        Coequalizer.arr F₂⊗F₁ ∘ᵥ F₂ ▷ actionʳ₁ ∎
+  
+  triangle⊗∘arr : (Bimodhom.α (id-bimodule-hom {B = B₂} ⊗₁ Unitorˡ⊗From {B = B₁})
+                  ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₂} {id-bimodule M₂} {B₁}))
+                  ∘ᵥ Coequalizer.arr [F₂⊗T₂]⊗F₁
+                  ≈ Bimodhom.α (Unitorʳ⊗From {B = B₂} ⊗₁ id-bimodule-hom {B = B₁})
+                    ∘ᵥ Coequalizer.arr [F₂⊗T₂]⊗F₁
+                    
+  triangle⊗∘arr = Coequalizer⇒Epi
+                    (precompCoequalizer F₂⊗T₂ F₁)
+                    ((Bimodhom.α (id-bimodule-hom ⊗₁ Unitorˡ⊗From)
+                    ∘ᵥ Bimodhom.α Associator⊗From)
+                    ∘ᵥ Coequalizer.arr [F₂⊗T₂]⊗F₁)
+                    (Bimodhom.α (Unitorʳ⊗From ⊗₁ id-bimodule-hom)
+                    ∘ᵥ Coequalizer.arr [F₂⊗T₂]⊗F₁)
+                    triangle⊗∘arr²
+  
+  triangle⊗ : Bimodhom.α (id-bimodule-hom {B = B₂} ⊗₁ Unitorˡ⊗From {B = B₁})
+              ∘ᵥ Bimodhom.α (Associator⊗From {B₃ = B₂} {id-bimodule M₂} {B₁})
+              ≈ Bimodhom.α (Unitorʳ⊗From {B = B₂} ⊗₁ id-bimodule-hom {B = B₁})
+
+  triangle⊗ = Coequalizer⇒Epi
+                [F₂⊗T₂]⊗F₁
+                (Bimodhom.α (id-bimodule-hom ⊗₁ Unitorˡ⊗From)
+                ∘ᵥ Bimodhom.α Associator⊗From)
+                (Bimodhom.α (Unitorʳ⊗From ⊗₁ id-bimodule-hom))
+                triangle⊗∘arr

--- a/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Functorial.agda
+++ b/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Functorial.agda
@@ -1,0 +1,99 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Bicategory
+open import Categories.Bicategory.LocalCoequalizers
+
+module Categories.Bicategory.Construction.Bimodules.Tensorproduct.Functorial {o ℓ e t} {𝒞 : Bicategory o ℓ e t} {localCoeq : LocalCoequalizers 𝒞} where
+
+open import Categories.Bicategory.Monad
+open import Level
+open import Categories.Bicategory.Monad.Bimodule {o} {ℓ} {e} {t} {𝒞}
+open Bimodulehomomorphism
+open import Categories.Bicategory.Construction.Bimodules.Tensorproduct {o} {ℓ} {e} {t} {𝒞} {localCoeq}
+
+_⊗₀_ = TensorproductOfBimodules.B₂⊗B₁
+_⊗₁_ = TensorproductOfHomomorphisms.h₂⊗h₁
+
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+open import Categories.Diagram.Coequalizer
+
+module Identity {M₁ M₂ M₃ : Monad 𝒞} (B₂ : Bimodule M₂ M₃) (B₁ : Bimodule M₁ M₂) where
+  open Monad M₁ using () renaming (C to C₁)
+  open Monad M₃ using () renaming (C to C₃)
+  open TensorproductOfBimodules B₂ B₁ using (F₂⊗F₁)
+
+  ⊗₁-resp-id₂∘arr : α (id-bimodule-hom {B = B₂} ⊗₁ id-bimodule-hom {B = B₁}) ∘ᵥ Coequalizer.arr F₂⊗F₁
+                 ≈ id₂ ∘ᵥ Coequalizer.arr F₂⊗F₁
+  ⊗₁-resp-id₂∘arr = begin
+    α (id-bimodule-hom {B = B₂} ⊗₁ id-bimodule-hom {B = B₁}) ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈⟨ ⟺ αSq ⟩
+    Coequalizer.arr F₂⊗F₁ ∘ᵥ (id₂ ⊚₁ id₂) ≈⟨ refl⟩∘⟨ ⊚.identity ⟩
+    Coequalizer.arr F₂⊗F₁ ∘ᵥ id₂ ≈⟨ identity₂ʳ ⟩
+    Coequalizer.arr F₂⊗F₁ ≈⟨ ⟺ identity₂ˡ ⟩
+    id₂ ∘ᵥ Coequalizer.arr F₂⊗F₁ ∎
+    where
+      open hom.HomReasoning
+      open TensorproductOfHomomorphisms {B₂ = B₂} {B₂} {B₁} {B₁} (id-bimodule-hom) (id-bimodule-hom) using (αSq)
+
+  ⊗₁-resp-id₂ : α (id-bimodule-hom {B = B₂} ⊗₁ id-bimodule-hom {B = B₁}) ≈ id₂
+  ⊗₁-resp-id₂ = Coequalizer⇒Epi (hom C₁ C₃) F₂⊗F₁
+                             (α (id-bimodule-hom {B = B₂} ⊗₁ id-bimodule-hom  {B = B₁}))
+                             (α (id-bimodule-hom {B = B₂ ⊗₀ B₁}))
+                             ⊗₁-resp-id₂∘arr
+
+module Composition {M₁ M₂ M₃ : Monad 𝒞} {B₂ B'₂ B''₂ : Bimodule M₂ M₃} {B₁ B'₁ B''₁ : Bimodule M₁ M₂}
+                            (h₂ : Bimodulehomomorphism B'₂ B''₂) (h₁ : Bimodulehomomorphism B'₁ B''₁)
+                            (g₂ : Bimodulehomomorphism B₂ B'₂) (g₁ : Bimodulehomomorphism B₁ B'₁) where
+
+  open Monad M₁ using () renaming (C to C₁)
+  open Monad M₃ using () renaming (C to C₃)
+  open TensorproductOfBimodules B₂ B₁ using (F₂⊗F₁)
+    
+  ⊗₁-distr-∘ᵥ∘arr : α (bimodule-hom-∘ h₂ g₂ ⊗₁ bimodule-hom-∘ h₁ g₁) ∘ᵥ Coequalizer.arr F₂⊗F₁
+                    ≈ (α (h₂ ⊗₁ h₁) ∘ᵥ α (g₂ ⊗₁ g₁)) ∘ᵥ Coequalizer.arr F₂⊗F₁
+  ⊗₁-distr-∘ᵥ∘arr = begin
+    α (bimodule-hom-∘ h₂ g₂ ⊗₁ bimodule-hom-∘ h₁ g₁) ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈⟨ ⟺ αSq ⟩
+    Coequalizer.arr F''₂⊗F''₁ ∘ᵥ ((α h₂ ∘ᵥ α g₂) ⊚₁
+      ((α h₁ ∘ᵥ Bimodulehomomorphism.α g₁))) ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-⊚ ⟩
+    Coequalizer.arr F''₂⊗F''₁ ∘ᵥ (α h₂ ⊚₁ α h₁)
+      ∘ᵥ (α g₂ ⊚₁ α g₁) ≈⟨ glue′ (hom C₁ C₃) αᵍSq αʰSq ⟩
+    (α (h₂ ⊗₁ h₁) ∘ᵥ α (g₂ ⊗₁ g₁)) ∘ᵥ Coequalizer.arr F₂⊗F₁ ∎
+    where
+      open hom.HomReasoning
+      open import Categories.Morphism.Reasoning.Core
+      open TensorproductOfBimodules B'₂ B'₁ using () renaming (F₂⊗F₁ to F'₂⊗F'₁)
+      open TensorproductOfBimodules B''₂ B''₁ using () renaming (F₂⊗F₁ to F''₂⊗F''₁)
+      open TensorproductOfHomomorphisms {B₂ = B₂} {B''₂} {B₁} {B''₁} (bimodule-hom-∘ h₂ g₂) (bimodule-hom-∘ h₁ g₁) using (αSq)
+      open TensorproductOfHomomorphisms {B₂ = B'₂} {B''₂} {B'₁} {B''₁} h₂ h₁ using () renaming (αSq to αᵍSq)
+      open TensorproductOfHomomorphisms {B₂ = B₂} {B'₂} {B₁} {B'₁} g₂ g₁ using () renaming (αSq to αʰSq)
+
+  ⊗₁-distr-∘ᵥ : α (bimodule-hom-∘ h₂ g₂ ⊗₁ bimodule-hom-∘ h₁ g₁)
+                ≈ α (h₂ ⊗₁ h₁) ∘ᵥ α (g₂ ⊗₁ g₁)
+  ⊗₁-distr-∘ᵥ = Coequalizer⇒Epi (hom C₁ C₃) F₂⊗F₁
+                                (α (bimodule-hom-∘ h₂ g₂ ⊗₁ bimodule-hom-∘ h₁ g₁))
+                                (α (h₂ ⊗₁ h₁) ∘ᵥ α (g₂ ⊗₁ g₁))
+                                ⊗₁-distr-∘ᵥ∘arr
+
+module ≈Preservation {M₁ M₂ M₃ : Monad 𝒞} {B₂ B'₂ : Bimodule M₂ M₃} {B₁ B'₁ : Bimodule M₁ M₂}
+                            (h₂ h'₂ : Bimodulehomomorphism B₂ B'₂) (h₁ h'₁ : Bimodulehomomorphism B₁ B'₁)
+                            (e₂ : α h₂ ≈ α h'₂) (e₁ : α h₁ ≈ α h'₁) where
+
+  open Monad M₁ using () renaming (C to C₁)
+  open Monad M₃ using () renaming (C to C₃)
+  open TensorproductOfBimodules B₂ B₁ using (F₂⊗F₁)
+
+  ⊗₁-resp-≈∘arr : α (h₂ ⊗₁ h₁) ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈ α (h'₂ ⊗₁ h'₁) ∘ᵥ Coequalizer.arr F₂⊗F₁
+  ⊗₁-resp-≈∘arr = begin
+    α (h₂ ⊗₁ h₁) ∘ᵥ Coequalizer.arr F₂⊗F₁ ≈⟨ ⟺ αSq ⟩
+    Coequalizer.arr F'₂⊗F'₁ ∘ᵥ (α h₂ ⊚₁ α h₁) ≈⟨ refl⟩∘⟨ e₂ ⟩⊚⟨ e₁ ⟩
+    Coequalizer.arr F'₂⊗F'₁ ∘ᵥ (α h'₂ ⊚₁ α h'₁) ≈⟨ α'Sq ⟩
+    α (h'₂ ⊗₁ h'₁) ∘ᵥ Coequalizer.arr F₂⊗F₁ ∎
+    where
+      open hom.HomReasoning
+      open TensorproductOfBimodules B'₂ B'₁ using () renaming (F₂⊗F₁ to F'₂⊗F'₁)
+      open TensorproductOfHomomorphisms h₂ h₁ using (αSq)
+      open TensorproductOfHomomorphisms h'₂ h'₁ using () renaming (αSq to α'Sq)
+
+  ⊗₁-resp-≈ : α (h₂ ⊗₁ h₁) ≈ α (h'₂ ⊗₁ h'₁)
+  ⊗₁-resp-≈ = Coequalizer⇒Epi (hom C₁ C₃) (F₂⊗F₁)
+                              (α (h₂ ⊗₁ h₁)) (α (h'₂ ⊗₁ h'₁)) (⊗₁-resp-≈∘arr)

--- a/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Unitor.agda
+++ b/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Unitor.agda
@@ -1,0 +1,390 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+
+open import Categories.Bicategory
+open import Categories.Bicategory.LocalCoequalizers
+
+open import Categories.Bicategory.Monad
+open import Categories.Bicategory.Monad.Bimodule
+
+
+-- We will define the left- and right-unitor in the bicategory of monads and bimodules. --
+
+module Categories.Bicategory.Construction.Bimodules.Tensorproduct.Unitor
+  {o ℓ e t} {𝒞 : Bicategory o ℓ e t} {localCoeq : LocalCoequalizers 𝒞}
+  {M₁ M₂ : Monad 𝒞} {B : Bimodule M₁ M₂} where
+  
+open import Categories.Bicategory.Construction.Bimodules.Tensorproduct {o} {ℓ} {e} {t} {𝒞} {localCoeq}
+
+private
+  _⊗₀_ = TensorproductOfBimodules.B₂⊗B₁
+  _⊗₁_ = TensorproductOfHomomorphisms.h₂⊗h₁
+
+infixr 30 _⊗₀_ _⊗₁_
+
+Id-Bimod : {M : Monad 𝒞} → Bimodule M M
+Id-Bimod {M} = id-bimodule M
+
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞 hiding (triangle)
+
+import Categories.Diagram.Coequalizer
+import Categories.Diagram.Coequalizer.Properties
+import Categories.Morphism
+
+-- To get constructions of the hom-categories with implicit arguments into scope --
+private
+  module HomCat {X} {Y} where
+    open Categories.Morphism (hom X Y) public using (_≅_)
+    open Categories.Diagram.Coequalizer (hom X Y) public
+    open Categories.Diagram.Coequalizer.Properties (hom X Y) public
+
+open HomCat
+
+-- Id-Bimod ⊗₀ B → B --
+module Left-Unitor where
+  open TensorproductOfBimodules Id-Bimod B using () renaming (F₂⊗F₁ to T₂⊗F)
+  open Bimodule B using (F; actionˡ; actionʳ; assoc; assoc-actionʳ) renaming (identityʳ to B-identityʳ)
+  open Monad M₁ using () renaming (T to T₁)
+  open Monad M₂ using () renaming (T to T₂; η to η₂; μ to μ₂; identityʳ to M₂-identityʳ)
+
+  module 2-cell where
+    open TensorproductOfBimodules Id-Bimod B using (act-to-the-left; act-to-the-right)
+
+    {-
+    We want to show that the following is a coequalizer: --
+
+                     act-to-the-left              actionʳ
+      T₂ ∘₁ T₂ ∘₁ F ==================> T₂ ∘₁ F -----------> F
+                     act-to-the-right
+
+    To do so we construct a split coequalizer.
+    -}
+
+    section₁ : T₂ ∘₁ F ⇒₂ T₂ ∘₁ T₂ ∘₁ F
+    section₁ = η₂ ◁ (T₂ ∘₁ F) ∘ᵥ unitorˡ.to
+
+    section₂ : F ⇒₂ T₂ ∘₁ F
+    section₂ = η₂ ◁ F ∘ᵥ unitorˡ.to
+
+    abstract
+      actionʳ-eq : actionʳ ∘ᵥ act-to-the-left ≈ actionʳ ∘ᵥ act-to-the-right
+      actionʳ-eq = ⟺ assoc-actionʳ
+        where
+          open hom.HomReasoning
+
+      isSection₁ : act-to-the-right ∘ᵥ section₁ ≈ id₂
+      isSection₁ = begin
+        (μ₂ ◁ F ∘ᵥ associator.to) ∘ᵥ η₂ ◁ (T₂ ∘₁ F) ∘ᵥ unitorˡ.to ≈⟨ assoc₂ ⟩
+        μ₂ ◁ F ∘ᵥ associator.to ∘ᵥ η₂ ◁ (T₂ ∘₁ F) ∘ᵥ unitorˡ.to   ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        μ₂ ◁ F ∘ᵥ (associator.to ∘ᵥ η₂ ◁ (T₂ ∘₁ F)) ∘ᵥ unitorˡ.to ≈⟨ refl⟩∘⟨ α⇐-◁-∘₁ ⟩∘⟨refl ⟩
+        μ₂ ◁ F ∘ᵥ (η₂ ◁ T₂ ◁ F ∘ᵥ associator.to) ∘ᵥ unitorˡ.to    ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        μ₂ ◁ F ∘ᵥ η₂ ◁ T₂ ◁ F ∘ᵥ associator.to ∘ᵥ unitorˡ.to      ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                                      ⟺ unitorˡ-coherence-inv ⟩
+        μ₂ ◁ F ∘ᵥ η₂ ◁ T₂ ◁ F ∘ᵥ unitorˡ.to ◁ F                   ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+        μ₂ ◁ F ∘ᵥ (η₂ ◁ T₂ ∘ᵥ unitorˡ.to) ◁ F                     ≈⟨ ∘ᵥ-distr-◁ ⟩
+        (μ₂ ∘ᵥ η₂ ◁ T₂ ∘ᵥ unitorˡ.to) ◁ F                         ≈⟨ ◁-resp-≈ M₂-identityʳ ⟩
+        id₂ ◁ F                                                   ≈⟨ id₂◁ ⟩
+        id₂                                                       ∎
+        where
+          open hom.HomReasoning
+
+      isSection₂ : actionʳ ∘ᵥ section₂ ≈ id₂
+      isSection₂ = B-identityʳ
+
+      sections-compatible : section₂ ∘ᵥ actionʳ ≈ act-to-the-left ∘ᵥ section₁
+      sections-compatible = begin
+        (η₂ ◁ F ∘ᵥ unitorˡ.to) ∘ᵥ actionʳ              ≈⟨ assoc₂ ⟩
+        η₂ ◁ F ∘ᵥ unitorˡ.to ∘ᵥ actionʳ                ≈⟨ refl⟩∘⟨ ⟺ ▷-∘ᵥ-λ⇐ ⟩
+        η₂ ◁ F ∘ᵥ id₁ ▷ actionʳ ∘ᵥ unitorˡ.to          ≈⟨ sym-assoc₂ ⟩
+        (η₂ ◁ F ∘ᵥ id₁ ▷ actionʳ) ∘ᵥ unitorˡ.to        ≈⟨ ⟺ ◁-▷-exchg ⟩∘⟨refl ⟩
+        (T₂ ▷ actionʳ ∘ᵥ η₂ ◁ (T₂ ∘₁ F)) ∘ᵥ unitorˡ.to ≈⟨ assoc₂ ⟩
+        T₂ ▷ actionʳ ∘ᵥ η₂ ◁ (T₂ ∘₁ F) ∘ᵥ unitorˡ.to   ∎
+        where
+          open hom.HomReasoning
+
+    -- end abstract --
+
+    FisCoequalizer : IsCoequalizer act-to-the-left act-to-the-right actionʳ
+    FisCoequalizer = splitCoequalizer⇒Coequalizer-sym
+                       {f = act-to-the-left} {g = act-to-the-right} {e = actionʳ}
+                       section₁
+                       section₂
+                       actionʳ-eq
+                       isSection₁
+                       isSection₂
+                       sections-compatible
+
+    FCoequalizer : Coequalizer act-to-the-left act-to-the-right
+    FCoequalizer = IsCoequalizer⇒Coequalizer FisCoequalizer
+
+    Unitorˡ⊗Iso : Bimodule.F (Id-Bimod ⊗₀ B) ≅ F
+    Unitorˡ⊗Iso = up-to-iso T₂⊗F FCoequalizer
+
+    λ⇒⊗ : Bimodule.F (Id-Bimod ⊗₀ B) ⇒₂ F
+    λ⇒⊗ = _≅_.from Unitorˡ⊗Iso
+
+    triangle : λ⇒⊗ ∘ᵥ Coequalizer.arr T₂⊗F ≈ actionʳ
+    triangle = up-to-iso-triangle T₂⊗F FCoequalizer
+
+  open 2-cell using (λ⇒⊗; triangle) public
+
+  module Linear-Left where
+    open TensorproductOfBimodules.Left-Action Id-Bimod B
+      using () renaming (actionˡSq to actionˡSqT₂⊗F)
+    open Bimodule (Id-Bimod ⊗₀ B) using () renaming (actionˡ to actionˡT₂⊗F)
+
+    abstract
+      linearˡ∘arr : (actionˡ ∘ᵥ λ⇒⊗ ◁ T₁) ∘ᵥ Coequalizer.arr T₂⊗F ◁ T₁
+                    ≈ (λ⇒⊗ ∘ᵥ actionˡT₂⊗F) ∘ᵥ Coequalizer.arr T₂⊗F ◁ T₁
+      linearˡ∘arr = begin
+        (actionˡ ∘ᵥ λ⇒⊗ ◁ T₁) ∘ᵥ Coequalizer.arr T₂⊗F ◁ T₁ ≈⟨ assoc₂ ⟩
+        actionˡ ∘ᵥ λ⇒⊗ ◁ T₁ ∘ᵥ Coequalizer.arr T₂⊗F ◁ T₁ ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+        actionˡ ∘ᵥ (λ⇒⊗ ∘ᵥ Coequalizer.arr T₂⊗F) ◁ T₁ ≈⟨ refl⟩∘⟨ ◁-resp-≈ triangle ⟩
+        actionˡ ∘ᵥ actionʳ ◁ T₁ ≈⟨ ⟺ assoc ⟩
+        actionʳ ∘ᵥ T₂ ▷ actionˡ ∘ᵥ associator.from ≈⟨ ⟺ triangle ⟩∘⟨refl ⟩
+        (λ⇒⊗ ∘ᵥ Coequalizer.arr T₂⊗F) ∘ᵥ T₂ ▷ actionˡ ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+        λ⇒⊗ ∘ᵥ Coequalizer.arr T₂⊗F ∘ᵥ T₂ ▷ actionˡ ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ actionˡSqT₂⊗F ⟩
+        λ⇒⊗ ∘ᵥ actionˡT₂⊗F ∘ᵥ Coequalizer.arr T₂⊗F ◁ T₁ ≈⟨ sym-assoc₂ ⟩
+        (λ⇒⊗ ∘ᵥ actionˡT₂⊗F) ∘ᵥ Coequalizer.arr T₂⊗F ◁ T₁ ∎
+        where
+          open hom.HomReasoning
+
+      linearˡ : actionˡ ∘ᵥ λ⇒⊗ ◁ T₁ ≈ λ⇒⊗ ∘ᵥ actionˡT₂⊗F
+      linearˡ = Coequalizer⇒Epi
+                  (precompCoequalizer T₂⊗F T₁)
+                  (actionˡ ∘ᵥ λ⇒⊗ ◁ T₁)
+                  (λ⇒⊗ ∘ᵥ actionˡT₂⊗F)
+                  linearˡ∘arr
+        where
+          open LocalCoequalizers localCoeq
+    -- end abstract --
+
+
+  module Linear-Right where
+    open TensorproductOfBimodules.Right-Action Id-Bimod B
+      using () renaming (actionʳSq to actionʳSqT₂⊗F)
+    open Bimodule (Id-Bimod ⊗₀ B) using () renaming (actionʳ to actionʳT₂⊗F)
+
+    abstract
+      linearʳ∘arr : (actionʳ ∘ᵥ T₂ ▷ λ⇒⊗) ∘ᵥ T₂ ▷ Coequalizer.arr T₂⊗F
+                    ≈ (λ⇒⊗ ∘ᵥ actionʳT₂⊗F) ∘ᵥ T₂ ▷ Coequalizer.arr T₂⊗F
+      linearʳ∘arr = begin
+        (actionʳ ∘ᵥ T₂ ▷  λ⇒⊗) ∘ᵥ T₂ ▷ Coequalizer.arr T₂⊗F ≈⟨ assoc₂ ⟩
+        actionʳ ∘ᵥ T₂ ▷ λ⇒⊗ ∘ᵥ T₂ ▷ Coequalizer.arr T₂⊗F ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+        actionʳ ∘ᵥ T₂ ▷ (λ⇒⊗ ∘ᵥ Coequalizer.arr T₂⊗F) ≈⟨ refl⟩∘⟨ ▷-resp-≈ triangle ⟩
+        actionʳ ∘ᵥ T₂ ▷ actionʳ ≈⟨ ⟺ assoc-actionʳ ⟩
+        actionʳ ∘ᵥ μ₂ ◁ F ∘ᵥ associator.to ≈⟨ ⟺ triangle ⟩∘⟨refl ⟩
+        (λ⇒⊗ ∘ᵥ Coequalizer.arr T₂⊗F) ∘ᵥ μ₂ ◁ F ∘ᵥ associator.to ≈⟨ assoc₂ ⟩
+        λ⇒⊗ ∘ᵥ Coequalizer.arr T₂⊗F ∘ᵥ μ₂ ◁ F ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ actionʳSqT₂⊗F ⟩
+        λ⇒⊗ ∘ᵥ actionʳT₂⊗F ∘ᵥ T₂ ▷ Coequalizer.arr T₂⊗F ≈⟨ sym-assoc₂ ⟩
+        (λ⇒⊗ ∘ᵥ actionʳT₂⊗F) ∘ᵥ T₂ ▷ Coequalizer.arr T₂⊗F ∎
+        where
+          open hom.HomReasoning
+
+      linearʳ : actionʳ ∘ᵥ T₂ ▷ λ⇒⊗ ≈ λ⇒⊗ ∘ᵥ actionʳT₂⊗F
+      linearʳ = Coequalizer⇒Epi
+                  (postcompCoequalizer T₂⊗F T₂)
+                  (actionʳ ∘ᵥ T₂ ▷ λ⇒⊗)
+                  (λ⇒⊗ ∘ᵥ actionʳT₂⊗F)
+                  linearʳ∘arr
+        where
+          open LocalCoequalizers localCoeq
+    -- end abstract --
+    
+
+  Unitorˡ⊗From : Bimodulehomomorphism (Id-Bimod ⊗₀ B) B
+  Unitorˡ⊗From = record
+    { α = λ⇒⊗
+    ; linearˡ = Linear-Left.linearˡ
+    ; linearʳ = Linear-Right.linearʳ
+    }
+
+  open import Categories.Category.Construction.Bimodules
+    renaming (Bimodules to Bimodules₁)
+  open import Categories.Category.Construction.Bimodules.Properties
+
+  Unitorˡ⊗ : Categories.Morphism._≅_ (Bimodules₁ M₁ M₂) (Id-Bimod ⊗₀ B) B
+  Unitorˡ⊗ = 2cellisIso⇒Iso Unitorˡ⊗From λ⇒⊗isIso
+    where
+      open Monad M₁ using () renaming (C to C₁)
+      open Monad M₂ using () renaming (C to C₂)
+      open Bimodulehom-isIso
+      λ⇒⊗isIso : Categories.Morphism.IsIso (hom C₁ C₂) λ⇒⊗
+      λ⇒⊗isIso = record
+       { inv = _≅_.to 2-cell.Unitorˡ⊗Iso
+       ; iso = _≅_.iso 2-cell.Unitorˡ⊗Iso
+       }
+
+
+-- Id-Bimod ⊗₀ B → B --
+module Right-Unitor where
+  open TensorproductOfBimodules B Id-Bimod using () renaming (F₂⊗F₁ to F⊗T₁)
+  open Bimodule B using (F; actionˡ; actionʳ; sym-assoc; assoc-actionˡ; sym-assoc-actionˡ) renaming (identityˡ to B-identityˡ)
+  open Monad M₁ using () renaming (T to T₁; η to η₁; μ to μ₁; identityˡ to M₁-identityˡ)
+  open Monad M₂ using () renaming (T to T₂)
+
+  module 2-cell where
+    open TensorproductOfBimodules B Id-Bimod using (act-to-the-left; act-to-the-right)
+
+    {-
+    We want to show that the following is a coequalizer: --
+
+                     act-to-the-left              actionˡ
+      F ∘₁ T₁ ∘₁ T₁ ==================> F ∘₁ T₁ -----------> F
+                     act-to-the-right
+
+    To do so we construct a split coequalizer.
+    -}
+
+    section₁ : F ∘₁ T₁ ⇒₂ F ∘₁ T₁ ∘₁ T₁
+    section₁ = F ▷ T₁ ▷ η₁ ∘ᵥ F ▷ unitorʳ.to
+
+    section₂ : F ⇒₂ F ∘₁ T₁
+    section₂ = F ▷ η₁ ∘ᵥ unitorʳ.to
+
+    abstract
+      actionˡ-eq : actionˡ ∘ᵥ act-to-the-left ≈ actionˡ ∘ᵥ act-to-the-right
+      actionˡ-eq = ⟺ sym-assoc-actionˡ
+        where
+          open hom.HomReasoning
+
+      isSection₁ : act-to-the-left ∘ᵥ section₁ ≈ id₂
+      isSection₁ = begin
+        F ▷ μ₁ ∘ᵥ F ▷ T₁ ▷ η₁ ∘ᵥ F ▷ unitorʳ.to ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+        F ▷ μ₁ ∘ᵥ F ▷ (T₁ ▷ η₁ ∘ᵥ unitorʳ.to)   ≈⟨ ∘ᵥ-distr-▷ ⟩
+        F ▷ (μ₁ ∘ᵥ T₁ ▷ η₁ ∘ᵥ unitorʳ.to)       ≈⟨ ▷-resp-≈ M₁-identityˡ ⟩
+        F ▷ id₂                                 ≈⟨ ▷id₂ ⟩
+        id₂                                     ∎
+        where
+          open hom.HomReasoning
+
+      isSection₂ : actionˡ ∘ᵥ section₂ ≈ id₂
+      isSection₂ = B-identityˡ
+
+      sections-compatible : section₂ ∘ᵥ actionˡ ≈ act-to-the-right ∘ᵥ section₁
+      sections-compatible = begin
+        (F ▷ η₁ ∘ᵥ unitorʳ.to) ∘ᵥ actionˡ                                   ≈⟨ assoc₂ ⟩
+        F ▷ η₁ ∘ᵥ unitorʳ.to ∘ᵥ actionˡ                                     ≈⟨ refl⟩∘⟨ ⟺ ◁-∘ᵥ-ρ⇐ ⟩
+        F ▷ η₁ ∘ᵥ actionˡ ◁ id₁ ∘ᵥ unitorʳ.to                               ≈⟨ sym-assoc₂ ⟩
+        (F ▷ η₁ ∘ᵥ actionˡ ◁ id₁) ∘ᵥ unitorʳ.to                             ≈⟨ ◁-▷-exchg ⟩∘⟨refl ⟩
+        (actionˡ ◁ T₁ ∘ᵥ (F ∘₁ T₁) ▷ η₁) ∘ᵥ unitorʳ.to                      ≈⟨ assoc₂ ⟩
+        actionˡ ◁ T₁ ∘ᵥ (F ∘₁ T₁) ▷ η₁ ∘ᵥ unitorʳ.to                        ≈⟨ refl⟩∘⟨ refl⟩∘⟨
+                                                                               ⟺ unitorʳ-coherence-inv ⟩
+        actionˡ ◁ T₁ ∘ᵥ (F ∘₁ T₁) ▷ η₁ ∘ᵥ associator.to ∘ᵥ F ▷ unitorʳ.to   ≈⟨ refl⟩∘⟨ sym-assoc₂ ⟩
+        actionˡ ◁ T₁ ∘ᵥ ((F ∘₁ T₁) ▷ η₁ ∘ᵥ associator.to) ∘ᵥ F ▷ unitorʳ.to ≈⟨ refl⟩∘⟨ ⟺ α⇐-▷-∘₁ ⟩∘⟨refl ⟩
+        actionˡ ◁ T₁ ∘ᵥ (associator.to ∘ᵥ F ▷ T₁ ▷ η₁) ∘ᵥ F ▷ unitorʳ.to    ≈⟨ refl⟩∘⟨ assoc₂ ⟩
+        actionˡ ◁ T₁ ∘ᵥ associator.to ∘ᵥ F ▷ T₁ ▷ η₁ ∘ᵥ F ▷ unitorʳ.to      ≈⟨ sym-assoc₂ ⟩
+        (actionˡ ◁ T₁ ∘ᵥ associator.to) ∘ᵥ F ▷ T₁ ▷ η₁ ∘ᵥ F ▷ unitorʳ.to    ∎
+        where
+          open hom.HomReasoning
+    -- end abstract --
+
+    FisCoequalizer : IsCoequalizer act-to-the-left act-to-the-right actionˡ
+    FisCoequalizer = splitCoequalizer⇒Coequalizer
+                       {f = act-to-the-left} {g = act-to-the-right} {e = actionˡ}
+                       section₁
+                       section₂
+                       actionˡ-eq
+                       isSection₁
+                       isSection₂
+                       sections-compatible
+
+    FCoequalizer : Coequalizer act-to-the-left act-to-the-right
+    FCoequalizer = IsCoequalizer⇒Coequalizer FisCoequalizer
+
+    Unitorʳ⊗Iso : Bimodule.F (B ⊗₀ Id-Bimod) ≅ F
+    Unitorʳ⊗Iso = up-to-iso F⊗T₁ FCoequalizer
+
+    ρ⇒⊗ : Bimodule.F (B ⊗₀ Id-Bimod) ⇒₂ F
+    ρ⇒⊗ = _≅_.from Unitorʳ⊗Iso
+
+    triangle : ρ⇒⊗ ∘ᵥ Coequalizer.arr F⊗T₁ ≈ actionˡ
+    triangle = up-to-iso-triangle F⊗T₁ FCoequalizer
+
+  open 2-cell using (ρ⇒⊗; triangle) public
+
+  module Linear-Left where
+    open TensorproductOfBimodules.Left-Action B Id-Bimod
+      using () renaming (actionˡSq to actionˡSqF⊗T₁)
+    open Bimodule (B ⊗₀ Id-Bimod) using () renaming (actionˡ to actionˡF⊗T₁)
+
+    abstract
+      linearˡ∘arr : (actionˡ ∘ᵥ ρ⇒⊗ ◁ T₁) ∘ᵥ Coequalizer.arr F⊗T₁ ◁ T₁
+                    ≈ (ρ⇒⊗ ∘ᵥ actionˡF⊗T₁) ∘ᵥ Coequalizer.arr F⊗T₁ ◁ T₁
+      linearˡ∘arr = begin
+        (actionˡ ∘ᵥ ρ⇒⊗ ◁ T₁) ∘ᵥ Coequalizer.arr F⊗T₁ ◁ T₁ ≈⟨ assoc₂ ⟩
+        actionˡ ∘ᵥ ρ⇒⊗ ◁ T₁ ∘ᵥ Coequalizer.arr F⊗T₁ ◁ T₁ ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-◁ ⟩
+        actionˡ ∘ᵥ (ρ⇒⊗ ∘ᵥ Coequalizer.arr F⊗T₁) ◁ T₁ ≈⟨ refl⟩∘⟨ ◁-resp-≈ triangle ⟩
+        actionˡ ∘ᵥ actionˡ ◁ T₁ ≈⟨ ⟺ assoc-actionˡ ⟩
+        actionˡ ∘ᵥ F ▷ μ₁ ∘ᵥ associator.from ≈⟨ ⟺ triangle ⟩∘⟨refl ⟩
+        (ρ⇒⊗ ∘ᵥ Coequalizer.arr F⊗T₁) ∘ᵥ F ▷ μ₁ ∘ᵥ associator.from ≈⟨ assoc₂ ⟩
+        ρ⇒⊗ ∘ᵥ Coequalizer.arr F⊗T₁ ∘ᵥ F ▷ μ₁ ∘ᵥ associator.from ≈⟨ refl⟩∘⟨ actionˡSqF⊗T₁ ⟩
+        ρ⇒⊗ ∘ᵥ actionˡF⊗T₁ ∘ᵥ Coequalizer.arr F⊗T₁ ◁ T₁ ≈⟨ sym-assoc₂ ⟩
+        (ρ⇒⊗ ∘ᵥ actionˡF⊗T₁) ∘ᵥ Coequalizer.arr F⊗T₁ ◁ T₁ ∎
+        where
+          open hom.HomReasoning
+
+      linearˡ : actionˡ ∘ᵥ ρ⇒⊗ ◁ T₁ ≈ ρ⇒⊗ ∘ᵥ actionˡF⊗T₁
+      linearˡ = Coequalizer⇒Epi
+                  (precompCoequalizer F⊗T₁ T₁)
+                  (actionˡ ∘ᵥ ρ⇒⊗ ◁ T₁)
+                  (ρ⇒⊗ ∘ᵥ actionˡF⊗T₁)
+                  linearˡ∘arr
+        where
+          open LocalCoequalizers localCoeq
+    -- end abstract --
+
+  module Linear-Right where
+    open TensorproductOfBimodules.Right-Action B Id-Bimod
+      using () renaming (actionʳSq to actionʳSqF⊗T₁)
+    open Bimodule (B ⊗₀ Id-Bimod) using () renaming (actionʳ to actionʳF⊗T₁)
+
+    abstract
+      linearʳ∘arr : (actionʳ ∘ᵥ T₂ ▷ ρ⇒⊗) ∘ᵥ T₂ ▷ Coequalizer.arr F⊗T₁
+                    ≈ (ρ⇒⊗ ∘ᵥ actionʳF⊗T₁) ∘ᵥ T₂ ▷ Coequalizer.arr F⊗T₁
+      linearʳ∘arr = begin
+        (actionʳ ∘ᵥ T₂ ▷ ρ⇒⊗) ∘ᵥ T₂ ▷ Coequalizer.arr F⊗T₁ ≈⟨ assoc₂ ⟩
+        actionʳ ∘ᵥ T₂ ▷ ρ⇒⊗ ∘ᵥ T₂ ▷ Coequalizer.arr F⊗T₁ ≈⟨ refl⟩∘⟨ ∘ᵥ-distr-▷ ⟩
+        actionʳ ∘ᵥ T₂ ▷ (ρ⇒⊗ ∘ᵥ Coequalizer.arr F⊗T₁) ≈⟨ refl⟩∘⟨ ▷-resp-≈ triangle ⟩
+        actionʳ ∘ᵥ T₂ ▷ actionˡ ≈⟨ ⟺ sym-assoc ⟩
+        actionˡ ∘ᵥ actionʳ ◁ T₁ ∘ᵥ associator.to ≈⟨ ⟺ triangle ⟩∘⟨refl ⟩
+        (ρ⇒⊗ ∘ᵥ Coequalizer.arr F⊗T₁) ∘ᵥ actionʳ ◁ T₁ ∘ᵥ associator.to ≈⟨ assoc₂ ⟩
+        ρ⇒⊗ ∘ᵥ Coequalizer.arr F⊗T₁ ∘ᵥ actionʳ ◁ T₁ ∘ᵥ associator.to ≈⟨ refl⟩∘⟨ actionʳSqF⊗T₁ ⟩
+        ρ⇒⊗ ∘ᵥ actionʳF⊗T₁ ∘ᵥ T₂ ▷ Coequalizer.arr F⊗T₁ ≈⟨ sym-assoc₂ ⟩
+        (ρ⇒⊗ ∘ᵥ actionʳF⊗T₁) ∘ᵥ T₂ ▷ Coequalizer.arr F⊗T₁ ∎
+        where
+          open hom.HomReasoning
+
+      linearʳ : actionʳ ∘ᵥ T₂ ▷ ρ⇒⊗ ≈ ρ⇒⊗ ∘ᵥ actionʳF⊗T₁
+      linearʳ = Coequalizer⇒Epi
+                  (postcompCoequalizer F⊗T₁ T₂)
+                  (actionʳ ∘ᵥ T₂ ▷ ρ⇒⊗)
+                  (ρ⇒⊗ ∘ᵥ actionʳF⊗T₁)
+                  linearʳ∘arr
+        where
+          open LocalCoequalizers localCoeq
+    -- end abstract --
+    
+
+  Unitorʳ⊗From : Bimodulehomomorphism (B ⊗₀ Id-Bimod) B
+  Unitorʳ⊗From = record
+    { α = ρ⇒⊗
+    ; linearˡ = Linear-Left.linearˡ
+    ; linearʳ = Linear-Right.linearʳ
+    }
+
+  open import Categories.Category.Construction.Bimodules
+    renaming (Bimodules to Bimodules₁)
+  open import Categories.Category.Construction.Bimodules.Properties
+
+  Unitorʳ⊗ : Categories.Morphism._≅_ (Bimodules₁ M₁ M₂) (B ⊗₀ Id-Bimod) B
+  Unitorʳ⊗ = 2cellisIso⇒Iso Unitorʳ⊗From ρ⇒⊗isIso
+    where
+      open Monad M₁ using () renaming (C to C₁)
+      open Monad M₂ using () renaming (C to C₂)
+      open Bimodulehom-isIso
+      ρ⇒⊗isIso : Categories.Morphism.IsIso (hom C₁ C₂) ρ⇒⊗
+      ρ⇒⊗isIso = record
+       { inv = _≅_.to 2-cell.Unitorʳ⊗Iso
+       ; iso = _≅_.iso 2-cell.Unitorʳ⊗Iso
+       }

--- a/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Unitor/Naturality.agda
+++ b/src/Categories/Bicategory/Construction/Bimodules/Tensorproduct/Unitor/Naturality.agda
@@ -1,0 +1,115 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+
+open import Categories.Bicategory
+open import Categories.Bicategory.LocalCoequalizers
+
+open import Categories.Bicategory.Monad
+open import Categories.Bicategory.Monad.Bimodule renaming (Bimodulehomomorphism to Bimodhom)
+
+
+-- We will show that the left- and right-unitor in the bicategory of monads and bimodules is natural. --
+
+module Categories.Bicategory.Construction.Bimodules.Tensorproduct.Unitor.Naturality
+  {o ℓ e t} {𝒞 : Bicategory o ℓ e t} {localCoeq : LocalCoequalizers 𝒞}
+  {M₁ M₂ : Monad 𝒞}
+  {B B' : Bimodule M₁ M₂}
+  (f : Bimodhom B B') where
+  
+open import Categories.Bicategory.Construction.Bimodules.Tensorproduct {o} {ℓ} {e} {t} {𝒞} {localCoeq}
+
+private
+  _⊗₀_ = TensorproductOfBimodules.B₂⊗B₁
+  _⊗₁_ = TensorproductOfHomomorphisms.h₂⊗h₁
+
+infixr 30 _⊗₀_ _⊗₁_
+
+Id-Bimod : {M : Monad 𝒞} → Bimodule M M
+Id-Bimod {M} = id-bimodule M
+
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞 hiding (triangle)
+
+import Categories.Diagram.Coequalizer
+import Categories.Diagram.Coequalizer.Properties
+-- import Categories.Morphism
+
+-- To get constructions of the hom-categories with implicit arguments into scope --
+private
+  module HomCat {X} {Y} where
+    -- open Categories.Morphism (hom X Y) public using (_≅_)
+    open Categories.Diagram.Coequalizer (hom X Y) public
+    open Categories.Diagram.Coequalizer.Properties (hom X Y) public
+
+open HomCat
+
+open Monad M₁ using () renaming (T to T₁)
+open Monad M₂ using () renaming (T to T₂)
+
+import Categories.Bicategory.Construction.Bimodules.Tensorproduct.Unitor
+  {o} {ℓ} {e} {t} {𝒞} {localCoeq} {M₁} {M₂} as Unitor
+
+module Left-Unitor-natural where
+  open Bimodule B using (actionʳ)
+  open Bimodule B' using () renaming (actionʳ to actionʳ')
+  open TensorproductOfBimodules Id-Bimod B using () renaming (F₂⊗F₁ to T₂⊗F)
+  open TensorproductOfBimodules Id-Bimod B' using () renaming (F₂⊗F₁ to T₂⊗F')
+  open Unitor.Left-Unitor using (λ⇒⊗; triangle)
+
+  abstract
+    λ⇒⊗-natural∘arr : (λ⇒⊗ {B'} ∘ᵥ Bimodhom.α (id-bimodule-hom ⊗₁ f)) ∘ᵥ Coequalizer.arr T₂⊗F
+                      ≈ (Bimodhom.α f ∘ᵥ λ⇒⊗ {B}) ∘ᵥ Coequalizer.arr T₂⊗F
+    λ⇒⊗-natural∘arr = begin
+      (λ⇒⊗ {B'} ∘ᵥ Bimodhom.α (id-bimodule-hom ⊗₁ f)) ∘ᵥ Coequalizer.arr T₂⊗F ≈⟨ assoc₂ ⟩
+      λ⇒⊗ {B'} ∘ᵥ Bimodhom.α (id-bimodule-hom ⊗₁ f) ∘ᵥ Coequalizer.arr T₂⊗F   ≈⟨ refl⟩∘⟨ ⟺ αSqid⊗f ⟩
+      λ⇒⊗ {B'} ∘ᵥ Coequalizer.arr T₂⊗F' ∘ᵥ T₂ ▷ Bimodhom.α f                  ≈⟨ sym-assoc₂ ⟩
+      (λ⇒⊗ {B'} ∘ᵥ Coequalizer.arr T₂⊗F') ∘ᵥ T₂ ▷ Bimodhom.α f                ≈⟨ triangle {B'} ⟩∘⟨refl ⟩
+      actionʳ' ∘ᵥ T₂ ▷ Bimodhom.α f                                           ≈⟨ linearʳ ⟩
+      Bimodhom.α f ∘ᵥ actionʳ                                                 ≈⟨ refl⟩∘⟨ ⟺ (triangle {B}) ⟩
+      Bimodhom.α f ∘ᵥ λ⇒⊗ {B} ∘ᵥ Coequalizer.arr T₂⊗F                         ≈⟨ sym-assoc₂ ⟩
+      (Bimodhom.α f ∘ᵥ λ⇒⊗ {B}) ∘ᵥ Coequalizer.arr T₂⊗F                       ∎
+      where
+        open hom.HomReasoning
+        open Bimodhom f using (linearʳ)
+        open TensorproductOfHomomorphisms id-bimodule-hom f using () renaming (αSq to αSqid⊗f)
+
+    λ⇒⊗-natural : λ⇒⊗ {B'} ∘ᵥ Bimodhom.α (id-bimodule-hom ⊗₁ f) ≈ Bimodhom.α f ∘ᵥ λ⇒⊗ {B}
+    λ⇒⊗-natural = Coequalizer⇒Epi
+                    T₂⊗F
+                    (λ⇒⊗ ∘ᵥ Bimodhom.α (id-bimodule-hom ⊗₁ f))
+                    (Bimodhom.α f ∘ᵥ λ⇒⊗)
+                    λ⇒⊗-natural∘arr
+
+  -- end abstract --
+
+module Right-Unitor-natural where
+  open Bimodule B using (actionˡ)
+  open Bimodule B' using () renaming (actionˡ to actionˡ')
+  open TensorproductOfBimodules B Id-Bimod using () renaming (F₂⊗F₁ to F⊗T₁)
+  open TensorproductOfBimodules B' Id-Bimod using () renaming (F₂⊗F₁ to F'⊗T₁)
+  open Unitor.Right-Unitor using (ρ⇒⊗; triangle)
+
+  abstract
+    ρ⇒⊗-natural∘arr : (ρ⇒⊗ {B'} ∘ᵥ Bimodhom.α (f ⊗₁ id-bimodule-hom)) ∘ᵥ Coequalizer.arr F⊗T₁
+                      ≈ (Bimodhom.α f ∘ᵥ ρ⇒⊗ {B}) ∘ᵥ Coequalizer.arr F⊗T₁
+    ρ⇒⊗-natural∘arr = begin
+      (ρ⇒⊗ {B'} ∘ᵥ Bimodhom.α (f ⊗₁ id-bimodule-hom)) ∘ᵥ Coequalizer.arr F⊗T₁ ≈⟨ assoc₂ ⟩
+      ρ⇒⊗ {B'} ∘ᵥ Bimodhom.α (f ⊗₁ id-bimodule-hom) ∘ᵥ Coequalizer.arr F⊗T₁   ≈⟨ refl⟩∘⟨ ⟺ αSqf⊗id ⟩
+      ρ⇒⊗ {B'} ∘ᵥ Coequalizer.arr F'⊗T₁ ∘ᵥ Bimodhom.α f ◁ T₁                   ≈⟨ sym-assoc₂ ⟩
+      (ρ⇒⊗ {B'} ∘ᵥ Coequalizer.arr F'⊗T₁) ∘ᵥ Bimodhom.α f ◁ T₁                ≈⟨ triangle {B'} ⟩∘⟨refl ⟩
+      actionˡ' ∘ᵥ Bimodhom.α f ◁ T₁                                           ≈⟨ linearˡ ⟩
+      Bimodhom.α f ∘ᵥ actionˡ                                                 ≈⟨ refl⟩∘⟨ ⟺ (triangle {B}) ⟩
+      Bimodhom.α f ∘ᵥ ρ⇒⊗ {B} ∘ᵥ Coequalizer.arr F⊗T₁                         ≈⟨ sym-assoc₂ ⟩
+      (Bimodhom.α f ∘ᵥ ρ⇒⊗ {B}) ∘ᵥ Coequalizer.arr F⊗T₁                       ∎
+      where
+        open hom.HomReasoning
+        open Bimodhom f using (linearˡ)
+        open TensorproductOfHomomorphisms f id-bimodule-hom using () renaming (αSq to αSqf⊗id)
+
+    ρ⇒⊗-natural : ρ⇒⊗ {B'} ∘ᵥ Bimodhom.α (f ⊗₁ id-bimodule-hom) ≈ Bimodhom.α f ∘ᵥ ρ⇒⊗ {B}
+    ρ⇒⊗-natural = Coequalizer⇒Epi
+                    F⊗T₁
+                    (ρ⇒⊗ ∘ᵥ Bimodhom.α (f ⊗₁ id-bimodule-hom))
+                    (Bimodhom.α f ∘ᵥ ρ⇒⊗)
+                    ρ⇒⊗-natural∘arr
+
+  -- end abstract --

--- a/src/Categories/Bicategory/LocalCoequalizers.agda
+++ b/src/Categories/Bicategory/LocalCoequalizers.agda
@@ -1,0 +1,46 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Bicategory
+
+module Categories.Bicategory.LocalCoequalizers {o ℓ e t} (𝒞 : Bicategory o ℓ e t)  where
+
+open import Categories.Diagram.Coequalizer
+open import Level
+open import Categories.Functor.Properties
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+open import Categories.Functor
+
+postCompFunc : {A B C : Obj} → B ⇒₁ C → Functor (hom A B) (hom A C)
+postCompFunc = _⊚-
+
+preCompFunc : {A B C : Obj} → A ⇒₁ B → Functor (hom B C) (hom A C)
+preCompFunc = -⊚_
+
+record LocalCoequalizers : Set (o ⊔ ℓ ⊔ e ⊔ t) where
+  field
+    localCoequalizers : (A B : Obj) → Coequalizers (hom A B)
+    precompPreservesCoequalizer : {A B C : Obj} → (f : A ⇒₁ B)
+      → PreservesCoequalizers (preCompFunc {A} {B} {C} f)
+    postcompPreservesCoequalizer : {A B C : Obj} → (f : B ⇒₁ C)
+      → PreservesCoequalizers (postCompFunc {A} {B} {C} f)
+      
+  precompCoequalizer : {A B C : Obj} → {X Y : B ⇒₁ C} {α β : X ⇒₂ Y}
+                                   → Coequalizer (hom B C) α β
+                                   → (f : A ⇒₁ B)
+                                   → Coequalizer (hom A C) (α ◁ f) (β ◁ f)
+  precompCoequalizer coeq f = record
+    { obj = Coequalizer.obj coeq ∘₁ f
+    ; arr = Coequalizer.arr coeq ◁ f
+    ; isCoequalizer = precompPreservesCoequalizer f {coeq = coeq}
+    }
+
+  postcompCoequalizer : {A B C : Obj} → {X Y : A ⇒₁ B} {α β : X ⇒₂ Y}
+                                   → Coequalizer (hom A B) α β
+                                   → (f : B ⇒₁ C)
+                                   → Coequalizer (hom A C) (f ▷ α) (f ▷ β)
+  postcompCoequalizer coeq f = record
+    { obj = f ∘₁ Coequalizer.obj coeq
+    ; arr = f ▷ Coequalizer.arr coeq
+    ; isCoequalizer = postcompPreservesCoequalizer f {coeq = coeq}
+    }

--- a/src/Categories/Bicategory/Monad/Bimodule.agda
+++ b/src/Categories/Bicategory/Monad/Bimodule.agda
@@ -1,0 +1,112 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+
+open import Categories.Bicategory
+
+module Categories.Bicategory.Monad.Bimodule {o ℓ e t} {𝒞 : Bicategory o ℓ e t} where
+
+open import Level
+open import Categories.Bicategory.Monad
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+
+record Bimodule (M₁ M₂ : Monad 𝒞) : Set (o ⊔ ℓ ⊔ e) where
+  open Monad M₁ renaming (C to C₁; T to T₁; μ to μ₁; η to η₁)
+  open Monad M₂ renaming (C to C₂; T to T₂; μ to μ₂; η to η₂)
+
+  field
+    F       : C₁ ⇒₁ C₂
+    actionˡ : F ∘₁ T₁ ⇒₂ F
+    actionʳ : T₂ ∘₁ F ⇒₂ F
+
+    assoc     : actionʳ ∘ᵥ (T₂ ▷ actionˡ) ∘ᵥ associator.from ≈ actionˡ ∘ᵥ (actionʳ ◁ T₁)
+    sym-assoc : actionˡ ∘ᵥ (actionʳ ◁ T₁) ∘ᵥ associator.to ≈ actionʳ ∘ᵥ (T₂ ▷ actionˡ)
+
+    assoc-actionˡ     : actionˡ ∘ᵥ (F ▷ μ₁) ∘ᵥ associator.from ≈ actionˡ ∘ᵥ (actionˡ ◁ T₁)
+    sym-assoc-actionˡ : actionˡ ∘ᵥ (actionˡ ◁ T₁) ∘ᵥ associator.to ≈ actionˡ ∘ᵥ (F ▷ μ₁)
+    assoc-actionʳ     : actionʳ ∘ᵥ (μ₂ ◁ F) ∘ᵥ associator.to ≈ actionʳ ∘ᵥ (T₂ ▷ actionʳ)
+    sym-assoc-actionʳ : actionʳ ∘ᵥ (T₂ ▷ actionʳ) ∘ᵥ associator.from ≈ actionʳ ∘ᵥ (μ₂ ◁ F)
+
+    identityˡ : actionˡ ∘ᵥ (F ▷ η₁) ∘ᵥ unitorʳ.to ≈ id₂
+    identityʳ : actionʳ ∘ᵥ (η₂ ◁ F) ∘ᵥ unitorˡ.to ≈ id₂
+
+id-bimodule : (M : Monad 𝒞) → Bimodule M M
+id-bimodule M = record
+  { F = T
+  ; actionˡ = μ
+  ; actionʳ = μ
+  ; assoc = assoc
+  ; sym-assoc = sym-assoc
+  ; assoc-actionˡ = assoc
+  ; sym-assoc-actionˡ = sym-assoc
+  ; assoc-actionʳ = sym-assoc
+  ; sym-assoc-actionʳ = assoc
+  ; identityˡ = identityˡ
+  ; identityʳ = identityʳ
+  }
+  where open Monad M
+
+record Bimodulehomomorphism {M₁ M₂ : Monad 𝒞} (B₁ B₂ : Bimodule M₁ M₂) : Set (ℓ ⊔ e) where
+  open Monad M₁ renaming (C to C₁; T to T₁)
+  open Monad M₂ renaming (C to C₂; T to T₂)
+  open Bimodule B₁ renaming (F to F₁; actionˡ to actionˡ₁; actionʳ to actionʳ₁)
+  open Bimodule B₂ renaming (F to F₂; actionˡ to actionˡ₂; actionʳ to actionʳ₂)
+  field
+    α       : F₁ ⇒₂ F₂
+    linearˡ : actionˡ₂ ∘ᵥ (α ◁ T₁) ≈ α ∘ᵥ actionˡ₁
+    linearʳ : actionʳ₂ ∘ᵥ (T₂ ▷ α) ≈ α ∘ᵥ actionʳ₁
+
+open import Categories.Category
+
+id-bimodule-hom : {M₁ M₂ : Monad 𝒞} → {B : Bimodule M₁ M₂} → Bimodulehomomorphism B B
+id-bimodule-hom {M₁} {M₂} {B} = record
+  { α = id₂
+  ; linearˡ = begin
+      actionˡ ∘ᵥ (id₂ ◁ T₁) ≈⟨ refl⟩∘⟨ id₂◁ ⟩
+      actionˡ ∘ᵥ id₂        ≈⟨ identity₂ʳ ⟩
+      actionˡ               ≈⟨ hom.Equiv.sym identity₂ˡ ⟩
+      id₂ ∘ᵥ actionˡ        ∎
+  ; linearʳ = begin
+      actionʳ ∘ᵥ (T₂ ▷ id₂) ≈⟨ refl⟩∘⟨ ▷id₂ ⟩
+      actionʳ ∘ᵥ id₂        ≈⟨ identity₂ʳ ⟩
+      actionʳ               ≈⟨ ⟺ identity₂ˡ ⟩
+      id₂ ∘ᵥ actionʳ        ∎
+  }
+  where
+    open Monad M₁ renaming (C to C₁; T to T₁)
+    open Monad M₂ renaming (C to C₂; T to T₂)
+    open Bimodule B
+    open Category (hom C₁ C₂)
+    open HomReasoning
+    open Equiv
+
+bimodule-hom-∘ : {M₁ M₂ : Monad 𝒞} → {B₁ B₂ B₃ : Bimodule M₁ M₂}
+                 → Bimodulehomomorphism B₂ B₃ → Bimodulehomomorphism B₁ B₂ → Bimodulehomomorphism B₁ B₃
+bimodule-hom-∘ {M₁} {M₂} {B₁} {B₂} {B₃} g f = record
+  { α = α g ∘ᵥ α f
+  ; linearˡ = begin
+      actionˡ₃ ∘ᵥ (α g ∘ᵥ α f) ◁ T₁          ≈⟨ refl⟩∘⟨ ⟺ ∘ᵥ-distr-◁ ⟩
+      actionˡ₃ ∘ᵥ (α g ◁ T₁) ∘ᵥ (α f ◁ T₁)   ≈⟨ sym-assoc₂ ⟩
+      (actionˡ₃ ∘ᵥ (α g ◁ T₁)) ∘ᵥ (α f ◁ T₁) ≈⟨ linearˡ g ⟩∘⟨refl ⟩
+      (α g ∘ᵥ actionˡ₂) ∘ᵥ (α f ◁ T₁)        ≈⟨ assoc₂ ⟩
+      α g ∘ᵥ actionˡ₂ ∘ᵥ (α f ◁ T₁)          ≈⟨ refl⟩∘⟨ linearˡ f ⟩
+      α g ∘ᵥ α f ∘ᵥ actionˡ₁                 ≈⟨ sym-assoc₂ ⟩
+      (α g ∘ᵥ α f) ∘ᵥ actionˡ₁               ∎
+  ; linearʳ = begin
+      actionʳ₃ ∘ᵥ T₂ ▷ (α g ∘ᵥ α f)          ≈⟨ refl⟩∘⟨ (⟺ ∘ᵥ-distr-▷) ⟩
+      actionʳ₃ ∘ᵥ (T₂ ▷ α g) ∘ᵥ (T₂ ▷ α f)   ≈⟨ sym-assoc₂ ⟩
+      (actionʳ₃ ∘ᵥ (T₂ ▷ α g)) ∘ᵥ (T₂ ▷ α f) ≈⟨ linearʳ g ⟩∘⟨refl ⟩
+      (α g ∘ᵥ actionʳ₂) ∘ᵥ (T₂ ▷ α f)        ≈⟨ assoc₂ ⟩
+      α g ∘ᵥ actionʳ₂ ∘ᵥ (T₂ ▷ α f)          ≈⟨ refl⟩∘⟨ linearʳ f ⟩
+      α g ∘ᵥ α f ∘ᵥ actionʳ₁                 ≈⟨ sym-assoc₂ ⟩
+      (α g ∘ᵥ α f) ∘ᵥ actionʳ₁               ∎
+  }
+  where
+    open Bimodulehomomorphism
+    open Monad M₁ renaming (C to C₁; T to T₁)
+    open Monad M₂ renaming (C to C₂; T to T₂)
+    open Bimodule B₁ renaming (F to F₁; actionˡ to actionˡ₁; actionʳ to actionʳ₁)
+    open Bimodule B₂ renaming (F to F₂; actionˡ to actionˡ₂; actionʳ to actionʳ₂)
+    open Bimodule B₃ renaming (F to F₃; actionˡ to actionˡ₃; actionʳ to actionʳ₃)
+    open Category (hom C₁ C₂)
+    open HomReasoning
+    open Equiv

--- a/src/Categories/Category/Construction/Bimodules.agda
+++ b/src/Categories/Category/Construction/Bimodules.agda
@@ -1,0 +1,33 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Bicategory
+
+module Categories.Category.Construction.Bimodules {o ℓ e t} {𝒞 : Bicategory o ℓ e t} where
+
+open import Level
+open import Categories.Category
+open import Categories.Bicategory.Monad
+open import Categories.Bicategory.Monad.Bimodule
+open Bimodulehomomorphism
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+
+Bimodules : Monad 𝒞 → Monad 𝒞 → Category (o ⊔ ℓ ⊔ e) (ℓ ⊔ e) e
+Bimodules M₁ M₂  = record
+  { Obj = Bimodule M₁ M₂
+  ; _⇒_ = λ B₁ B₂ → Bimodulehomomorphism B₁ B₂
+  ; _≈_ = λ h₁ h₂ → α h₁ ≈ α h₂
+  ; id = id-bimodule-hom
+  ; _∘_ = bimodule-hom-∘
+  ; assoc = assoc₂
+  ; sym-assoc = sym-assoc₂
+  ; identityˡ = identity₂ˡ
+  ; identityʳ = identity₂ʳ
+  ; identity² = identity₂²
+  ; equiv = record
+    { refl = hom.Equiv.refl
+    ; sym = hom.Equiv.sym
+    ; trans = hom.Equiv.trans
+    }
+  ; ∘-resp-≈ = hom.∘-resp-≈
+  }

--- a/src/Categories/Category/Construction/Bimodules/Properties.agda
+++ b/src/Categories/Category/Construction/Bimodules/Properties.agda
@@ -1,0 +1,70 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+
+
+open import Categories.Bicategory
+open import Categories.Bicategory.Monad
+
+module Categories.Category.Construction.Bimodules.Properties
+  {o ℓ e t} {𝒞 : Bicategory o ℓ e t} {M₁ M₂ : Monad 𝒞} where
+
+open import Agda.Primitive
+
+import Categories.Category.Construction.Bimodules
+open import Categories.Category
+
+Bimodules : Category (o ⊔ ℓ ⊔ e) (ℓ ⊔ e) e
+Bimodules = Categories.Category.Construction.Bimodules.Bimodules M₁ M₂
+
+private
+  module Cat {o₁ ℓ₁ e₁} {C : Categories.Category.Category o₁ ℓ₁ e₁} where
+    open Categories.Category.Category C public
+    open import Categories.Morphism C public
+    open import Categories.Morphism.Reasoning.Iso C public
+
+open Cat
+
+
+import Categories.Bicategory.Extras as Bicat
+open Bicat 𝒞
+
+open import Categories.Bicategory.Monad.Bimodule {o} {ℓ} {e} {t} {𝒞}
+
+
+module Bimodulehom-isIso {B₁ B₂ : Obj Bimodules} (f : _⇒_ {C = Bimodules} B₁ B₂) where
+  open Monad M₁ using () renaming (C to C₁; T to T₁)
+  open Monad M₂ using () renaming (C to C₂; T to T₂)
+  open Bimodule B₁ using () renaming (F to F₁; actionˡ to actionˡ₁)
+  open Bimodule B₂ using () renaming (F to F₂; actionˡ to actionˡ₂)
+  open Bimodulehomomorphism {M₁} {M₂} {B₁} {B₂} f using (α; linearˡ; linearʳ)
+
+  2cellisIso⇒isIso : IsIso {C = hom C₁ C₂} α → IsIso {C = Bimodules} f
+  2cellisIso⇒isIso αisIso = record
+    { inv = record
+      { α = α⁻¹
+        -- F₂ ⇒₂ F₁
+      ; linearˡ = ⟺ (conjugate-from (αIso ◁ᵢ T₁) αIso linearˡ)
+        -- linearˡ : actionˡ₁ ∘ᵥ α⁻¹ ◁ T₁ ≈ α⁻¹ ∘ᵥ actionˡ₂
+      ; linearʳ = ⟺ (conjugate-from (T₂ ▷ᵢ αIso) αIso linearʳ)
+      -- linearʳ : actionʳ₁ ∘ᵥ T₂ ▷ α⁻¹ ≈ α⁻¹ ∘ᵥ actionʳ₂
+      }
+    ; iso = record
+      { isoˡ = IsIso.isoˡ αisIso
+      ; isoʳ = IsIso.isoʳ αisIso
+      }
+    }
+    where
+      open hom.HomReasoning
+      α⁻¹ = IsIso.inv αisIso
+      αIso : F₁ ≅ F₂
+      αIso = record
+        { from = α
+        ; to = α⁻¹
+        ; iso = IsIso.iso αisIso
+        }
+
+  2cellisIso⇒Iso : IsIso {C = hom C₁ C₂} α → _≅_ {C = Bimodules} B₁ B₂
+  2cellisIso⇒Iso αisIso = record
+    { from = f
+    ; to = IsIso.inv (2cellisIso⇒isIso αisIso)
+    ; iso = IsIso.iso (2cellisIso⇒isIso αisIso)
+    }

--- a/src/Categories/Diagram/Coequalizer.agda
+++ b/src/Categories/Diagram/Coequalizer.agda
@@ -91,8 +91,17 @@ up-to-iso coe₁ coe₂ = record
     repack-cancel : (e₁ e₂ : Coequalizer h i) → repack e₁ e₂ ∘ repack e₂ e₁ ≈ id
     repack-cancel coe₁ coe₂ = repack∘ coe₂ coe₁ coe₂ ○ ⟺ (id-coequalize coe₂)
 
+-- We prove that the isomorphism of up-to-iso fits into a triangle --
+up-to-iso-triangle : (coe₁ coe₂ : Coequalizer h i) →
+                     _≅_.from (up-to-iso coe₁ coe₂) ∘ Coequalizer.arr coe₁
+                     ≈ Coequalizer.arr coe₂
+up-to-iso-triangle coe₁ coe₂ = ⟺ (Coequalizer.universal coe₁)
+
 IsCoequalizer⇒Coequalizer : IsCoequalizer h i k → Coequalizer h i
 IsCoequalizer⇒Coequalizer {k = k} is-coe = record
   { arr = k
   ; isCoequalizer = is-coe
   }
+
+Coequalizers : Set (o ⊔ ℓ ⊔ e)
+Coequalizers = {A B : Obj} → (f g : A ⇒ B) → Coequalizer f g

--- a/src/Categories/Diagram/Coequalizer/Properties.agda
+++ b/src/Categories/Diagram/Coequalizer/Properties.agda
@@ -7,14 +7,14 @@ module Categories.Diagram.Coequalizer.Properties {o ℓ e} (C : Category o ℓ e
 
 open Category C
 
-open import Categories.Diagram.Coequalizer C using (Coequalizer; IsCoequalizer)
+open import Categories.Diagram.Coequalizer C using (Coequalizer; IsCoequalizer; Coequalizer⇒Epi; up-to-iso)
 open import Categories.Morphism C
 import Categories.Morphism.Reasoning as MR
-open import Categories.Diagram.Equalizer op
+open import Categories.Diagram.Equalizer op hiding (up-to-iso)
 open import Categories.Diagram.Equalizer.Properties op
 open import Categories.Diagram.Duality C
 open import Categories.Diagram.KernelPair C
-open import Categories.Diagram.Pullback C
+open import Categories.Diagram.Pullback C hiding (up-to-iso)
 open import Categories.Morphism.Regular C
 
 
@@ -68,3 +68,352 @@ regular-is-coeq-kp {A} {B} f record { C = D ; h = h ; g = g ; coequalizer = coeq
 
 retract-coequalizer : ∀ {X Y} {f : Y ⇒ X} {g : X ⇒ Y} → f RetractOf g → IsCoequalizer (g ∘ f) id f
 retract-coequalizer f∘g≈id = IscoEqualizer⇒IsCoequalizer (section-equalizer f∘g≈id)
+
+-- split coequalizer are coequalizer --
+splitCoequalizer⇒Coequalizer : {A B C : Obj} {f g : A ⇒ B} {e : B ⇒ C}
+                               (t : B ⇒ A) (s : C ⇒ B)
+                               (eq : e ∘ f ≈ e ∘ g)
+                               (tisSection : f ∘ t ≈ id)
+                               (sisSection : e ∘ s ≈ id)
+                               (sq : s ∘ e ≈ g ∘ t)
+                               → IsCoequalizer f g e
+splitCoequalizer⇒Coequalizer {f = f} {g} {e} t s eq tisSection sisSection sq = record
+  { equality = eq
+  ; coequalize = λ {T} {h} _ → h ∘ s
+  ; universal = λ {T} {h} {h∘f≈h∘g} → begin
+    h           ≈⟨ ⟺ identityʳ ⟩
+    h ∘ id      ≈⟨ refl⟩∘⟨ ⟺ tisSection ⟩
+    h ∘ f ∘ t   ≈⟨ sym-assoc ⟩
+    (h ∘ f) ∘ t ≈⟨ h∘f≈h∘g ⟩∘⟨refl ⟩
+    (h ∘ g) ∘ t ≈⟨ assoc ⟩
+    h ∘ g ∘ t   ≈⟨ refl⟩∘⟨ ⟺ sq ⟩
+    h ∘ s ∘ e   ≈⟨ sym-assoc ⟩
+    (h ∘ s) ∘ e ∎
+  ; unique = λ {C} {h} {i} {h∘f≈h∘g} h≈i∘e → begin
+    i ≈⟨ ⟺ identityʳ ⟩
+    i ∘ id ≈⟨ refl⟩∘⟨ ⟺ sisSection ⟩
+    i ∘ e ∘ s ≈⟨ sym-assoc ⟩
+    (i ∘ e) ∘ s ≈⟨ ⟺ h≈i∘e ⟩∘⟨refl ⟩
+    h ∘ s ∎
+  }
+  where
+    open HomReasoning
+
+splitCoequalizer⇒Coequalizer-sym : {A B C : Obj} {f g : A ⇒ B} {e : B ⇒ C}
+                               (t : B ⇒ A) (s : C ⇒ B)
+                               (eq : e ∘ f ≈ e ∘ g)
+                               (tisSection : g ∘ t ≈ id)
+                               (sisSection : e ∘ s ≈ id)
+                               (sq : s ∘ e ≈ f ∘ t)
+                               → IsCoequalizer f g e
+splitCoequalizer⇒Coequalizer-sym {f = f} {g} {e} t s eq tisSection sisSection sq = record
+  { equality = eq
+  ; coequalize = λ {T} {h} _ → h ∘ s
+  ; universal = λ {T} {h} {h∘f≈h∘g} → begin
+    h           ≈⟨ ⟺ identityʳ ⟩
+    h ∘ id      ≈⟨ refl⟩∘⟨ ⟺ tisSection ⟩
+    h ∘ g ∘ t   ≈⟨ sym-assoc ⟩
+    (h ∘ g) ∘ t ≈⟨ ⟺ h∘f≈h∘g ⟩∘⟨refl ⟩
+    (h ∘ f) ∘ t ≈⟨ assoc ⟩
+    h ∘ f ∘ t   ≈⟨ refl⟩∘⟨ ⟺ sq ⟩
+    h ∘ s ∘ e   ≈⟨ sym-assoc ⟩
+    (h ∘ s) ∘ e ∎
+  ; unique = λ {C} {h} {i} {h∘f≈h∘g} h≈i∘e → begin
+    i ≈⟨ ⟺ identityʳ ⟩
+    i ∘ id ≈⟨ refl⟩∘⟨ ⟺ sisSection ⟩
+    i ∘ e ∘ s ≈⟨ sym-assoc ⟩
+    (i ∘ e) ∘ s ≈⟨ ⟺ h≈i∘e ⟩∘⟨refl ⟩
+    h ∘ s ∎
+  }
+  where
+    open HomReasoning
+
+
+open Categories.Category.Definitions C
+
+module MapBetweenCoequalizers where
+
+  ⇒coequalize : {A₁ B₁ A₂ B₂ : Obj}
+              → {f₁ g₁ : A₁ ⇒ B₁} → {f₂ g₂ : A₂ ⇒ B₂}
+              → (α : A₁ ⇒ A₂) → (β : B₁ ⇒ B₂)
+              → CommutativeSquare α f₁ f₂ β                -- f₂ ∘ α ≈ β ∘ f₁
+              → CommutativeSquare α g₁ g₂ β                -- g₂ ∘ α ≈ β ∘ g₁
+              → (coeq₂ : Coequalizer f₂ g₂)
+              → (Coequalizer.arr coeq₂ ∘ β) ∘ f₁ ≈ (Coequalizer.arr coeq₂ ∘ β) ∘ g₁
+  ⇒coequalize {A₁} {B₁} {A₂} {B₂} {f₁} {g₁} {f₂} {g₂} α β sq₁ sq₂ coeq₂ = begin
+    (Coequalizer.arr coeq₂ ∘ β) ∘ f₁ ≈⟨ assoc ⟩
+    Coequalizer.arr coeq₂ ∘ (β ∘ f₁) ≈⟨ refl⟩∘⟨ ⟺ sq₁ ⟩
+    Coequalizer.arr coeq₂ ∘ (f₂ ∘ α) ≈⟨ ⟺ assoc ⟩
+    (Coequalizer.arr coeq₂ ∘ f₂) ∘ α ≈⟨ equality₂ ⟩∘⟨refl ⟩
+    (Coequalizer.arr coeq₂ ∘ g₂) ∘ α ≈⟨ assoc ⟩
+    Coequalizer.arr coeq₂ ∘ (g₂ ∘ α) ≈⟨ refl⟩∘⟨ sq₂ ⟩
+    Coequalizer.arr coeq₂ ∘ (β ∘ g₁) ≈⟨ ⟺ assoc ⟩
+    (Coequalizer.arr coeq₂ ∘ β) ∘ g₁ ∎
+    where
+      open HomReasoning
+      open Coequalizer coeq₂
+      open IsCoequalizer isCoequalizer renaming (equality to equality₂)
+
+  ⇒MapBetweenCoeq : {A₁ B₁ A₂ B₂ : Obj}
+                  → {f₁ g₁ : A₁ ⇒ B₁}
+                  → {f₂ g₂ : A₂ ⇒ B₂}
+                  → (α : A₁ ⇒ A₂)
+                  → (β : B₁ ⇒ B₂)
+                  → CommutativeSquare α f₁ f₂ β                -- f₂ ∘ α ≈ β ∘ f₁
+                  → CommutativeSquare α g₁ g₂ β                -- g₂ ∘ α ≈ β ∘ g₁
+                  → (coeq₁ : Coequalizer f₁ g₁)
+                  → (coeq₂ : Coequalizer f₂ g₂)
+                  → Coequalizer.obj coeq₁ ⇒ Coequalizer.obj coeq₂
+  ⇒MapBetweenCoeq α β sq₁ sq₂ coeq₁ coeq₂ = coequalize₁ (⇒coequalize α β sq₁ sq₂ coeq₂)
+    where
+      open Coequalizer coeq₁ renaming (isCoequalizer to isCoequalizer₁)
+      open IsCoequalizer isCoequalizer₁ renaming (coequalize to coequalize₁)
+      open Category.HomReasoning C
+
+  ⇒MapBetweenCoeqSq : {A₁ B₁ A₂ B₂ : Obj}
+                  → {f₁ g₁ : A₁ ⇒ B₁}
+                  → {f₂ g₂ : A₂ ⇒ B₂}
+                  → (α : A₁ ⇒ A₂)
+                  → (β : B₁ ⇒ B₂)
+                  → (sq₁ : CommutativeSquare α f₁ f₂ β)               -- f₂ ∘ α ≈ β ∘ f₁
+                  → (sq₂ : CommutativeSquare α g₁ g₂ β)               -- g₂ ∘ α ≈ β ∘ g₁
+                  → (coeq₁ : Coequalizer f₁ g₁)
+                  → (coeq₂ : Coequalizer f₂ g₂)
+                  → CommutativeSquare
+                      β (Coequalizer.arr coeq₁)
+                      (Coequalizer.arr coeq₂) (⇒MapBetweenCoeq α β sq₁ sq₂ coeq₁ coeq₂)
+  ⇒MapBetweenCoeqSq α β sq₁ sq₂ coeq₁ coeq₂ = universal₁
+    where
+      open Coequalizer coeq₁ renaming (isCoequalizer to isCoequalizer₁)
+      open IsCoequalizer isCoequalizer₁ renaming (universal to universal₁)
+
+open MapBetweenCoequalizers public
+
+CoeqOfIsomorphicDiagram : {A B : Obj} {f g : A ⇒ B} (coeq : Coequalizer f g )
+                        → {A' B' : Obj}
+                        → (a : A ≅ A') (b : B ≅ B')
+                        → Coequalizer (_≅_.from b ∘ f ∘ _≅_.to a) (_≅_.from b ∘ g ∘ _≅_.to a)
+CoeqOfIsomorphicDiagram {A} {B} {f} {g} coeq {A'} {B'} a b = record
+  { arr = arr ∘ _≅_.to b
+  ; isCoequalizer = record
+    { equality = begin
+        (arr ∘ _≅_.to b) ∘ _≅_.from b ∘ f ∘ _≅_.to a ≈⟨ sym-assoc ⟩
+        ((arr ∘ _≅_.to b) ∘ _≅_.from b) ∘ f ∘ _≅_.to a ≈⟨ assoc ⟩∘⟨refl ⟩
+        (arr ∘ _≅_.to b ∘ _≅_.from b) ∘ f ∘ _≅_.to a ≈⟨ (refl⟩∘⟨ _≅_.isoˡ b) ⟩∘⟨refl ⟩
+        (arr ∘ id) ∘ f ∘ _≅_.to a ≈⟨ identityʳ ⟩∘⟨refl ⟩
+        arr ∘ f ∘ _≅_.to a ≈⟨ sym-assoc ⟩
+        (arr ∘ f) ∘ _≅_.to a ≈⟨ equality ⟩∘⟨refl ⟩
+        (arr ∘ g) ∘ _≅_.to a ≈⟨ assoc ⟩
+        arr ∘ g ∘ _≅_.to a ≈⟨ ⟺ identityʳ ⟩∘⟨refl ⟩
+        (arr ∘ id) ∘ g ∘ _≅_.to a ≈⟨ (refl⟩∘⟨ ⟺ (_≅_.isoˡ b)) ⟩∘⟨refl ⟩
+        (arr ∘ _≅_.to b ∘ _≅_.from b) ∘ g ∘ _≅_.to a ≈⟨ sym-assoc ⟩∘⟨refl ⟩
+        ((arr ∘ _≅_.to b) ∘ _≅_.from b) ∘ g ∘ _≅_.to a ≈⟨ assoc ⟩
+        (arr ∘ _≅_.to b) ∘ _≅_.from b ∘ g ∘ _≅_.to a ∎
+    ; coequalize = coequalize'
+    ; universal =  λ {C} {h} {eq} → begin
+        h ≈⟨ switch-fromtoʳ b universal ⟩
+        (coequalize' eq ∘ arr) ∘ _≅_.to b ≈⟨ assoc ⟩
+        coequalize' eq ∘ (arr ∘ _≅_.to b) ∎
+    ; unique = λ {C} {h} {i} {eq} e → unique (⟺ (switch-tofromʳ b (begin
+        (i ∘ arr) ∘ _≅_.to b ≈⟨ assoc ⟩
+        i ∘ arr ∘ _≅_.to b ≈⟨ ⟺ e ⟩
+        h ∎)))
+    }
+  }
+  where
+    open Coequalizer coeq
+    open HomReasoning
+    open MR C using (switch-fromtoʳ; switch-tofromʳ; cancel-toʳ)
+    
+    f' g' : A' ⇒ B'
+    f' = _≅_.from b ∘ f ∘ _≅_.to a
+    g' = _≅_.from b ∘ g ∘ _≅_.to a
+
+    equalize'⇒equalize : {C : Obj} {h : B' ⇒ C}
+                         (eq : h ∘ f' ≈ h ∘ g')
+                       → (h ∘ _≅_.from b) ∘ f ≈ (h ∘ _≅_.from b) ∘ g
+    equalize'⇒equalize {C} {h} eq = cancel-toʳ a (begin
+      ((h ∘ _≅_.from b) ∘ f) ∘ _≅_.to a ≈⟨ assoc ⟩
+      (h ∘ _≅_.from b) ∘ f ∘ _≅_.to a ≈⟨ assoc ⟩
+      h ∘ f' ≈⟨ eq ⟩
+      h ∘ g' ≈⟨ sym-assoc ⟩
+      (h ∘ _≅_.from b) ∘ g ∘ _≅_.to a ≈⟨ sym-assoc ⟩
+      ((h ∘ _≅_.from b) ∘ g) ∘ _≅_.to a ∎)
+
+    coequalize' : {C : Obj} {h : B' ⇒ C}
+                  (eq : h ∘ _≅_.from b ∘ f ∘ _≅_.to a ≈ h ∘ _≅_.from b ∘ g ∘ _≅_.to a)
+                  → obj ⇒ C
+    coequalize' {C} {h} eq = coequalize (equalize'⇒equalize eq)
+
+
+-- coequalizer commutes with coequalizer
+module CoequalizerOfCoequalizer
+  {A B C D : Obj} {f₁ f₂ : A ⇒ B} {g₁ g₂ : A ⇒ C} {h₁ h₂ : B ⇒ D} {i₁ i₂ : C ⇒ D}
+  (coeqᶠ : Coequalizer f₁ f₂) (coeqᵍ : Coequalizer g₁ g₂)
+  (coeqʰ : Coequalizer h₁ h₂) (coeqⁱ : Coequalizer i₁ i₂)
+  (f⇒i₁ f⇒i₂ : Coequalizer.obj coeqᶠ ⇒ Coequalizer.obj coeqⁱ)
+  (g⇒h₁ g⇒h₂ : Coequalizer.obj coeqᵍ ⇒ Coequalizer.obj coeqʰ)
+  (sq₁ᶠⁱ : CommutativeSquare (Coequalizer.arr coeqᶠ) h₁ f⇒i₁ (Coequalizer.arr coeqⁱ))
+  (sq₂ᶠⁱ : CommutativeSquare (Coequalizer.arr coeqᶠ) h₂ f⇒i₂ (Coequalizer.arr coeqⁱ))
+  (sq₁ᵍʰ : CommutativeSquare i₁ (Coequalizer.arr coeqᵍ) (Coequalizer.arr coeqʰ) g⇒h₁)
+  (sq₂ᵍʰ : CommutativeSquare i₂ (Coequalizer.arr coeqᵍ) (Coequalizer.arr coeqʰ) g⇒h₂)
+  (coeqcoeqᵍʰ : Coequalizer g⇒h₁ g⇒h₂) where
+
+  {-
+          f₁₂
+       A ====> B ----> coeqᶠ
+       ||      ||       ||
+    g₁₂||   h₁₂||  sqᶠⁱ ||
+       vv i₁₂  vv       vv        t
+       C ====> D ----> coeqⁱ ----------
+       |       |         |             |
+       | sqᵍʰ  |  arrSq  |             |
+       v       v         v             v
+     coeqᵍ==>coeqʰ --> coeqcoeqᵍʰ ···> T
+               .               coequalize
+               .                       ^
+               .                       .
+               .........................
+                            u
+  -}
+
+  -- We construct a coequalizer of the parallel pair f⇒i₁, f⇒i₂
+
+  open HomReasoning
+
+  obj : Obj
+  obj = Coequalizer.obj coeqcoeqᵍʰ
+
+  arr : Coequalizer.obj coeqⁱ ⇒ obj
+  arr = ⇒MapBetweenCoeq (Coequalizer.arr coeqᵍ) (Coequalizer.arr coeqʰ)
+                        (⟺ sq₁ᵍʰ) (⟺ sq₂ᵍʰ) coeqⁱ coeqcoeqᵍʰ
+
+  abstract
+    arrSq : Coequalizer.arr coeqcoeqᵍʰ ∘ Coequalizer.arr coeqʰ
+            ≈ arr ∘ Coequalizer.arr coeqⁱ
+    arrSq = ⇒MapBetweenCoeqSq (Coequalizer.arr coeqᵍ) (Coequalizer.arr coeqʰ)
+                              (⟺ sq₁ᵍʰ) (⟺ sq₂ᵍʰ) coeqⁱ coeqcoeqᵍʰ
+
+    equality∘arr : (arr ∘ f⇒i₁) ∘ Coequalizer.arr coeqᶠ  ≈ (arr ∘ f⇒i₂) ∘ Coequalizer.arr coeqᶠ
+    equality∘arr = begin
+      (arr ∘ f⇒i₁) ∘ Coequalizer.arr coeqᶠ ≈⟨ assoc ⟩
+      arr ∘ f⇒i₁ ∘ Coequalizer.arr coeqᶠ ≈⟨ refl⟩∘⟨ sq₁ᶠⁱ ⟩
+      arr ∘ Coequalizer.arr coeqⁱ ∘ h₁ ≈⟨ ⟺ assoc ⟩
+      (arr ∘ Coequalizer.arr coeqⁱ) ∘ h₁ ≈⟨ ⟺ arrSq ⟩∘⟨refl ⟩
+      (Coequalizer.arr coeqcoeqᵍʰ ∘ Coequalizer.arr coeqʰ) ∘ h₁ ≈⟨ assoc ⟩
+      Coequalizer.arr coeqcoeqᵍʰ ∘ Coequalizer.arr coeqʰ ∘ h₁ ≈⟨ refl⟩∘⟨ Coequalizer.equality coeqʰ ⟩
+      Coequalizer.arr coeqcoeqᵍʰ ∘ Coequalizer.arr coeqʰ ∘ h₂ ≈⟨ ⟺ assoc ⟩
+      (Coequalizer.arr coeqcoeqᵍʰ ∘ Coequalizer.arr coeqʰ) ∘ h₂ ≈⟨ arrSq ⟩∘⟨refl ⟩
+      (arr ∘ Coequalizer.arr coeqⁱ) ∘ h₂ ≈⟨ assoc ⟩
+      arr ∘ Coequalizer.arr coeqⁱ ∘ h₂ ≈⟨ refl⟩∘⟨ ⟺ sq₂ᶠⁱ ⟩
+      arr ∘ f⇒i₂ ∘ Coequalizer.arr coeqᶠ ≈⟨ ⟺ assoc ⟩
+      (arr ∘ f⇒i₂) ∘ Coequalizer.arr coeqᶠ ∎
+
+    equality : arr ∘ f⇒i₁ ≈ arr ∘ f⇒i₂
+    equality = Coequalizer⇒Epi coeqᶠ (arr ∘ f⇒i₁) (arr ∘ f⇒i₂) equality∘arr
+
+
+    commutes : {T : Obj} {t : Coequalizer.obj coeqⁱ ⇒ T} (eq : t ∘ f⇒i₁ ≈ t ∘ f⇒i₂)
+               → (t ∘ Coequalizer.arr coeqⁱ) ∘ h₁ ≈ (t ∘ Coequalizer.arr coeqⁱ) ∘ h₂
+    commutes {T} {t} eq = begin
+      (t ∘ Coequalizer.arr coeqⁱ) ∘ h₁ ≈⟨ assoc ⟩
+      t ∘ Coequalizer.arr coeqⁱ ∘ h₁ ≈⟨ refl⟩∘⟨ ⟺ sq₁ᶠⁱ ⟩
+      t ∘ f⇒i₁ ∘ Coequalizer.arr coeqᶠ ≈⟨ ⟺ assoc ⟩
+      (t ∘ f⇒i₁) ∘ Coequalizer.arr coeqᶠ ≈⟨ eq ⟩∘⟨refl ⟩
+      (t ∘ f⇒i₂) ∘ Coequalizer.arr coeqᶠ ≈⟨ assoc ⟩
+      t ∘ f⇒i₂ ∘ Coequalizer.arr coeqᶠ ≈⟨ refl⟩∘⟨ sq₂ᶠⁱ ⟩
+      t ∘ Coequalizer.arr coeqⁱ ∘ h₂ ≈⟨ ⟺ assoc ⟩
+      (t ∘ Coequalizer.arr coeqⁱ) ∘ h₂ ∎
+  
+    u : {T : Obj} {t : Coequalizer.obj coeqⁱ ⇒ T} (eq : t ∘ f⇒i₁ ≈ t ∘ f⇒i₂)
+        → Coequalizer.obj coeqʰ ⇒ T
+    u {T} {t} eq = Coequalizer.coequalize coeqʰ {h = t ∘ Coequalizer.arr coeqⁱ} (commutes eq)
+
+    uEqualizes∘arr : {T : Obj} {t : Coequalizer.obj coeqⁱ ⇒ T} (eq : t ∘ f⇒i₁ ≈ t ∘ f⇒i₂)
+                     → (u eq ∘ g⇒h₁) ∘ Coequalizer.arr coeqᵍ ≈ (u eq ∘ g⇒h₂) ∘ Coequalizer.arr coeqᵍ
+    uEqualizes∘arr {T} {t} eq = begin
+      (u eq ∘ g⇒h₁) ∘ Coequalizer.arr coeqᵍ ≈⟨ assoc ⟩
+      u eq ∘ g⇒h₁ ∘ Coequalizer.arr coeqᵍ ≈⟨ refl⟩∘⟨ ⟺ sq₁ᵍʰ ⟩
+      u eq ∘ Coequalizer.arr coeqʰ ∘ i₁ ≈⟨ sym-assoc ⟩
+      (u eq ∘ Coequalizer.arr coeqʰ) ∘ i₁ ≈⟨ ⟺ (Coequalizer.universal coeqʰ) ⟩∘⟨refl ⟩
+      (t ∘ Coequalizer.arr coeqⁱ) ∘ i₁ ≈⟨ assoc ⟩
+      t ∘ Coequalizer.arr coeqⁱ ∘ i₁ ≈⟨ refl⟩∘⟨ Coequalizer.equality coeqⁱ ⟩
+      t ∘ Coequalizer.arr coeqⁱ ∘ i₂ ≈⟨ ⟺ assoc ⟩
+      (t ∘ Coequalizer.arr coeqⁱ) ∘ i₂ ≈⟨ Coequalizer.universal coeqʰ ⟩∘⟨refl ⟩
+      (u eq ∘ Coequalizer.arr coeqʰ) ∘ i₂ ≈⟨ assoc ⟩
+      u eq ∘ Coequalizer.arr coeqʰ ∘ i₂ ≈⟨ refl⟩∘⟨ sq₂ᵍʰ ⟩
+      u eq ∘ g⇒h₂ ∘ Coequalizer.arr coeqᵍ ≈⟨ ⟺ assoc ⟩
+      (u eq ∘ g⇒h₂) ∘ Coequalizer.arr coeqᵍ ∎
+
+    uEqualizes : {T : Obj} {t : Coequalizer.obj coeqⁱ ⇒ T} (eq : t ∘ f⇒i₁ ≈ t ∘ f⇒i₂) → u eq ∘ g⇒h₁ ≈ u eq ∘ g⇒h₂
+    uEqualizes {T} {t} eq = Coequalizer⇒Epi coeqᵍ (u eq ∘ g⇒h₁) (u eq ∘ g⇒h₂) (uEqualizes∘arr eq)
+
+    coequalize : {T : Obj} {t : Coequalizer.obj coeqⁱ ⇒ T} → t ∘ f⇒i₁ ≈ t ∘ f⇒i₂ → obj ⇒ T
+    coequalize {T} {t} eq = Coequalizer.coequalize coeqcoeqᵍʰ {h = u eq} (uEqualizes eq)
+
+    universal∘arr : {T : Obj} {t : Coequalizer.obj coeqⁱ ⇒ T} {eq : t ∘ f⇒i₁ ≈ t ∘ f⇒i₂}
+                → t ∘ Coequalizer.arr coeqⁱ ≈ (coequalize eq ∘ arr) ∘ Coequalizer.arr coeqⁱ
+    universal∘arr {T} {t} {eq} = begin
+      t ∘ Coequalizer.arr coeqⁱ ≈⟨ Coequalizer.universal coeqʰ ⟩
+      u eq ∘ Coequalizer.arr coeqʰ ≈⟨ Coequalizer.universal coeqcoeqᵍʰ ⟩∘⟨refl ⟩
+      (coequalize eq ∘ Coequalizer.arr coeqcoeqᵍʰ) ∘ Coequalizer.arr coeqʰ ≈⟨ assoc ⟩
+      coequalize eq ∘ Coequalizer.arr coeqcoeqᵍʰ ∘ Coequalizer.arr coeqʰ ≈⟨ refl⟩∘⟨ arrSq ⟩
+      coequalize eq ∘ arr ∘ Coequalizer.arr coeqⁱ ≈⟨ ⟺ assoc ⟩
+      (coequalize eq ∘ arr) ∘ Coequalizer.arr coeqⁱ ∎
+
+    universal : {T : Obj} {t : Coequalizer.obj coeqⁱ ⇒ T} {eq : t ∘ f⇒i₁ ≈ t ∘ f⇒i₂}
+                → t ≈ coequalize eq ∘ arr
+    universal {T} {t} {eq} = Coequalizer⇒Epi coeqⁱ t (coequalize eq ∘ arr) universal∘arr
+
+    unique∘arr∘arr : {T : Obj} {t : Coequalizer.obj coeqⁱ ⇒ T} {i : obj ⇒ T} {eq : t ∘ f⇒i₁ ≈ t ∘ f⇒i₂}
+                     → t ≈ i ∘ arr
+                     → (i ∘ Coequalizer.arr coeqcoeqᵍʰ) ∘ Coequalizer.arr coeqʰ
+                       ≈ (coequalize eq  ∘ Coequalizer.arr coeqcoeqᵍʰ) ∘ Coequalizer.arr coeqʰ
+    unique∘arr∘arr {T} {t} {i} {eq} factors = begin
+      (i ∘ Coequalizer.arr coeqcoeqᵍʰ) ∘ Coequalizer.arr coeqʰ ≈⟨ assoc ⟩
+      i ∘ Coequalizer.arr coeqcoeqᵍʰ ∘ Coequalizer.arr coeqʰ ≈⟨ refl⟩∘⟨ arrSq ⟩
+      i ∘ arr ∘ Coequalizer.arr coeqⁱ ≈⟨ ⟺ assoc ⟩
+      (i ∘ arr) ∘ Coequalizer.arr coeqⁱ ≈⟨ ⟺ factors ⟩∘⟨refl ⟩
+      t ∘ Coequalizer.arr coeqⁱ ≈⟨ universal ⟩∘⟨refl ⟩
+      (coequalize eq ∘ arr) ∘ Coequalizer.arr coeqⁱ ≈⟨ assoc ⟩
+      coequalize eq ∘ arr ∘ Coequalizer.arr coeqⁱ ≈⟨ refl⟩∘⟨ ⟺ arrSq ⟩
+      coequalize eq ∘ Coequalizer.arr coeqcoeqᵍʰ ∘ Coequalizer.arr coeqʰ ≈⟨ ⟺ assoc ⟩
+      (coequalize eq  ∘ Coequalizer.arr coeqcoeqᵍʰ) ∘ Coequalizer.arr coeqʰ ∎
+
+    unique : {T : Obj} {t : Coequalizer.obj coeqⁱ ⇒ T} {i : obj ⇒ T} {eq : t ∘ f⇒i₁ ≈ t ∘ f⇒i₂}
+             → t ≈ i ∘ arr → i ≈ coequalize eq
+    unique {T} {t} {i} {eq} factors = Coequalizer⇒Epi coeqcoeqᵍʰ i (coequalize eq) (
+                                        Coequalizer⇒Epi coeqʰ
+                                        (i ∘ Coequalizer.arr coeqcoeqᵍʰ)
+                                        (coequalize eq  ∘ Coequalizer.arr coeqcoeqᵍʰ)
+                                        (unique∘arr∘arr factors)
+                                      )
+  -- end abstract --
+
+  coeqcoeqᶠⁱ : Coequalizer f⇒i₁ f⇒i₂
+  coeqcoeqᶠⁱ = record
+    { obj = obj
+    ; arr = arr
+    ; isCoequalizer = record
+      { equality = equality
+      ; coequalize = coequalize
+      ; universal = universal
+      ; unique = unique
+      }
+    }
+
+  CoeqsAreIsomorphic : (coeq : Coequalizer f⇒i₁ f⇒i₂) → Coequalizer.obj coeq ≅ Coequalizer.obj coeqcoeqᵍʰ
+  CoeqsAreIsomorphic coeq = up-to-iso coeq coeqcoeqᶠⁱ
+
+  -- The Isomorphism of coequalizers fits into a commutative pentagon --
+  -- We need this for proving some coherences in the bicategory of monads and bimodules --
+  IsoFitsInPentagon : (coeq : Coequalizer f⇒i₁ f⇒i₂)
+                      → Coequalizer.arr coeqcoeqᵍʰ ∘ Coequalizer.arr coeqʰ ≈
+                        _≅_.from (CoeqsAreIsomorphic coeq) ∘ Coequalizer.arr coeq  ∘ Coequalizer.arr coeqⁱ 
+  IsoFitsInPentagon coeq = begin
+    Coequalizer.arr coeqcoeqᵍʰ ∘ Coequalizer.arr coeqʰ ≈⟨ arrSq ⟩
+    arr ∘ Coequalizer.arr coeqⁱ                        ≈⟨ (Coequalizer.universal coeq ⟩∘⟨refl) ⟩
+    (_≅_.from (CoeqsAreIsomorphic coeq)
+      ∘ Coequalizer.arr coeq) ∘ Coequalizer.arr coeqⁱ  ≈⟨ assoc ⟩
+    _≅_.from (CoeqsAreIsomorphic coeq)
+      ∘ Coequalizer.arr coeq ∘ Coequalizer.arr coeqⁱ  ∎

--- a/src/Categories/Functor/Properties.agda
+++ b/src/Categories/Functor/Properties.agda
@@ -51,6 +51,15 @@ Conservative {C = C} {D = D} F = ∀ {A B} {f : C [ A , B ]} {g : D [ F₀ B , F
     open Functor F
     open Morphism
 
+PreservesCoequalizers : Functor C D → Set _
+PreservesCoequalizers {C = C} {D = D} F = ∀ {A B : C.Obj} {f g : A C.⇒ B} {coeq : Coequalizer C f g}
+                      → IsCoequalizer D (F₁ f) (F₁ g) (F₁ (arr coeq))
+  where
+    module C = Category C
+    open Functor F
+    open import Categories.Diagram.Coequalizer
+    open Coequalizer
+
 -- a series of [ Functor ]-respects-Thing combinators (with respects -> resp)
 
 module _ (F : Functor C D) where


### PR DESCRIPTION
This PR contains
- some lemmas and definitions concerning coequalizers
- definition of bicategory with local coequalizers
  (this is the premise for the construction of the bicategory of monads and bimodules)
- definition of bimodule between monads
- given two monads, construction of 1-category of bimodules
- construction of bicategory of monads and bimodules