### PR TITLE
Restriction Kleisli Category #2: Kleisli Category is monoidal symmetric

### DIFF
--- a/src/Categories/Category/Construction/Kleisli/Monoidal.agda
+++ b/src/Categories/Category/Construction/Kleisli/Monoidal.agda
@@ -1,0 +1,166 @@
+{-# OPTIONS --without-K --safe #-}
+module Categories.Category.Construction.Kleisli.Monoidal where
+
+open import Level
+open import Data.Product using (_,_)
+
+open import Categories.Category.Core using (Category)
+open import Categories.Monad using (Monad)
+open import Categories.Monad.Strong using (Strength; RightStrength)
+open import Categories.Monad.Commutative using (CommutativeMonad)
+open import Categories.Monad.Commutative.Properties using (module CommutativeProperties; module SymmetricProperties)
+open import Categories.Category.Construction.Kleisli using (Kleisli; module TripleNotation)
+open import Categories.Category.Monoidal using (Monoidal)
+open import Categories.Category.Monoidal.Symmetric using (Symmetric)
+
+
+import Categories.Morphism.Reasoning as MR
+import Categories.Monad.Strong.Properties as StrongProps
+
+private
+  variable
+    o ℓ e : Level
+
+-- The Kleisli category of a commutative monad (where 𝒞 is symmetric) is monoidal.
+
+module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symmetric monoidal) (CM : CommutativeMonad (Symmetric.braided symmetric)) where
+  open Category 𝒞
+  open MR 𝒞
+  open HomReasoning
+  open Equiv
+
+  open CommutativeMonad CM hiding (identityˡ)
+  open Monad M using (μ)
+  open TripleNotation M
+
+  open StrongProps.Left.Shorthands strength
+  open StrongProps.Right.Shorthands rightStrength
+
+  open Symmetric symmetric
+  open CommutativeProperties braided CM
+  open SymmetricProperties symmetric CM
+
+  Kleisli-Monoidal : Monoidal (Kleisli M)
+  Kleisli-Monoidal = record
+    { ⊗ = record
+      { F₀ = λ (X , Y) → X ⊗₀ Y
+      ; F₁ = λ (f , g) → ψ ∘ (f ⊗₁ g)
+      ; identity = begin 
+        (τ * ∘ σ) ∘ (η ⊗₁ η)              ≈˘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityˡ , identityʳ)) ⟩
+        (τ * ∘ σ) ∘ (id ⊗₁ η) ∘ (η ⊗₁ id) ≈⟨ pullʳ (pullˡ η-comm) ⟩ 
+        τ * ∘ η ∘ (η ⊗₁ id)               ≈⟨ pullˡ *-identityʳ ⟩ 
+        τ ∘ (η ⊗₁ id)                     ≈⟨ RightStrength.η-comm rightStrength ⟩
+        η                                 ∎
+      ; homomorphism = λ {X} {Y} {Z} {(f , g)} {(h , i)} → begin 
+        ψ ∘ ((h * ∘ f) ⊗₁ (i * ∘ g))                           ≈˘⟨ refl⟩∘⟨ (pullˡ (sym ⊗.homomorphism) ○ sym ⊗.homomorphism) ⟩ 
+        ψ ∘ (μ.η _ ⊗₁ μ.η _) ∘ (M.F.₁ h ⊗₁ M.F.₁ i) ∘ (f ⊗₁ g) ≈˘⟨ extendʳ ψ-μ ⟩ 
+        ψ * ∘ ψ ∘ (M.F.₁ h ⊗₁ M.F.₁ i) ∘ (f ⊗₁ g)              ≈⟨ refl⟩∘⟨ extendʳ ψ-comm ⟩ 
+        ψ * ∘ M.F.₁ (h ⊗₁ i) ∘ ψ ∘ (f ⊗₁ g)                    ≈⟨ pullˡ *∘F₁ ⟩ 
+        (ψ ∘ (h ⊗₁ i)) * ∘ ψ ∘ (f ⊗₁ g)                        ∎
+      ; F-resp-≈ = λ (f≈g , h≈i) → ∘-resp-≈ʳ (⊗.F-resp-≈ (f≈g , h≈i))
+      }
+    ; unit = unit
+    ; unitorˡ = record { from = η ∘ unitorˡ.from ; to = η ∘ unitorˡ.to ; iso = record 
+      { isoˡ = begin 
+        (η ∘ unitorˡ.to) * ∘ (η ∘ unitorˡ.from) ≈⟨ pullˡ *-identityʳ ⟩ 
+        (η ∘ unitorˡ.to) ∘ unitorˡ.from         ≈⟨ cancelʳ unitorˡ.isoˡ ⟩ 
+        η                                       ∎ 
+      ; isoʳ = begin 
+        (η ∘ unitorˡ.from) * ∘ (η ∘ unitorˡ.to) ≈⟨ pullˡ *-identityʳ ⟩ 
+        (η ∘ unitorˡ.from) ∘ unitorˡ.to         ≈⟨ cancelʳ unitorˡ.isoʳ ⟩ 
+        η                                       ∎ 
+      } }
+    ; unitorʳ = record { from = η ∘ unitorʳ.from ; to = η ∘ unitorʳ.to ; iso = record 
+      { isoˡ = begin 
+        (η ∘ unitorʳ.to) * ∘ (η ∘ unitorʳ.from) ≈⟨ pullˡ *-identityʳ ⟩ 
+        (η ∘ unitorʳ.to) ∘ unitorʳ.from         ≈⟨ cancelʳ unitorʳ.isoˡ ⟩ 
+        η                                       ∎ 
+      ; isoʳ = begin 
+        (η ∘ unitorʳ.from) * ∘ (η ∘ unitorʳ.to) ≈⟨ pullˡ *-identityʳ ⟩ 
+        (η ∘ unitorʳ.from) ∘ unitorʳ.to         ≈⟨ cancelʳ unitorʳ.isoʳ ⟩ 
+        η                                       ∎ 
+      } }
+    ; associator = record { from = η ∘ associator.from ; to = η ∘ associator.to ; iso = record 
+      { isoˡ = begin 
+        (η ∘ associator.to) * ∘ (η ∘ associator.from) ≈⟨ pullˡ *-identityʳ ⟩ 
+        (η ∘ associator.to) ∘ associator.from         ≈⟨ cancelʳ associator.isoˡ ⟩ 
+        η                                             ∎ 
+      ; isoʳ = begin 
+        (η ∘ associator.from) * ∘ (η ∘ associator.to) ≈⟨ pullˡ *-identityʳ ⟩ 
+        (η ∘ associator.from) ∘ associator.to         ≈⟨ cancelʳ associator.isoʳ ⟩ 
+        η                                             ∎ 
+      } }    
+    ; unitorˡ-commute-from = λ {X} {Y} {f} → begin 
+      (η ∘ unitorˡ.from) * ∘ ψ ∘ (η ⊗₁ f)                   ≈⟨ *⇒F₁ ⟩∘⟨ ψ-σ' ⟩ 
+      M.F.₁ unitorˡ.from ∘ σ ∘ (id ⊗₁ f)                    ≈⟨ pullˡ (Strength.identityˡ strength) ⟩ 
+      unitorˡ.from ∘ (id ⊗₁ f)                              ≈⟨ unitorˡ-commute-from ⟩ 
+      f ∘ unitorˡ.from                                      ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      f * ∘ η ∘ unitorˡ.from                                ∎
+    ; unitorˡ-commute-to = λ {X} {Y} {f} → begin 
+      (η ∘ unitorˡ.to) * ∘ f                                       ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ unitorˡ.to ∘ f                                         ≈˘⟨ refl⟩∘⟨ (cancelˡ unitorˡ.isoʳ) ⟩ 
+      M.F.₁ unitorˡ.to ∘ unitorˡ.from ∘ unitorˡ.to ∘ f             ≈˘⟨ pullʳ (pullˡ (Strength.identityˡ strength)) ⟩
+      (M.F.₁ unitorˡ.to ∘ M.F.₁ unitorˡ.from) ∘ σ ∘ unitorˡ.to ∘ f ≈⟨ elimˡ (sym M.F.homomorphism ○ (M.F.F-resp-≈ unitorˡ.isoˡ ○ M.F.identity)) ⟩
+      σ ∘ unitorˡ.to ∘ f                                           ≈˘⟨ pullʳ (sym unitorˡ-commute-to) ⟩ 
+      (σ ∘ (id ⊗₁ f)) ∘ unitorˡ.to                                 ≈˘⟨ ψ-σ' ⟩∘⟨refl ⟩ 
+      (ψ ∘ (η ⊗₁ f)) ∘ unitorˡ.to                                  ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (η ⊗₁ f)) * ∘ η ∘ unitorˡ.to                            ∎
+    ; unitorʳ-commute-from = λ {X} {Y} {f} → begin 
+      (η ∘ unitorʳ.from) * ∘ ψ ∘ (f ⊗₁ η) ≈⟨ *⇒F₁ ⟩∘⟨ ψ-τ' ⟩ 
+      M.F.₁ unitorʳ.from ∘ τ ∘ (f ⊗₁ id)  ≈⟨ pullˡ (RightStrength.identityˡ rightStrength) ⟩ 
+      unitorʳ.from ∘ (f ⊗₁ id)            ≈⟨ unitorʳ-commute-from ⟩ 
+      f ∘ unitorʳ.from                    ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      f * ∘ η ∘ unitorʳ.from              ∎
+    ; unitorʳ-commute-to = λ {X} {Y} {f} → begin 
+      (η ∘ unitorʳ.to) * ∘ f                                       ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ unitorʳ.to ∘ f                                         ≈˘⟨ refl⟩∘⟨ (cancelˡ unitorʳ.isoʳ) ⟩ 
+      M.F.₁ unitorʳ.to ∘ unitorʳ.from ∘ unitorʳ.to ∘ f             ≈˘⟨ pullʳ (pullˡ (RightStrength.identityˡ rightStrength)) ⟩
+      (M.F.₁ unitorʳ.to ∘ M.F.₁ unitorʳ.from) ∘ τ ∘ unitorʳ.to ∘ f ≈⟨ elimˡ (sym M.F.homomorphism ○ (M.F.F-resp-≈ unitorʳ.isoˡ ○ M.F.identity)) ⟩
+      τ ∘ unitorʳ.to ∘ f                                           ≈˘⟨ pullʳ (sym unitorʳ-commute-to) ⟩ 
+      (τ ∘ (f ⊗₁ id)) ∘ unitorʳ.to                                 ≈˘⟨ ψ-τ' ⟩∘⟨refl ⟩ 
+      (ψ ∘ (f ⊗₁ η)) ∘ unitorʳ.to                                  ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (f ⊗₁ η)) * ∘ η ∘ unitorʳ.to                            ∎
+    ; assoc-commute-from = λ {X} {Y} {f} {A} {B} {g} {U} {V} {h} → begin 
+      (η ∘ associator.from) * ∘ ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)     ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ associator.from ∘ ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityˡ)) ⟩ 
+      M.F.₁ associator.from ∘ ψ ∘ (ψ ⊗₁ id) ∘ ((f ⊗₁ g) ⊗₁ h) ≈⟨ (sym-assoc ○ pullˡ (assoc ○ ψ-assoc-from) ○ assoc²βε) ⟩ 
+      ψ ∘ (id ⊗₁ ψ) ∘ associator.from ∘ ((f ⊗₁ g) ⊗₁ h)       ≈˘⟨ pullʳ (pullʳ (sym assoc-commute-from)) ⟩ 
+      (ψ ∘ (id ⊗₁ ψ) ∘ (f ⊗₁ (g ⊗₁ h))) ∘ associator.from     ≈⟨ (refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityˡ , refl))) ⟩∘⟨refl ⟩ 
+      (ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))) ∘ associator.from           ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))) * ∘ (η ∘ associator.from)   ∎
+    ; assoc-commute-to = λ {X} {Y} {f} {A} {B} {g} {U} {V} {h} → begin 
+      (η ∘ associator.to) * ∘ ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))     ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ associator.to ∘ ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityˡ , refl)) ⟩ 
+      M.F.₁ associator.to ∘ ψ ∘ (id ⊗₁ ψ) ∘ (f ⊗₁ (g ⊗₁ h)) ≈⟨ (sym-assoc ○ (pullˡ (assoc ○ ψ-assoc-to) ○ assoc²βε)) ⟩ 
+      ψ ∘ (ψ ⊗₁ id) ∘ associator.to ∘ (f ⊗₁ (g ⊗₁ h))       ≈˘⟨ pullʳ (pullʳ (sym assoc-commute-to)) ⟩
+      (ψ ∘ (ψ ⊗₁ id) ∘ ((f ⊗₁ g) ⊗₁ h)) ∘ associator.to     ≈⟨ (refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityˡ))) ⟩∘⟨refl ⟩ 
+      (ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)) ∘ associator.to           ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)) * ∘ (η ∘ associator.to)   ∎
+    ; triangle = begin 
+      (ψ ∘ (η ⊗₁ (η ∘ unitorˡ.from))) * ∘ (η ∘ associator.from) ≈⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (η ⊗₁ (η ∘ unitorˡ.from))) ∘ associator.from         ≈˘⟨ pullˡ (pullʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl))) ⟩ 
+      (ψ ∘ (η ⊗₁ η)) ∘ (id ⊗₁ unitorˡ.from) ∘ associator.from   ≈⟨ (refl⟩∘⟨ triangle) ⟩ 
+      (ψ ∘ (η ⊗₁ η)) ∘ (unitorʳ.from ⊗₁ id)                     ≈⟨ pullʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)) ⟩  
+      ψ ∘ ((η ∘ unitorʳ.from) ⊗₁ η)                             ∎
+    ; pentagon = begin 
+      (ψ ∘ (η ⊗₁ (η ∘ associator.from))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ associator.from) ⊗₁ η)) 
+        ≈⟨ refl⟩∘⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      (ψ ∘ (η ⊗₁ (η ∘ associator.from))) * ∘ M.F.₁ associator.from ∘ (ψ ∘ ((η ∘ associator.from) ⊗₁ η))   
+        ≈⟨ pullˡ (*∘F₁ ○ *-resp-≈ assoc) ⟩ 
+      (ψ ∘ (η ⊗₁ (η ∘ associator.from)) ∘ associator.from) * ∘ (ψ ∘ ((η ∘ associator.from) ⊗₁ η))         
+        ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)) ⟩ 
+      (ψ ∘ (η ⊗₁ (η ∘ associator.from)) ∘ associator.from) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (associator.from ⊗₁ id))  
+        ≈⟨ refl⟩∘⟨ pullˡ ψ-η ⟩ 
+      (ψ ∘ (η ⊗₁ (η ∘ associator.from)) ∘ associator.from) * ∘ (η ∘ (associator.from ⊗₁ id))            
+        ≈⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (η ⊗₁ (η ∘ associator.from)) ∘ associator.from) ∘ (associator.from ⊗₁ id)                    
+        ≈˘⟨ sym-assoc ○ (∘-resp-≈ʳ sym-assoc ○ pullˡ (pullʳ (pullˡ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl))))) ⟩ 
+      ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ associator.from) ∘ associator.from ∘ (associator.from ⊗₁ id)                 
+        ≈⟨ (refl⟩∘⟨ refl⟩∘⟨ pentagon) ⟩ 
+      ψ ∘ (η ⊗₁ η) ∘ (associator.from ∘ associator.from)                                               
+        ≈⟨ (pullˡ ψ-η) ○ sym-assoc ⟩ 
+      (η ∘ associator.from) ∘ associator.from                                                         
+        ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (η ∘ associator.from) * ∘ (η ∘ associator.from)                                                 
+        ∎
+    }

--- a/src/Categories/Category/Construction/Kleisli/Monoidal.agda
+++ b/src/Categories/Category/Construction/Kleisli/Monoidal.agda
@@ -45,81 +45,27 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
     { ⊗ = record
       { F₀ = λ (X , Y) → X ⊗₀ Y
       ; F₁ = λ (f , g) → ψ ∘ (f ⊗₁ g)
-      ; identity = begin 
-        (τ * ∘ σ) ∘ (η ⊗₁ η)              ≈˘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityˡ , identityʳ)) ⟩
-        (τ * ∘ σ) ∘ (id ⊗₁ η) ∘ (η ⊗₁ id) ≈⟨ pullʳ (pullˡ η-comm) ⟩ 
-        τ * ∘ η ∘ (η ⊗₁ id)               ≈⟨ pullˡ *-identityʳ ⟩ 
-        τ ∘ (η ⊗₁ id)                     ≈⟨ RightStrength.η-comm rightStrength ⟩
-        η                                 ∎
-      ; homomorphism = λ {X} {Y} {Z} {(f , g)} {(h , i)} → begin 
-        ψ ∘ ((h * ∘ f) ⊗₁ (i * ∘ g))                           ≈˘⟨ refl⟩∘⟨ (pullˡ (sym ⊗.homomorphism) ○ sym ⊗.homomorphism) ⟩ 
-        ψ ∘ (μ.η _ ⊗₁ μ.η _) ∘ (M.F.₁ h ⊗₁ M.F.₁ i) ∘ (f ⊗₁ g) ≈˘⟨ extendʳ ψ-μ ⟩ 
-        ψ * ∘ ψ ∘ (M.F.₁ h ⊗₁ M.F.₁ i) ∘ (f ⊗₁ g)              ≈⟨ refl⟩∘⟨ extendʳ ψ-comm ⟩ 
-        ψ * ∘ M.F.₁ (h ⊗₁ i) ∘ ψ ∘ (f ⊗₁ g)                    ≈⟨ pullˡ *∘F₁ ⟩ 
-        (ψ ∘ (h ⊗₁ i)) * ∘ ψ ∘ (f ⊗₁ g)                        ∎
+      ; identity = identity'
+      ; homomorphism = λ {(X₁ , X₂)} {(Y₁ , Y₂)} {(Z₁ , Z₂)} {(f , g)} {(h , i)} → homomorphism' {X₁} {X₂} {Y₁} {Y₂} {Z₁} {Z₂} {f} {g} {h} {i}
       ; F-resp-≈ = λ (f≈g , h≈i) → ∘-resp-≈ʳ (⊗.F-resp-≈ (f≈g , h≈i))
       }
     ; unit = unit
     ; unitorˡ = record { from = η ∘ unitorˡ.from ; to = η ∘ unitorˡ.to ; iso = record 
-      { isoˡ = begin 
-        (η ∘ unitorˡ.to) * ∘ (η ∘ unitorˡ.from) ≈⟨ pullˡ *-identityʳ ⟩ 
-        (η ∘ unitorˡ.to) ∘ unitorˡ.from         ≈⟨ cancelʳ unitorˡ.isoˡ ⟩ 
-        η                                       ∎ 
-      ; isoʳ = begin 
-        (η ∘ unitorˡ.from) * ∘ (η ∘ unitorˡ.to) ≈⟨ pullˡ *-identityʳ ⟩ 
-        (η ∘ unitorˡ.from) ∘ unitorˡ.to         ≈⟨ cancelʳ unitorˡ.isoʳ ⟩ 
-        η                                       ∎ 
+      { isoˡ = pullˡ *-identityʳ ○ cancelʳ unitorˡ.isoˡ
+      ; isoʳ = pullˡ *-identityʳ ○ cancelʳ unitorˡ.isoʳ
       } }
     ; unitorʳ = record { from = η ∘ unitorʳ.from ; to = η ∘ unitorʳ.to ; iso = record 
-      { isoˡ = begin 
-        (η ∘ unitorʳ.to) * ∘ (η ∘ unitorʳ.from) ≈⟨ pullˡ *-identityʳ ⟩ 
-        (η ∘ unitorʳ.to) ∘ unitorʳ.from         ≈⟨ cancelʳ unitorʳ.isoˡ ⟩ 
-        η                                       ∎ 
-      ; isoʳ = begin 
-        (η ∘ unitorʳ.from) * ∘ (η ∘ unitorʳ.to) ≈⟨ pullˡ *-identityʳ ⟩ 
-        (η ∘ unitorʳ.from) ∘ unitorʳ.to         ≈⟨ cancelʳ unitorʳ.isoʳ ⟩ 
-        η                                       ∎ 
+      { isoˡ = pullˡ *-identityʳ ○ cancelʳ unitorʳ.isoˡ
+      ; isoʳ = pullˡ *-identityʳ ○ cancelʳ unitorʳ.isoʳ
       } }
     ; associator = record { from = η ∘ associator.from ; to = η ∘ associator.to ; iso = record 
-      { isoˡ = begin 
-        (η ∘ associator.to) * ∘ (η ∘ associator.from) ≈⟨ pullˡ *-identityʳ ⟩ 
-        (η ∘ associator.to) ∘ associator.from         ≈⟨ cancelʳ associator.isoˡ ⟩ 
-        η                                             ∎ 
-      ; isoʳ = begin 
-        (η ∘ associator.from) * ∘ (η ∘ associator.to) ≈⟨ pullˡ *-identityʳ ⟩ 
-        (η ∘ associator.from) ∘ associator.to         ≈⟨ cancelʳ associator.isoʳ ⟩ 
-        η                                             ∎ 
+      { isoˡ = pullˡ *-identityʳ ○ cancelʳ associator.isoˡ
+      ; isoʳ = pullˡ *-identityʳ ○ cancelʳ associator.isoʳ
       } }    
-    ; unitorˡ-commute-from = λ {X} {Y} {f} → begin 
-      (η ∘ unitorˡ.from) * ∘ ψ ∘ (η ⊗₁ f)                   ≈⟨ *⇒F₁ ⟩∘⟨ ψ-σ' ⟩ 
-      M.F.₁ unitorˡ.from ∘ σ ∘ (id ⊗₁ f)                    ≈⟨ pullˡ (Strength.identityˡ strength) ⟩ 
-      unitorˡ.from ∘ (id ⊗₁ f)                              ≈⟨ unitorˡ-commute-from ⟩ 
-      f ∘ unitorˡ.from                                      ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      f * ∘ η ∘ unitorˡ.from                                ∎
-    ; unitorˡ-commute-to = λ {X} {Y} {f} → begin 
-      (η ∘ unitorˡ.to) * ∘ f                                       ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
-      M.F.₁ unitorˡ.to ∘ f                                         ≈˘⟨ refl⟩∘⟨ (cancelˡ unitorˡ.isoʳ) ⟩ 
-      M.F.₁ unitorˡ.to ∘ unitorˡ.from ∘ unitorˡ.to ∘ f             ≈˘⟨ pullʳ (pullˡ (Strength.identityˡ strength)) ⟩
-      (M.F.₁ unitorˡ.to ∘ M.F.₁ unitorˡ.from) ∘ σ ∘ unitorˡ.to ∘ f ≈⟨ elimˡ (sym M.F.homomorphism ○ (M.F.F-resp-≈ unitorˡ.isoˡ ○ M.F.identity)) ⟩
-      σ ∘ unitorˡ.to ∘ f                                           ≈˘⟨ pullʳ (sym unitorˡ-commute-to) ⟩ 
-      (σ ∘ (id ⊗₁ f)) ∘ unitorˡ.to                                 ≈˘⟨ ψ-σ' ⟩∘⟨refl ⟩ 
-      (ψ ∘ (η ⊗₁ f)) ∘ unitorˡ.to                                  ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      (ψ ∘ (η ⊗₁ f)) * ∘ η ∘ unitorˡ.to                            ∎
-    ; unitorʳ-commute-from = λ {X} {Y} {f} → begin 
-      (η ∘ unitorʳ.from) * ∘ ψ ∘ (f ⊗₁ η) ≈⟨ *⇒F₁ ⟩∘⟨ ψ-τ' ⟩ 
-      M.F.₁ unitorʳ.from ∘ τ ∘ (f ⊗₁ id)  ≈⟨ pullˡ (RightStrength.identityˡ rightStrength) ⟩ 
-      unitorʳ.from ∘ (f ⊗₁ id)            ≈⟨ unitorʳ-commute-from ⟩ 
-      f ∘ unitorʳ.from                    ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      f * ∘ η ∘ unitorʳ.from              ∎
-    ; unitorʳ-commute-to = λ {X} {Y} {f} → begin 
-      (η ∘ unitorʳ.to) * ∘ f                                       ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
-      M.F.₁ unitorʳ.to ∘ f                                         ≈˘⟨ refl⟩∘⟨ (cancelˡ unitorʳ.isoʳ) ⟩ 
-      M.F.₁ unitorʳ.to ∘ unitorʳ.from ∘ unitorʳ.to ∘ f             ≈˘⟨ pullʳ (pullˡ (RightStrength.identityˡ rightStrength)) ⟩
-      (M.F.₁ unitorʳ.to ∘ M.F.₁ unitorʳ.from) ∘ τ ∘ unitorʳ.to ∘ f ≈⟨ elimˡ (sym M.F.homomorphism ○ (M.F.F-resp-≈ unitorʳ.isoˡ ○ M.F.identity)) ⟩
-      τ ∘ unitorʳ.to ∘ f                                           ≈˘⟨ pullʳ (sym unitorʳ-commute-to) ⟩ 
-      (τ ∘ (f ⊗₁ id)) ∘ unitorʳ.to                                 ≈˘⟨ ψ-τ' ⟩∘⟨refl ⟩ 
-      (ψ ∘ (f ⊗₁ η)) ∘ unitorʳ.to                                  ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      (ψ ∘ (f ⊗₁ η)) * ∘ η ∘ unitorʳ.to                            ∎
+    ; unitorˡ-commute-from = unitorˡ-commute-from'
+    ; unitorˡ-commute-to = unitorˡ-commute-to'
+    ; unitorʳ-commute-from = unitorʳ-commute-from'
+    ; unitorʳ-commute-to = unitorʳ-commute-to'
     ; assoc-commute-from = λ {X} {Y} {f} {A} {B} {g} {U} {V} {h} → begin 
       (η ∘ associator.from) * ∘ ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)     ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
       M.F.₁ associator.from ∘ ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityˡ)) ⟩ 
@@ -136,13 +82,67 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
       (ψ ∘ (ψ ⊗₁ id) ∘ ((f ⊗₁ g) ⊗₁ h)) ∘ associator.to     ≈⟨ (refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityˡ))) ⟩∘⟨refl ⟩ 
       (ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)) ∘ associator.to           ≈˘⟨ pullˡ *-identityʳ ⟩ 
       (ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)) * ∘ (η ∘ associator.to)   ∎
-    ; triangle = begin 
+    ; triangle = triangle'
+    ; pentagon = pentagon'
+    }
+    where
+    identity' : ∀ {X} {Y} → ψ ∘ (η {X} ⊗₁ η {Y}) ≈ η
+    identity' = begin 
+        (τ * ∘ σ) ∘ (η ⊗₁ η)              ≈˘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityˡ , identityʳ)) ⟩
+        (τ * ∘ σ) ∘ (id ⊗₁ η) ∘ (η ⊗₁ id) ≈⟨ pullʳ (pullˡ η-comm) ⟩ 
+        τ * ∘ η ∘ (η ⊗₁ id)               ≈⟨ pullˡ *-identityʳ ⟩ 
+        τ ∘ (η ⊗₁ id)                     ≈⟨ RightStrength.η-comm rightStrength ⟩
+        η                                 ∎
+    homomorphism' : ∀ {X₁ X₂ Y₁ Y₂ Z₁ Z₂ : Obj} {f : X₁ ⇒ M.F.₀ Y₁} {g : X₂ ⇒ M.F.₀ Y₂} {h : Y₁ ⇒ M.F.₀ Z₁} {i : Y₂ ⇒ M.F.₀ Z₂} → ψ ∘ ((h * ∘ f) ⊗₁ (i * ∘ g)) ≈ (ψ ∘ (h ⊗₁ i)) * ∘ ψ ∘ (f ⊗₁ g)
+    homomorphism' {f = f} {g} {h} {i} = begin 
+        ψ ∘ ((h * ∘ f) ⊗₁ (i * ∘ g))                           ≈˘⟨ refl⟩∘⟨ (pullˡ (sym ⊗.homomorphism) ○ sym ⊗.homomorphism) ⟩ 
+        ψ ∘ (μ.η _ ⊗₁ μ.η _) ∘ (M.F.₁ h ⊗₁ M.F.₁ i) ∘ (f ⊗₁ g) ≈˘⟨ extendʳ ψ-μ ⟩ 
+        ψ * ∘ ψ ∘ (M.F.₁ h ⊗₁ M.F.₁ i) ∘ (f ⊗₁ g)              ≈⟨ refl⟩∘⟨ extendʳ ψ-comm ⟩ 
+        ψ * ∘ M.F.₁ (h ⊗₁ i) ∘ ψ ∘ (f ⊗₁ g)                    ≈⟨ pullˡ *∘F₁ ⟩ 
+        (ψ ∘ (h ⊗₁ i)) * ∘ ψ ∘ (f ⊗₁ g)                        ∎
+    unitorˡ-commute-from' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ unitorˡ.from) * ∘ ψ ∘ (η ⊗₁ f) ≈ f * ∘ η ∘ unitorˡ.from
+    unitorˡ-commute-from' {f = f} = begin 
+      (η ∘ unitorˡ.from) * ∘ ψ ∘ (η ⊗₁ f)                   ≈⟨ *⇒F₁ ⟩∘⟨ ψ-σ' ⟩ 
+      M.F.₁ unitorˡ.from ∘ σ ∘ (id ⊗₁ f)                    ≈⟨ pullˡ (Strength.identityˡ strength) ⟩ 
+      unitorˡ.from ∘ (id ⊗₁ f)                              ≈⟨ unitorˡ-commute-from ⟩ 
+      f ∘ unitorˡ.from                                      ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      f * ∘ η ∘ unitorˡ.from                                ∎
+    unitorˡ-commute-to' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ unitorˡ.to) * ∘ f ≈ (ψ ∘ (η ⊗₁ f)) * ∘ η ∘ unitorˡ.to
+    unitorˡ-commute-to' {f = f} = begin 
+      (η ∘ unitorˡ.to) * ∘ f                                       ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ unitorˡ.to ∘ f                                         ≈˘⟨ refl⟩∘⟨ (cancelˡ unitorˡ.isoʳ) ⟩ 
+      M.F.₁ unitorˡ.to ∘ unitorˡ.from ∘ unitorˡ.to ∘ f             ≈˘⟨ pullʳ (pullˡ (Strength.identityˡ strength)) ⟩
+      (M.F.₁ unitorˡ.to ∘ M.F.₁ unitorˡ.from) ∘ σ ∘ unitorˡ.to ∘ f ≈⟨ elimˡ (sym M.F.homomorphism ○ (M.F.F-resp-≈ unitorˡ.isoˡ ○ M.F.identity)) ⟩
+      σ ∘ unitorˡ.to ∘ f                                           ≈˘⟨ pullʳ (sym unitorˡ-commute-to) ⟩ 
+      (σ ∘ (id ⊗₁ f)) ∘ unitorˡ.to                                 ≈˘⟨ ψ-σ' ⟩∘⟨refl ⟩ 
+      (ψ ∘ (η ⊗₁ f)) ∘ unitorˡ.to                                  ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (η ⊗₁ f)) * ∘ η ∘ unitorˡ.to                            ∎
+    unitorʳ-commute-from' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ unitorʳ.from) * ∘ ψ ∘ (f ⊗₁ η) ≈ f * ∘ η ∘ unitorʳ.from
+    unitorʳ-commute-from' {f = f} = begin 
+      (η ∘ unitorʳ.from) * ∘ ψ ∘ (f ⊗₁ η) ≈⟨ *⇒F₁ ⟩∘⟨ ψ-τ' ⟩ 
+      M.F.₁ unitorʳ.from ∘ τ ∘ (f ⊗₁ id)  ≈⟨ pullˡ (RightStrength.identityˡ rightStrength) ⟩ 
+      unitorʳ.from ∘ (f ⊗₁ id)            ≈⟨ unitorʳ-commute-from ⟩ 
+      f ∘ unitorʳ.from                    ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      f * ∘ η ∘ unitorʳ.from              ∎
+    unitorʳ-commute-to' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ unitorʳ.to) * ∘ f ≈ (ψ ∘ (f ⊗₁ η)) * ∘ η ∘ unitorʳ.to
+    unitorʳ-commute-to' {f = f} = begin 
+      (η ∘ unitorʳ.to) * ∘ f                                       ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ unitorʳ.to ∘ f                                         ≈˘⟨ refl⟩∘⟨ (cancelˡ unitorʳ.isoʳ) ⟩ 
+      M.F.₁ unitorʳ.to ∘ unitorʳ.from ∘ unitorʳ.to ∘ f             ≈˘⟨ pullʳ (pullˡ (RightStrength.identityˡ rightStrength)) ⟩
+      (M.F.₁ unitorʳ.to ∘ M.F.₁ unitorʳ.from) ∘ τ ∘ unitorʳ.to ∘ f ≈⟨ elimˡ (sym M.F.homomorphism ○ (M.F.F-resp-≈ unitorʳ.isoˡ ○ M.F.identity)) ⟩
+      τ ∘ unitorʳ.to ∘ f                                           ≈˘⟨ pullʳ (sym unitorʳ-commute-to) ⟩ 
+      (τ ∘ (f ⊗₁ id)) ∘ unitorʳ.to                                 ≈˘⟨ ψ-τ' ⟩∘⟨refl ⟩ 
+      (ψ ∘ (f ⊗₁ η)) ∘ unitorʳ.to                                  ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (f ⊗₁ η)) * ∘ η ∘ unitorʳ.to                            ∎
+    triangle' : ∀ {X} {Y} → (ψ ∘ (η {X} ⊗₁ (η ∘ unitorˡ.from))) * ∘ (η ∘ associator.from) ≈ ψ ∘ ((η ∘ unitorʳ.from) ⊗₁ η {Y})
+    triangle' = begin 
       (ψ ∘ (η ⊗₁ (η ∘ unitorˡ.from))) * ∘ (η ∘ associator.from) ≈⟨ pullˡ *-identityʳ ⟩ 
       (ψ ∘ (η ⊗₁ (η ∘ unitorˡ.from))) ∘ associator.from         ≈˘⟨ pullˡ (pullʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl))) ⟩ 
       (ψ ∘ (η ⊗₁ η)) ∘ (id ⊗₁ unitorˡ.from) ∘ associator.from   ≈⟨ (refl⟩∘⟨ triangle) ⟩ 
       (ψ ∘ (η ⊗₁ η)) ∘ (unitorʳ.from ⊗₁ id)                     ≈⟨ pullʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)) ⟩  
       ψ ∘ ((η ∘ unitorʳ.from) ⊗₁ η)                             ∎
-    ; pentagon = begin 
+    pentagon' : ∀ {A B C D : Obj} → (ψ {A} {B ⊗₀ (C ⊗₀ D)} ∘ (η ⊗₁ (η ∘ associator.from))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ associator.from) ⊗₁ η)) ≈ (η ∘ associator.from) * ∘ (η ∘ associator.from)
+    pentagon' = begin 
       (ψ ∘ (η ⊗₁ (η ∘ associator.from))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ associator.from) ⊗₁ η)) 
         ≈⟨ refl⟩∘⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
       (ψ ∘ (η ⊗₁ (η ∘ associator.from))) * ∘ M.F.₁ associator.from ∘ (ψ ∘ ((η ∘ associator.from) ⊗₁ η))   
@@ -163,4 +163,5 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
         ≈˘⟨ pullˡ *-identityʳ ⟩ 
       (η ∘ associator.from) * ∘ (η ∘ associator.from)                                                 
         ∎
-    }
+    
+

--- a/src/Categories/Category/Construction/Kleisli/Monoidal.agda
+++ b/src/Categories/Category/Construction/Kleisli/Monoidal.agda
@@ -16,6 +16,7 @@ open import Categories.Category.Monoidal.Symmetric using (Symmetric)
 
 import Categories.Morphism.Reasoning as MR
 import Categories.Monad.Strong.Properties as StrongProps
+import Categories.Category.Monoidal.Utilities as MonoidalUtils
 
 private
   variable
@@ -35,6 +36,8 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
 
   open StrongProps.Left.Shorthands strength
   open StrongProps.Right.Shorthands rightStrength
+  open MonoidalUtils.Shorthands monoidal using (α⇒; α⇐; λ⇒; λ⇐; ρ⇒; ρ⇐)
+
 
   open Symmetric symmetric
   open CommutativeProperties braided CM
@@ -50,15 +53,15 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
       ; F-resp-≈ = λ (f≈g , h≈i) → ∘-resp-≈ʳ (⊗.F-resp-≈ (f≈g , h≈i))
       }
     ; unit = unit
-    ; unitorˡ = record { from = η ∘ unitorˡ.from ; to = η ∘ unitorˡ.to ; iso = record 
+    ; unitorˡ = record { from = η ∘ λ⇒ ; to = η ∘ λ⇐ ; iso = record 
       { isoˡ = pullˡ *-identityʳ ○ cancelʳ unitorˡ.isoˡ
       ; isoʳ = pullˡ *-identityʳ ○ cancelʳ unitorˡ.isoʳ
       } }
-    ; unitorʳ = record { from = η ∘ unitorʳ.from ; to = η ∘ unitorʳ.to ; iso = record 
+    ; unitorʳ = record { from = η ∘ ρ⇒ ; to = η ∘ ρ⇐ ; iso = record 
       { isoˡ = pullˡ *-identityʳ ○ cancelʳ unitorʳ.isoˡ
       ; isoʳ = pullˡ *-identityʳ ○ cancelʳ unitorʳ.isoʳ
       } }
-    ; associator = record { from = η ∘ associator.from ; to = η ∘ associator.to ; iso = record 
+    ; associator = record { from = η ∘ α⇒ ; to = η ∘ α⇐ ; iso = record 
       { isoˡ = pullˡ *-identityʳ ○ cancelʳ associator.isoˡ
       ; isoʳ = pullˡ *-identityʳ ○ cancelʳ associator.isoʳ
       } }    
@@ -66,22 +69,8 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
     ; unitorˡ-commute-to = unitorˡ-commute-to'
     ; unitorʳ-commute-from = unitorʳ-commute-from'
     ; unitorʳ-commute-to = unitorʳ-commute-to'
-    ; assoc-commute-from = λ {X} {Y} {f} {A} {B} {g} {U} {V} {h} → begin 
-      (η ∘ associator.from) * ∘ ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)     ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
-      M.F.₁ associator.from ∘ ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityˡ)) ⟩ 
-      M.F.₁ associator.from ∘ ψ ∘ (ψ ⊗₁ id) ∘ ((f ⊗₁ g) ⊗₁ h) ≈⟨ (sym-assoc ○ pullˡ (assoc ○ ψ-assoc-from) ○ assoc²βε) ⟩ 
-      ψ ∘ (id ⊗₁ ψ) ∘ associator.from ∘ ((f ⊗₁ g) ⊗₁ h)       ≈˘⟨ pullʳ (pullʳ (sym assoc-commute-from)) ⟩ 
-      (ψ ∘ (id ⊗₁ ψ) ∘ (f ⊗₁ (g ⊗₁ h))) ∘ associator.from     ≈⟨ (refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityˡ , refl))) ⟩∘⟨refl ⟩ 
-      (ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))) ∘ associator.from           ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      (ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))) * ∘ (η ∘ associator.from)   ∎
-    ; assoc-commute-to = λ {X} {Y} {f} {A} {B} {g} {U} {V} {h} → begin 
-      (η ∘ associator.to) * ∘ ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))     ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
-      M.F.₁ associator.to ∘ ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityˡ , refl)) ⟩ 
-      M.F.₁ associator.to ∘ ψ ∘ (id ⊗₁ ψ) ∘ (f ⊗₁ (g ⊗₁ h)) ≈⟨ (sym-assoc ○ (pullˡ (assoc ○ ψ-assoc-to) ○ assoc²βε)) ⟩ 
-      ψ ∘ (ψ ⊗₁ id) ∘ associator.to ∘ (f ⊗₁ (g ⊗₁ h))       ≈˘⟨ pullʳ (pullʳ (sym assoc-commute-to)) ⟩
-      (ψ ∘ (ψ ⊗₁ id) ∘ ((f ⊗₁ g) ⊗₁ h)) ∘ associator.to     ≈⟨ (refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityˡ))) ⟩∘⟨refl ⟩ 
-      (ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)) ∘ associator.to           ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      (ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)) * ∘ (η ∘ associator.to)   ∎
+    ; assoc-commute-from = assoc-commute-from'
+    ; assoc-commute-to = assoc-commute-to'
     ; triangle = triangle'
     ; pentagon = pentagon'
     }
@@ -100,68 +89,84 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
         ψ * ∘ ψ ∘ (M.F.₁ h ⊗₁ M.F.₁ i) ∘ (f ⊗₁ g)              ≈⟨ refl⟩∘⟨ extendʳ ψ-comm ⟩ 
         ψ * ∘ M.F.₁ (h ⊗₁ i) ∘ ψ ∘ (f ⊗₁ g)                    ≈⟨ pullˡ *∘F₁ ⟩ 
         (ψ ∘ (h ⊗₁ i)) * ∘ ψ ∘ (f ⊗₁ g)                        ∎
-    unitorˡ-commute-from' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ unitorˡ.from) * ∘ ψ ∘ (η ⊗₁ f) ≈ f * ∘ η ∘ unitorˡ.from
+    unitorˡ-commute-from' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ λ⇒) * ∘ ψ ∘ (η ⊗₁ f) ≈ f * ∘ η ∘ λ⇒
     unitorˡ-commute-from' {f = f} = begin 
-      (η ∘ unitorˡ.from) * ∘ ψ ∘ (η ⊗₁ f)                   ≈⟨ *⇒F₁ ⟩∘⟨ ψ-σ' ⟩ 
-      M.F.₁ unitorˡ.from ∘ σ ∘ (id ⊗₁ f)                    ≈⟨ pullˡ (Strength.identityˡ strength) ⟩ 
-      unitorˡ.from ∘ (id ⊗₁ f)                              ≈⟨ unitorˡ-commute-from ⟩ 
-      f ∘ unitorˡ.from                                      ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      f * ∘ η ∘ unitorˡ.from                                ∎
-    unitorˡ-commute-to' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ unitorˡ.to) * ∘ f ≈ (ψ ∘ (η ⊗₁ f)) * ∘ η ∘ unitorˡ.to
+      (η ∘ λ⇒) * ∘ ψ ∘ (η ⊗₁ f) ≈⟨ *⇒F₁ ⟩∘⟨ ψ-σ' ⟩ 
+      M.F.₁ λ⇒ ∘ σ ∘ (id ⊗₁ f)  ≈⟨ pullˡ (Strength.identityˡ strength) ⟩ 
+      λ⇒ ∘ (id ⊗₁ f)            ≈⟨ unitorˡ-commute-from ⟩ 
+      f ∘ λ⇒                    ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      f * ∘ η ∘ λ⇒              ∎
+    unitorˡ-commute-to' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ λ⇐) * ∘ f ≈ (ψ ∘ (η ⊗₁ f)) * ∘ η ∘ λ⇐
     unitorˡ-commute-to' {f = f} = begin 
-      (η ∘ unitorˡ.to) * ∘ f                                       ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
-      M.F.₁ unitorˡ.to ∘ f                                         ≈˘⟨ refl⟩∘⟨ (cancelˡ unitorˡ.isoʳ) ⟩ 
-      M.F.₁ unitorˡ.to ∘ unitorˡ.from ∘ unitorˡ.to ∘ f             ≈˘⟨ pullʳ (pullˡ (Strength.identityˡ strength)) ⟩
-      (M.F.₁ unitorˡ.to ∘ M.F.₁ unitorˡ.from) ∘ σ ∘ unitorˡ.to ∘ f ≈⟨ elimˡ (sym M.F.homomorphism ○ (M.F.F-resp-≈ unitorˡ.isoˡ ○ M.F.identity)) ⟩
-      σ ∘ unitorˡ.to ∘ f                                           ≈˘⟨ pullʳ (sym unitorˡ-commute-to) ⟩ 
-      (σ ∘ (id ⊗₁ f)) ∘ unitorˡ.to                                 ≈˘⟨ ψ-σ' ⟩∘⟨refl ⟩ 
-      (ψ ∘ (η ⊗₁ f)) ∘ unitorˡ.to                                  ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      (ψ ∘ (η ⊗₁ f)) * ∘ η ∘ unitorˡ.to                            ∎
-    unitorʳ-commute-from' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ unitorʳ.from) * ∘ ψ ∘ (f ⊗₁ η) ≈ f * ∘ η ∘ unitorʳ.from
+      (η ∘ λ⇐) * ∘ f                     ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ λ⇐ ∘ f                       ≈˘⟨ refl⟩∘⟨ (cancelˡ unitorˡ.isoʳ) ⟩ 
+      M.F.₁ λ⇐ ∘ λ⇒ ∘ λ⇐ ∘ f             ≈˘⟨ pullʳ (pullˡ (Strength.identityˡ strength)) ⟩
+      (M.F.₁ λ⇐ ∘ M.F.₁ λ⇒) ∘ σ ∘ λ⇐ ∘ f ≈⟨ elimˡ (sym M.F.homomorphism ○ (M.F.F-resp-≈ unitorˡ.isoˡ ○ M.F.identity)) ⟩
+      σ ∘ λ⇐ ∘ f                         ≈˘⟨ pullʳ (sym unitorˡ-commute-to) ⟩ 
+      (σ ∘ (id ⊗₁ f)) ∘ λ⇐               ≈˘⟨ ψ-σ' ⟩∘⟨refl ⟩ 
+      (ψ ∘ (η ⊗₁ f)) ∘ λ⇐                ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (η ⊗₁ f)) * ∘ η ∘ λ⇐          ∎
+    unitorʳ-commute-from' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ ρ⇒) * ∘ ψ ∘ (f ⊗₁ η) ≈ f * ∘ η ∘ ρ⇒
     unitorʳ-commute-from' {f = f} = begin 
-      (η ∘ unitorʳ.from) * ∘ ψ ∘ (f ⊗₁ η) ≈⟨ *⇒F₁ ⟩∘⟨ ψ-τ' ⟩ 
-      M.F.₁ unitorʳ.from ∘ τ ∘ (f ⊗₁ id)  ≈⟨ pullˡ (RightStrength.identityˡ rightStrength) ⟩ 
-      unitorʳ.from ∘ (f ⊗₁ id)            ≈⟨ unitorʳ-commute-from ⟩ 
-      f ∘ unitorʳ.from                    ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      f * ∘ η ∘ unitorʳ.from              ∎
-    unitorʳ-commute-to' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ unitorʳ.to) * ∘ f ≈ (ψ ∘ (f ⊗₁ η)) * ∘ η ∘ unitorʳ.to
+      (η ∘ ρ⇒) * ∘ ψ ∘ (f ⊗₁ η) ≈⟨ *⇒F₁ ⟩∘⟨ ψ-τ' ⟩ 
+      M.F.₁ ρ⇒ ∘ τ ∘ (f ⊗₁ id)  ≈⟨ pullˡ (RightStrength.identityˡ rightStrength) ⟩ 
+      ρ⇒ ∘ (f ⊗₁ id)            ≈⟨ unitorʳ-commute-from ⟩ 
+      f ∘ ρ⇒                    ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      f * ∘ η ∘ ρ⇒              ∎
+    unitorʳ-commute-to' : ∀ {X} {Y} {f : X ⇒ M.F.₀ Y} → (η ∘ ρ⇐) * ∘ f ≈ (ψ ∘ (f ⊗₁ η)) * ∘ η ∘ ρ⇐
     unitorʳ-commute-to' {f = f} = begin 
-      (η ∘ unitorʳ.to) * ∘ f                                       ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
-      M.F.₁ unitorʳ.to ∘ f                                         ≈˘⟨ refl⟩∘⟨ (cancelˡ unitorʳ.isoʳ) ⟩ 
-      M.F.₁ unitorʳ.to ∘ unitorʳ.from ∘ unitorʳ.to ∘ f             ≈˘⟨ pullʳ (pullˡ (RightStrength.identityˡ rightStrength)) ⟩
-      (M.F.₁ unitorʳ.to ∘ M.F.₁ unitorʳ.from) ∘ τ ∘ unitorʳ.to ∘ f ≈⟨ elimˡ (sym M.F.homomorphism ○ (M.F.F-resp-≈ unitorʳ.isoˡ ○ M.F.identity)) ⟩
-      τ ∘ unitorʳ.to ∘ f                                           ≈˘⟨ pullʳ (sym unitorʳ-commute-to) ⟩ 
-      (τ ∘ (f ⊗₁ id)) ∘ unitorʳ.to                                 ≈˘⟨ ψ-τ' ⟩∘⟨refl ⟩ 
-      (ψ ∘ (f ⊗₁ η)) ∘ unitorʳ.to                                  ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      (ψ ∘ (f ⊗₁ η)) * ∘ η ∘ unitorʳ.to                            ∎
-    triangle' : ∀ {X} {Y} → (ψ ∘ (η {X} ⊗₁ (η ∘ unitorˡ.from))) * ∘ (η ∘ associator.from) ≈ ψ ∘ ((η ∘ unitorʳ.from) ⊗₁ η {Y})
+      (η ∘ ρ⇐) * ∘ f                     ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ ρ⇐ ∘ f                       ≈˘⟨ refl⟩∘⟨ (cancelˡ unitorʳ.isoʳ) ⟩ 
+      M.F.₁ ρ⇐ ∘ ρ⇒ ∘ ρ⇐ ∘ f             ≈˘⟨ pullʳ (pullˡ (RightStrength.identityˡ rightStrength)) ⟩
+      (M.F.₁ ρ⇐ ∘ M.F.₁ ρ⇒) ∘ τ ∘ ρ⇐ ∘ f ≈⟨ elimˡ (sym M.F.homomorphism ○ (M.F.F-resp-≈ unitorʳ.isoˡ ○ M.F.identity)) ⟩
+      τ ∘ ρ⇐ ∘ f                         ≈˘⟨ pullʳ (sym unitorʳ-commute-to) ⟩ 
+      (τ ∘ (f ⊗₁ id)) ∘ ρ⇐               ≈˘⟨ ψ-τ' ⟩∘⟨refl ⟩ 
+      (ψ ∘ (f ⊗₁ η)) ∘ ρ⇐                ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (f ⊗₁ η)) * ∘ η ∘ ρ⇐          ∎
+    assoc-commute-from' : ∀ {X Y} {f : X ⇒ M.F.₀ Y} {A B} {g : A ⇒ M.F.₀ B} {U V} {h : U ⇒ M.F.₀ V} → (η ∘ α⇒) * ∘ ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h) ≈ (ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))) * ∘ (η ∘ α⇒)
+    assoc-commute-from' {f = f} {g = g} {h = h} = begin  
+      (η ∘ α⇒) * ∘ ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)     ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ α⇒ ∘ ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityˡ)) ⟩ 
+      M.F.₁ α⇒ ∘ ψ ∘ (ψ ⊗₁ id) ∘ ((f ⊗₁ g) ⊗₁ h) ≈⟨ (sym-assoc ○ pullˡ (assoc ○ ψ-assoc-from) ○ assoc²βε) ⟩ 
+      ψ ∘ (id ⊗₁ ψ) ∘ α⇒ ∘ ((f ⊗₁ g) ⊗₁ h)       ≈˘⟨ pullʳ (pullʳ (sym assoc-commute-from)) ⟩ 
+      (ψ ∘ (id ⊗₁ ψ) ∘ (f ⊗₁ (g ⊗₁ h))) ∘ α⇒     ≈⟨ (refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityˡ , refl))) ⟩∘⟨refl ⟩ 
+      (ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))) ∘ α⇒           ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))) * ∘ (η ∘ α⇒)   ∎
+    assoc-commute-to' : ∀ {X Y} {f : X ⇒ M.F.₀ Y} {A B} {g : A ⇒ M.F.₀ B} {U V} {h : U ⇒ M.F.₀ V} → (η ∘ α⇐) * ∘ ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h))) ≈ (ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)) * ∘ (η ∘ α⇐)
+    assoc-commute-to' {f = f} {g = g} {h = h} = begin 
+      (η ∘ α⇐) * ∘ ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))     ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ α⇐ ∘ ψ ∘ (f ⊗₁ (ψ ∘ (g ⊗₁ h)))       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityˡ , refl)) ⟩ 
+      M.F.₁ α⇐ ∘ ψ ∘ (id ⊗₁ ψ) ∘ (f ⊗₁ (g ⊗₁ h)) ≈⟨ (sym-assoc ○ (pullˡ (assoc ○ ψ-assoc-to) ○ assoc²βε)) ⟩ 
+      ψ ∘ (ψ ⊗₁ id) ∘ α⇐ ∘ (f ⊗₁ (g ⊗₁ h))       ≈˘⟨ pullʳ (pullʳ (sym assoc-commute-to)) ⟩
+      (ψ ∘ (ψ ⊗₁ id) ∘ ((f ⊗₁ g) ⊗₁ h)) ∘ α⇐     ≈⟨ (refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityˡ))) ⟩∘⟨refl ⟩ 
+      (ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)) ∘ α⇐           ≈˘⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ ((ψ ∘ (f ⊗₁ g)) ⊗₁ h)) * ∘ (η ∘ α⇐)   ∎
+    triangle' : ∀ {X} {Y} → (ψ ∘ (η {X} ⊗₁ (η ∘ λ⇒))) * ∘ (η ∘ α⇒) ≈ ψ ∘ ((η ∘ ρ⇒) ⊗₁ η {Y})
     triangle' = begin 
-      (ψ ∘ (η ⊗₁ (η ∘ unitorˡ.from))) * ∘ (η ∘ associator.from) ≈⟨ pullˡ *-identityʳ ⟩ 
-      (ψ ∘ (η ⊗₁ (η ∘ unitorˡ.from))) ∘ associator.from         ≈˘⟨ pullˡ (pullʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl))) ⟩ 
-      (ψ ∘ (η ⊗₁ η)) ∘ (id ⊗₁ unitorˡ.from) ∘ associator.from   ≈⟨ (refl⟩∘⟨ triangle) ⟩ 
-      (ψ ∘ (η ⊗₁ η)) ∘ (unitorʳ.from ⊗₁ id)                     ≈⟨ pullʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)) ⟩  
-      ψ ∘ ((η ∘ unitorʳ.from) ⊗₁ η)                             ∎
-    pentagon' : ∀ {A B C D : Obj} → (ψ {A} {B ⊗₀ (C ⊗₀ D)} ∘ (η ⊗₁ (η ∘ associator.from))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ associator.from) ⊗₁ η)) ≈ (η ∘ associator.from) * ∘ (η ∘ associator.from)
+      (ψ ∘ (η ⊗₁ (η ∘ λ⇒))) * ∘ (η ∘ α⇒) ≈⟨ pullˡ *-identityʳ ⟩ 
+      (ψ ∘ (η ⊗₁ (η ∘ λ⇒))) ∘ α⇒         ≈˘⟨ pullˡ (pullʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl))) ⟩ 
+      (ψ ∘ (η ⊗₁ η)) ∘ (id ⊗₁ λ⇒) ∘ α⇒   ≈⟨ (refl⟩∘⟨ triangle) ⟩ 
+      (ψ ∘ (η ⊗₁ η)) ∘ (ρ⇒ ⊗₁ id)        ≈⟨ pullʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)) ⟩  
+      ψ ∘ ((η ∘ ρ⇒) ⊗₁ η)                ∎
+    pentagon' : ∀ {A B C D : Obj} → (ψ {A} {B ⊗₀ (C ⊗₀ D)} ∘ (η ⊗₁ (η ∘ α⇒))) * ∘ (η ∘ α⇒) * ∘ (ψ ∘ ((η ∘ α⇒) ⊗₁ η)) ≈ (η ∘ α⇒) * ∘ (η ∘ α⇒)
     pentagon' = begin 
-      (ψ ∘ (η ⊗₁ (η ∘ associator.from))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ associator.from) ⊗₁ η)) 
+      (ψ ∘ (η ⊗₁ (η ∘ α⇒))) * ∘ (η ∘ α⇒) * ∘ (ψ ∘ ((η ∘ α⇒) ⊗₁ η)) 
         ≈⟨ refl⟩∘⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
-      (ψ ∘ (η ⊗₁ (η ∘ associator.from))) * ∘ M.F.₁ associator.from ∘ (ψ ∘ ((η ∘ associator.from) ⊗₁ η))   
+      (ψ ∘ (η ⊗₁ (η ∘ α⇒))) * ∘ M.F.₁ α⇒ ∘ (ψ ∘ ((η ∘ α⇒) ⊗₁ η))   
         ≈⟨ pullˡ (*∘F₁ ○ *-resp-≈ assoc) ⟩ 
-      (ψ ∘ (η ⊗₁ (η ∘ associator.from)) ∘ associator.from) * ∘ (ψ ∘ ((η ∘ associator.from) ⊗₁ η))         
+      (ψ ∘ (η ⊗₁ (η ∘ α⇒)) ∘ α⇒) * ∘ (ψ ∘ ((η ∘ α⇒) ⊗₁ η))         
         ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)) ⟩ 
-      (ψ ∘ (η ⊗₁ (η ∘ associator.from)) ∘ associator.from) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (associator.from ⊗₁ id))  
+      (ψ ∘ (η ⊗₁ (η ∘ α⇒)) ∘ α⇒) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (α⇒ ⊗₁ id))  
         ≈⟨ refl⟩∘⟨ pullˡ ψ-η ⟩ 
-      (ψ ∘ (η ⊗₁ (η ∘ associator.from)) ∘ associator.from) * ∘ (η ∘ (associator.from ⊗₁ id))            
+      (ψ ∘ (η ⊗₁ (η ∘ α⇒)) ∘ α⇒) * ∘ (η ∘ (α⇒ ⊗₁ id))            
         ≈⟨ pullˡ *-identityʳ ⟩ 
-      (ψ ∘ (η ⊗₁ (η ∘ associator.from)) ∘ associator.from) ∘ (associator.from ⊗₁ id)                    
+      (ψ ∘ (η ⊗₁ (η ∘ α⇒)) ∘ α⇒) ∘ (α⇒ ⊗₁ id)                    
         ≈˘⟨ sym-assoc ○ (∘-resp-≈ʳ sym-assoc ○ pullˡ (pullʳ (pullˡ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl))))) ⟩ 
-      ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ associator.from) ∘ associator.from ∘ (associator.from ⊗₁ id)                 
+      ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ α⇒) ∘ α⇒ ∘ (α⇒ ⊗₁ id)                 
         ≈⟨ (refl⟩∘⟨ refl⟩∘⟨ pentagon) ⟩ 
-      ψ ∘ (η ⊗₁ η) ∘ (associator.from ∘ associator.from)                                               
+      ψ ∘ (η ⊗₁ η) ∘ (α⇒ ∘ α⇒)                                               
         ≈⟨ (pullˡ ψ-η) ○ sym-assoc ⟩ 
-      (η ∘ associator.from) ∘ associator.from                                                         
+      (η ∘ α⇒) ∘ α⇒                                                         
         ≈˘⟨ pullˡ *-identityʳ ⟩ 
-      (η ∘ associator.from) * ∘ (η ∘ associator.from)                                                 
+      (η ∘ α⇒) * ∘ (η ∘ α⇒)                                                 
         ∎
-    
-

--- a/src/Categories/Category/Construction/Kleisli/Symmetric.agda
+++ b/src/Categories/Category/Construction/Kleisli/Symmetric.agda
@@ -1,0 +1,117 @@
+{-# OPTIONS --without-K --safe #-}
+module Categories.Category.Construction.Kleisli.Symmetric where
+
+open import Level
+open import Data.Product using (_,_)
+
+open import Categories.Category.Core using (Category)
+open import Categories.Monad using (Monad)
+open import Categories.Monad.Commutative using (CommutativeMonad)
+open import Categories.Monad.Commutative.Properties using (module CommutativeProperties)
+open import Categories.Category.Monoidal using (Monoidal)
+open import Categories.Category.Monoidal.Symmetric using (Symmetric)
+open import Categories.Category.Construction.Kleisli
+open import Categories.Category.Construction.Kleisli.Monoidal using (Kleisli-Monoidal)
+
+import Categories.Morphism.Reasoning as MR
+import Categories.Monad.Strong.Properties as StrongProps
+import Categories.Category.Monoidal.Symmetric.Properties as SymmProps
+
+private
+  variable
+    o ℓ e : Level
+
+-- The Kleisli category of a commutative monad (where 𝒞 is symmetric) is symmetric.
+
+module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symmetric monoidal) (CM : CommutativeMonad (Symmetric.braided symmetric)) where
+  open Category 𝒞
+  open MR 𝒞
+  open HomReasoning
+  open Equiv
+
+  open CommutativeMonad CM hiding (identityˡ)
+  open Monad M using (μ)
+  open TripleNotation M
+
+  open StrongProps.Left strength using (left-right-braiding-comm; right-left-braiding-comm)
+  open StrongProps.Left.Shorthands strength
+  open StrongProps.Right.Shorthands rightStrength
+
+  open Symmetric symmetric renaming (commutative to B-commutative)
+  open SymmProps symmetric
+  open CommutativeProperties braided CM
+
+  private
+    B : ∀ {X Y} → X ⊗₀ Y ⇒ Y ⊗₀ X
+    B {X} {Y} = braiding.⇒.η (X , Y)
+
+  Kleisli-Symmetric : Symmetric (Kleisli-Monoidal symmetric CM)
+  Kleisli-Symmetric = record 
+    { braided = record 
+      { braiding = record 
+        { F⇒G = record { η = λ _ → η ∘ B ; commute = λ (f , g) → swapping f g ; sym-commute = λ (f , g) → sym (swapping f g) }
+        ; F⇐G = record { η = λ _ → η ∘ B ; commute = λ (f , g) → swapping g f ; sym-commute = λ (f , g) → sym (swapping g f) }
+        ; iso = λ _ → record { isoˡ = pullˡ *-identityʳ ○ cancelʳ B-commutative ; isoʳ = pullˡ *-identityʳ ○ cancelʳ B-commutative } 
+        } 
+      ; hexagon₁ = λ {X} {Y} {Z} → begin 
+        (ψ ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))       
+          ≈⟨ pullˡ *-sym-assoc ⟩ 
+        ((ψ ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ associator.from)) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))     
+          ≈⟨ ((*-resp-≈ (pullˡ *-identityʳ)) ⟩∘⟨refl) ⟩ 
+        ((ψ ∘ (η ⊗₁ (η ∘ B))) ∘ associator.from) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))             
+          ≈˘⟨ *-resp-≈ (∘-resp-≈ˡ (∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl)))) ⟩∘⟨ ∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)) ⟩ 
+        ((ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ B)) ∘ associator.from) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (B ⊗₁ id)) 
+          ≈⟨ *-resp-≈ (∘-resp-≈ˡ (pullˡ ψ-η)) ⟩∘⟨ pullˡ ψ-η ⟩ 
+        ((η ∘ (id ⊗₁ B)) ∘ associator.from) * ∘ (η ∘ (B ⊗₁ id))                       
+          ≈⟨ pullˡ *-identityʳ ⟩ 
+        ((η ∘ (id ⊗₁ B)) ∘ associator.from) ∘ (B ⊗₁ id)                               
+          ≈⟨ (assoc ○ pullʳ hexagon₁ ○ (sym-assoc ○ sym-assoc)) ⟩ 
+        ((η ∘ associator.from) ∘ B) ∘ associator.from                                 
+          ≈˘⟨ pullˡ (pullˡ *-identityʳ) ⟩ 
+        (η ∘ associator.from) * ∘ (η ∘ B) ∘ associator.from                           
+          ≈˘⟨ refl⟩∘⟨ (pullˡ *-identityʳ) ⟩ 
+        (η ∘ associator.from) * ∘ (η ∘ B) * ∘ (η ∘ associator.from)                   
+          ∎ 
+      ; hexagon₂ = λ {X} {Y} {Z} → begin 
+        ((ψ ∘ ((η ∘ B) ⊗₁ η)) * ∘ (η ∘ associator.to)) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B)))     
+          ≈⟨ ((*-resp-≈ (pullˡ *-identityʳ)) ⟩∘⟨refl) ⟩ 
+        ((ψ ∘ ((η ∘ B) ⊗₁ η)) ∘ associator.to) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B)))             
+          ≈˘⟨ *-resp-≈ (∘-resp-≈ˡ (∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)))) ⟩∘⟨ ∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl)) ⟩ 
+        ((ψ ∘ (η ⊗₁ η) ∘ (B ⊗₁ id)) ∘ associator.to) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ B)) 
+          ≈⟨ *-resp-≈ (∘-resp-≈ˡ (pullˡ ψ-η)) ⟩∘⟨ pullˡ ψ-η ⟩ 
+        ((η ∘ (B ⊗₁ id)) ∘ associator.to) * ∘ (η ∘ (id ⊗₁ B))                       
+          ≈⟨ pullˡ *-identityʳ ⟩ 
+        ((η ∘ (B ⊗₁ id)) ∘ associator.to) ∘ (id ⊗₁ B)                               
+          ≈⟨ (assoc ○ pullʳ (sym-assoc ○ hexagon₂) ○ (sym-assoc ○ ∘-resp-≈ˡ sym-assoc)) ⟩
+        ((η ∘ associator.to) ∘ B) ∘ associator.to                                   
+          ≈˘⟨ pullˡ (pullˡ *-identityʳ) ⟩ 
+        (η ∘ associator.to) * ∘ (η ∘ B) ∘ associator.to                             
+          ≈˘⟨ refl⟩∘⟨ (pullˡ *-identityʳ) ⟩ 
+        (η ∘ associator.to) * ∘ (η ∘ B) * ∘ (η ∘ associator.to)                     
+          ≈˘⟨ *-assoc ⟩∘⟨refl ○ assoc ⟩ 
+        ((η ∘ associator.to) * ∘ (η ∘ B)) * ∘ (η ∘ associator.to)                   
+          ∎ 
+      } 
+    ; commutative = λ {X} {Y} → pullˡ *-identityʳ ○ cancelʳ B-commutative 
+    }
+    where
+    swapping : ∀ {X Y U V} (f : X ⇒ M.F.₀ Y) (g : U ⇒ M.F.₀ V) → (η ∘ B) * ∘ ψ ∘ (f ⊗₁ g) ≈ (ψ ∘ (g ⊗₁ f)) * ∘ η ∘ B
+    swapping f g = begin 
+      (η ∘ B) * ∘ ψ ∘ (f ⊗₁ g)       
+        ≈⟨ *⇒F₁ ⟩∘⟨refl ⟩ 
+      M.F.₁ B ∘ ψ ∘ (f ⊗₁ g)         
+        ≈⟨ refl⟩∘⟨ commutes ⟩∘⟨refl ⟩ 
+      M.F.₁ B ∘ (σ * ∘ τ) ∘ (f ⊗₁ g) 
+        ≈⟨ extendʳ (pullˡ F₁∘*) ⟩
+      (M.F.₁ B ∘ σ) * ∘ τ ∘ (f ⊗₁ g) 
+        ≈⟨ *-resp-≈ (∘-resp-≈ˡ (M.F.F-resp-≈ (sym braiding-selfInverse)) ○ left-right-braiding-comm braided ○ ∘-resp-≈ʳ braiding-selfInverse) ⟩∘⟨refl ⟩
+      (τ ∘ B) * ∘ τ ∘ (f ⊗₁ g)       
+        ≈˘⟨ pullˡ (pullˡ *∘F₁) ○ assoc ⟩
+      τ * ∘ (M.F.₁ B ∘ τ) ∘ (f ⊗₁ g) 
+        ≈˘⟨ extendʳ (pullʳ (sym (right-left-braiding-comm braided))) ⟩
+      ψ ∘ B ∘ (f ⊗₁ g)               
+        ≈⟨ refl⟩∘⟨ braiding.⇒.commute _ ⟩ 
+      ψ ∘ (g ⊗₁ f) ∘ B               
+        ≈˘⟨ extendʳ *-identityʳ ⟩ 
+      (ψ ∘ (g ⊗₁ f)) * ∘ η ∘ B       
+        ∎

--- a/src/Categories/Category/Construction/Kleisli/Symmetric.agda
+++ b/src/Categories/Category/Construction/Kleisli/Symmetric.agda
@@ -10,12 +10,13 @@ open import Categories.Monad.Commutative using (CommutativeMonad)
 open import Categories.Monad.Commutative.Properties using (module CommutativeProperties)
 open import Categories.Category.Monoidal using (Monoidal)
 open import Categories.Category.Monoidal.Symmetric using (Symmetric)
-open import Categories.Category.Construction.Kleisli
+open import Categories.Category.Construction.Kleisli using (module TripleNotation)
 open import Categories.Category.Construction.Kleisli.Monoidal using (Kleisli-Monoidal)
 
 import Categories.Morphism.Reasoning as MR
 import Categories.Monad.Strong.Properties as StrongProps
 import Categories.Category.Monoidal.Symmetric.Properties as SymmProps
+import Categories.Category.Monoidal.Utilities as MonoidalUtils
 
 private
   variable
@@ -36,6 +37,8 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
   open StrongProps.Left strength using (left-right-braiding-comm; right-left-braiding-comm)
   open StrongProps.Left.Shorthands strength
   open StrongProps.Right.Shorthands rightStrength
+  open MonoidalUtils.Shorthands monoidal using (α⇒; α⇐)
+
 
   open Symmetric symmetric renaming (commutative to B-commutative)
   open SymmProps symmetric
@@ -79,43 +82,43 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
         ≈˘⟨ extendʳ *-identityʳ ⟩ 
       (ψ ∘ (g ⊗₁ f)) * ∘ η ∘ B       
         ∎
-    hexagon₁' : ∀ {X Y Z : Obj} → (ψ {X} {Y ⊗₀ Z} ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η)) ≈ (η ∘ associator.from) * ∘ (η ∘ B) * ∘ (η ∘ associator.from)
+    hexagon₁' : ∀ {X Y Z : Obj} → (ψ {X} {Y ⊗₀ Z} ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ α⇒) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η)) ≈ (η ∘ α⇒) * ∘ (η ∘ B) * ∘ (η ∘ α⇒)
     hexagon₁' = begin 
-      (ψ ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))       
+      (ψ ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ α⇒) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))       
         ≈⟨ pullˡ *-sym-assoc ⟩ 
-      ((ψ ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ associator.from)) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))     
+      ((ψ ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ α⇒)) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))     
         ≈⟨ ((*-resp-≈ (pullˡ *-identityʳ)) ⟩∘⟨refl) ⟩ 
-      ((ψ ∘ (η ⊗₁ (η ∘ B))) ∘ associator.from) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))             
+      ((ψ ∘ (η ⊗₁ (η ∘ B))) ∘ α⇒) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))             
         ≈˘⟨ *-resp-≈ (∘-resp-≈ˡ (∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl)))) ⟩∘⟨ ∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)) ⟩ 
-      ((ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ B)) ∘ associator.from) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (B ⊗₁ id)) 
+      ((ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ B)) ∘ α⇒) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (B ⊗₁ id)) 
         ≈⟨ *-resp-≈ (∘-resp-≈ˡ (pullˡ ψ-η)) ⟩∘⟨ pullˡ ψ-η ⟩ 
-      ((η ∘ (id ⊗₁ B)) ∘ associator.from) * ∘ (η ∘ (B ⊗₁ id))                       
+      ((η ∘ (id ⊗₁ B)) ∘ α⇒) * ∘ (η ∘ (B ⊗₁ id))                       
         ≈⟨ pullˡ *-identityʳ ⟩ 
-      ((η ∘ (id ⊗₁ B)) ∘ associator.from) ∘ (B ⊗₁ id)                               
+      ((η ∘ (id ⊗₁ B)) ∘ α⇒) ∘ (B ⊗₁ id)                               
         ≈⟨ (assoc ○ pullʳ hexagon₁ ○ (sym-assoc ○ sym-assoc)) ⟩ 
-      ((η ∘ associator.from) ∘ B) ∘ associator.from                                 
+      ((η ∘ α⇒) ∘ B) ∘ α⇒                                 
         ≈˘⟨ pullˡ (pullˡ *-identityʳ) ⟩ 
-      (η ∘ associator.from) * ∘ (η ∘ B) ∘ associator.from                           
+      (η ∘ α⇒) * ∘ (η ∘ B) ∘ α⇒                           
         ≈˘⟨ refl⟩∘⟨ (pullˡ *-identityʳ) ⟩ 
-      (η ∘ associator.from) * ∘ (η ∘ B) * ∘ (η ∘ associator.from)                   
+      (η ∘ α⇒) * ∘ (η ∘ B) * ∘ (η ∘ α⇒)                   
         ∎
-    hexagon₂' : ∀ {X Y Z : Obj} → ((ψ {X ⊗₀ Y} {Z} ∘ ((η ∘ B) ⊗₁ η)) * ∘ (η ∘ associator.to)) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B))) ≈ ((η ∘ associator.to) * ∘ (η ∘ B)) * ∘ (η ∘ associator.to)
+    hexagon₂' : ∀ {X Y Z : Obj} → ((ψ {X ⊗₀ Y} {Z} ∘ ((η ∘ B) ⊗₁ η)) * ∘ (η ∘ α⇐)) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B))) ≈ ((η ∘ α⇐) * ∘ (η ∘ B)) * ∘ (η ∘ α⇐)
     hexagon₂' = begin 
-      ((ψ ∘ ((η ∘ B) ⊗₁ η)) * ∘ (η ∘ associator.to)) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B)))     
+      ((ψ ∘ ((η ∘ B) ⊗₁ η)) * ∘ (η ∘ α⇐)) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B)))     
         ≈⟨ ((*-resp-≈ (pullˡ *-identityʳ)) ⟩∘⟨refl) ⟩ 
-      ((ψ ∘ ((η ∘ B) ⊗₁ η)) ∘ associator.to) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B)))             
+      ((ψ ∘ ((η ∘ B) ⊗₁ η)) ∘ α⇐) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B)))             
         ≈˘⟨ *-resp-≈ (∘-resp-≈ˡ (∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)))) ⟩∘⟨ ∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl)) ⟩ 
-      ((ψ ∘ (η ⊗₁ η) ∘ (B ⊗₁ id)) ∘ associator.to) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ B)) 
+      ((ψ ∘ (η ⊗₁ η) ∘ (B ⊗₁ id)) ∘ α⇐) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ B)) 
         ≈⟨ *-resp-≈ (∘-resp-≈ˡ (pullˡ ψ-η)) ⟩∘⟨ pullˡ ψ-η ⟩ 
-      ((η ∘ (B ⊗₁ id)) ∘ associator.to) * ∘ (η ∘ (id ⊗₁ B))                       
+      ((η ∘ (B ⊗₁ id)) ∘ α⇐) * ∘ (η ∘ (id ⊗₁ B))                       
         ≈⟨ pullˡ *-identityʳ ⟩ 
-      ((η ∘ (B ⊗₁ id)) ∘ associator.to) ∘ (id ⊗₁ B)                               
+      ((η ∘ (B ⊗₁ id)) ∘ α⇐) ∘ (id ⊗₁ B)                               
         ≈⟨ (assoc ○ pullʳ (sym-assoc ○ hexagon₂) ○ (sym-assoc ○ ∘-resp-≈ˡ sym-assoc)) ⟩
-      ((η ∘ associator.to) ∘ B) ∘ associator.to                                   
+      ((η ∘ α⇐) ∘ B) ∘ α⇐                                   
         ≈˘⟨ pullˡ (pullˡ *-identityʳ) ⟩ 
-      (η ∘ associator.to) * ∘ (η ∘ B) ∘ associator.to                             
+      (η ∘ α⇐) * ∘ (η ∘ B) ∘ α⇐                             
         ≈˘⟨ refl⟩∘⟨ (pullˡ *-identityʳ) ⟩ 
-      (η ∘ associator.to) * ∘ (η ∘ B) * ∘ (η ∘ associator.to)                     
+      (η ∘ α⇐) * ∘ (η ∘ B) * ∘ (η ∘ α⇐)                     
         ≈˘⟨ *-assoc ⟩∘⟨refl ○ assoc ⟩ 
-      ((η ∘ associator.to) * ∘ (η ∘ B)) * ∘ (η ∘ associator.to)                   
+      ((η ∘ α⇐) * ∘ (η ∘ B)) * ∘ (η ∘ α⇐)                   
         ∎ 

--- a/src/Categories/Category/Construction/Kleisli/Symmetric.agda
+++ b/src/Categories/Category/Construction/Kleisli/Symmetric.agda
@@ -53,44 +53,8 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
         ; F⇐G = record { η = λ _ → η ∘ B ; commute = λ (f , g) → swapping g f ; sym-commute = λ (f , g) → sym (swapping g f) }
         ; iso = λ _ → record { isoˡ = pullˡ *-identityʳ ○ cancelʳ B-commutative ; isoʳ = pullˡ *-identityʳ ○ cancelʳ B-commutative } 
         } 
-      ; hexagon₁ = λ {X} {Y} {Z} → begin 
-        (ψ ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))       
-          ≈⟨ pullˡ *-sym-assoc ⟩ 
-        ((ψ ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ associator.from)) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))     
-          ≈⟨ ((*-resp-≈ (pullˡ *-identityʳ)) ⟩∘⟨refl) ⟩ 
-        ((ψ ∘ (η ⊗₁ (η ∘ B))) ∘ associator.from) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))             
-          ≈˘⟨ *-resp-≈ (∘-resp-≈ˡ (∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl)))) ⟩∘⟨ ∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)) ⟩ 
-        ((ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ B)) ∘ associator.from) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (B ⊗₁ id)) 
-          ≈⟨ *-resp-≈ (∘-resp-≈ˡ (pullˡ ψ-η)) ⟩∘⟨ pullˡ ψ-η ⟩ 
-        ((η ∘ (id ⊗₁ B)) ∘ associator.from) * ∘ (η ∘ (B ⊗₁ id))                       
-          ≈⟨ pullˡ *-identityʳ ⟩ 
-        ((η ∘ (id ⊗₁ B)) ∘ associator.from) ∘ (B ⊗₁ id)                               
-          ≈⟨ (assoc ○ pullʳ hexagon₁ ○ (sym-assoc ○ sym-assoc)) ⟩ 
-        ((η ∘ associator.from) ∘ B) ∘ associator.from                                 
-          ≈˘⟨ pullˡ (pullˡ *-identityʳ) ⟩ 
-        (η ∘ associator.from) * ∘ (η ∘ B) ∘ associator.from                           
-          ≈˘⟨ refl⟩∘⟨ (pullˡ *-identityʳ) ⟩ 
-        (η ∘ associator.from) * ∘ (η ∘ B) * ∘ (η ∘ associator.from)                   
-          ∎ 
-      ; hexagon₂ = λ {X} {Y} {Z} → begin 
-        ((ψ ∘ ((η ∘ B) ⊗₁ η)) * ∘ (η ∘ associator.to)) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B)))     
-          ≈⟨ ((*-resp-≈ (pullˡ *-identityʳ)) ⟩∘⟨refl) ⟩ 
-        ((ψ ∘ ((η ∘ B) ⊗₁ η)) ∘ associator.to) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B)))             
-          ≈˘⟨ *-resp-≈ (∘-resp-≈ˡ (∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)))) ⟩∘⟨ ∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl)) ⟩ 
-        ((ψ ∘ (η ⊗₁ η) ∘ (B ⊗₁ id)) ∘ associator.to) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ B)) 
-          ≈⟨ *-resp-≈ (∘-resp-≈ˡ (pullˡ ψ-η)) ⟩∘⟨ pullˡ ψ-η ⟩ 
-        ((η ∘ (B ⊗₁ id)) ∘ associator.to) * ∘ (η ∘ (id ⊗₁ B))                       
-          ≈⟨ pullˡ *-identityʳ ⟩ 
-        ((η ∘ (B ⊗₁ id)) ∘ associator.to) ∘ (id ⊗₁ B)                               
-          ≈⟨ (assoc ○ pullʳ (sym-assoc ○ hexagon₂) ○ (sym-assoc ○ ∘-resp-≈ˡ sym-assoc)) ⟩
-        ((η ∘ associator.to) ∘ B) ∘ associator.to                                   
-          ≈˘⟨ pullˡ (pullˡ *-identityʳ) ⟩ 
-        (η ∘ associator.to) * ∘ (η ∘ B) ∘ associator.to                             
-          ≈˘⟨ refl⟩∘⟨ (pullˡ *-identityʳ) ⟩ 
-        (η ∘ associator.to) * ∘ (η ∘ B) * ∘ (η ∘ associator.to)                     
-          ≈˘⟨ *-assoc ⟩∘⟨refl ○ assoc ⟩ 
-        ((η ∘ associator.to) * ∘ (η ∘ B)) * ∘ (η ∘ associator.to)                   
-          ∎ 
+      ; hexagon₁ = hexagon₁'
+      ; hexagon₂ = hexagon₂'
       } 
     ; commutative = λ {X} {Y} → pullˡ *-identityʳ ○ cancelʳ B-commutative 
     }
@@ -115,3 +79,43 @@ module _ {𝒞 : Category o ℓ e} {monoidal : Monoidal 𝒞} (symmetric : Symme
         ≈˘⟨ extendʳ *-identityʳ ⟩ 
       (ψ ∘ (g ⊗₁ f)) * ∘ η ∘ B       
         ∎
+    hexagon₁' : ∀ {X Y Z : Obj} → (ψ {X} {Y ⊗₀ Z} ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η)) ≈ (η ∘ associator.from) * ∘ (η ∘ B) * ∘ (η ∘ associator.from)
+    hexagon₁' = begin 
+      (ψ ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ associator.from) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))       
+        ≈⟨ pullˡ *-sym-assoc ⟩ 
+      ((ψ ∘ (η ⊗₁ (η ∘ B))) * ∘ (η ∘ associator.from)) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))     
+        ≈⟨ ((*-resp-≈ (pullˡ *-identityʳ)) ⟩∘⟨refl) ⟩ 
+      ((ψ ∘ (η ⊗₁ (η ∘ B))) ∘ associator.from) * ∘ (ψ ∘ ((η ∘ B) ⊗₁ η))             
+        ≈˘⟨ *-resp-≈ (∘-resp-≈ˡ (∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl)))) ⟩∘⟨ ∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)) ⟩ 
+      ((ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ B)) ∘ associator.from) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (B ⊗₁ id)) 
+        ≈⟨ *-resp-≈ (∘-resp-≈ˡ (pullˡ ψ-η)) ⟩∘⟨ pullˡ ψ-η ⟩ 
+      ((η ∘ (id ⊗₁ B)) ∘ associator.from) * ∘ (η ∘ (B ⊗₁ id))                       
+        ≈⟨ pullˡ *-identityʳ ⟩ 
+      ((η ∘ (id ⊗₁ B)) ∘ associator.from) ∘ (B ⊗₁ id)                               
+        ≈⟨ (assoc ○ pullʳ hexagon₁ ○ (sym-assoc ○ sym-assoc)) ⟩ 
+      ((η ∘ associator.from) ∘ B) ∘ associator.from                                 
+        ≈˘⟨ pullˡ (pullˡ *-identityʳ) ⟩ 
+      (η ∘ associator.from) * ∘ (η ∘ B) ∘ associator.from                           
+        ≈˘⟨ refl⟩∘⟨ (pullˡ *-identityʳ) ⟩ 
+      (η ∘ associator.from) * ∘ (η ∘ B) * ∘ (η ∘ associator.from)                   
+        ∎
+    hexagon₂' : ∀ {X Y Z : Obj} → ((ψ {X ⊗₀ Y} {Z} ∘ ((η ∘ B) ⊗₁ η)) * ∘ (η ∘ associator.to)) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B))) ≈ ((η ∘ associator.to) * ∘ (η ∘ B)) * ∘ (η ∘ associator.to)
+    hexagon₂' = begin 
+      ((ψ ∘ ((η ∘ B) ⊗₁ η)) * ∘ (η ∘ associator.to)) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B)))     
+        ≈⟨ ((*-resp-≈ (pullˡ *-identityʳ)) ⟩∘⟨refl) ⟩ 
+      ((ψ ∘ ((η ∘ B) ⊗₁ η)) ∘ associator.to) * ∘ (ψ ∘ (η ⊗₁ (η ∘ B)))             
+        ≈˘⟨ *-resp-≈ (∘-resp-≈ˡ (∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , identityʳ)))) ⟩∘⟨ ∘-resp-≈ʳ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identityʳ , refl)) ⟩ 
+      ((ψ ∘ (η ⊗₁ η) ∘ (B ⊗₁ id)) ∘ associator.to) * ∘ (ψ ∘ (η ⊗₁ η) ∘ (id ⊗₁ B)) 
+        ≈⟨ *-resp-≈ (∘-resp-≈ˡ (pullˡ ψ-η)) ⟩∘⟨ pullˡ ψ-η ⟩ 
+      ((η ∘ (B ⊗₁ id)) ∘ associator.to) * ∘ (η ∘ (id ⊗₁ B))                       
+        ≈⟨ pullˡ *-identityʳ ⟩ 
+      ((η ∘ (B ⊗₁ id)) ∘ associator.to) ∘ (id ⊗₁ B)                               
+        ≈⟨ (assoc ○ pullʳ (sym-assoc ○ hexagon₂) ○ (sym-assoc ○ ∘-resp-≈ˡ sym-assoc)) ⟩
+      ((η ∘ associator.to) ∘ B) ∘ associator.to                                   
+        ≈˘⟨ pullˡ (pullˡ *-identityʳ) ⟩ 
+      (η ∘ associator.to) * ∘ (η ∘ B) ∘ associator.to                             
+        ≈˘⟨ refl⟩∘⟨ (pullˡ *-identityʳ) ⟩ 
+      (η ∘ associator.to) * ∘ (η ∘ B) * ∘ (η ∘ associator.to)                     
+        ≈˘⟨ *-assoc ⟩∘⟨refl ○ assoc ⟩ 
+      ((η ∘ associator.to) * ∘ (η ∘ B)) * ∘ (η ∘ associator.to)                   
+        ∎ 

--- a/src/Categories/Category/Monoidal/Properties.agda
+++ b/src/Categories/Category/Monoidal/Properties.agda
@@ -30,6 +30,26 @@ private
     A B : Obj
 open Core.Shorthands
 
+monoidal-Op : M.Monoidal (C.op)
+monoidal-Op = record
+  { ⊗ = Functor.op ⊗
+  ; unit = unit
+  ; unitorˡ = ≅⇒op-≅ unitorˡ
+  ; unitorʳ = ≅⇒op-≅ unitorʳ
+  ; associator = ≅⇒op-≅ associator
+  ; unitorˡ-commute-from = sym unitorˡ-commute-to
+  ; unitorˡ-commute-to = sym unitorˡ-commute-from
+  ; unitorʳ-commute-from = sym unitorʳ-commute-to
+  ; unitorʳ-commute-to = sym unitorʳ-commute-from
+  ; assoc-commute-from = sym assoc-commute-to
+  ; assoc-commute-to = sym assoc-commute-from
+  ; triangle = triangle-inv
+  ; pentagon = pentagon-inv
+  }
+  where
+  open import Categories.Morphism.Duality C using (≅⇒op-≅)
+  open Equiv using (sym)
+
 ⊗-iso : Bifunctor Core Core Core
 ⊗-iso = record
   { F₀           = uncurry′ _⊗₀_

--- a/src/Categories/Monad/Commutative/Properties.agda
+++ b/src/Categories/Monad/Commutative/Properties.agda
@@ -24,6 +24,7 @@ import Categories.Category.Monoidal.Braided.Properties as BraidedProps
 import Categories.Category.Monoidal.Symmetric.Properties as SymmetricProps
 import Categories.Morphism.Reasoning as MR
 import Categories.Category.Monoidal.Reasoning as MonoidalReasoning
+import Categories.Category.Monoidal.Utilities as MonoidalUtils
 
 
 private
@@ -111,6 +112,7 @@ module SymmetricProperties  {C : Category o ℓ e} {V : Monoidal C} (symmetric :
   open Symmetric symmetric using (commutative) renaming (braided to BV)
   open SymmetricProps symmetric
   open BraidedProps.Shorthands BV renaming (σ to B; σ⇒ to B⇒; σ⇐ to B⇐)
+  open MonoidalUtils.Shorthands V using (α⇒; α⇐)
   open Braided (Symmetric.braided symmetric) using (_⊗₀_; _⊗₁_; associator)
   open CommutativeMonad CM hiding (identityˡ; commutative)
   open StrongProps.Left.Shorthands strength
@@ -129,154 +131,186 @@ module SymmetricProperties  {C : Category o ℓ e} {V : Monoidal C} (symmetric :
   open TripleNotation M
 
   private
-    σ-strength-assoc' : ∀ {X Y Z} → M.F.₁ associator.to ∘ σ ∘ (id ⊗₁ σ) ≈ σ ∘ associator.to {X} {Y} {M.F.₀ Z}
+    σ-strength-assoc' : ∀ {X Y Z} → M.F.₁ α⇐ ∘ σ ∘ (id ⊗₁ σ) ≈ σ ∘ α⇐ {X} {Y} {M.F.₀ Z}
     σ-strength-assoc' = begin 
-      M.F.₁ associator.to ∘ σ ∘ (id ⊗₁ σ) 
+      M.F.₁ α⇐ ∘ σ ∘ (id ⊗₁ σ) 
         ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ elimʳ associator.isoʳ ⟩ 
-      M.F.₁ associator.to ∘ σ ∘ (id ⊗₁ σ) ∘ associator.from ∘ associator.to 
+      M.F.₁ α⇐ ∘ σ ∘ (id ⊗₁ σ) ∘ α⇒ ∘ α⇐ 
         ≈˘⟨ refl⟩∘⟨ (pullˡ strength-assoc ○ assoc²βε) ⟩ 
-      M.F.₁ associator.to ∘ M.F.₁ associator.from ∘ σ ∘ associator.to 
+      M.F.₁ α⇐ ∘ M.F.₁ α⇒ ∘ σ ∘ α⇐ 
         ≈⟨ cancelˡ (sym M.F.homomorphism ○ M.F.F-resp-≈ associator.isoˡ ○ M.F.identity) ⟩ 
-      σ ∘ associator.to 
+      σ ∘ α⇐ 
         ∎
 
-    τ-strength-assoc' : ∀ {X Y Z} → M.F.₁ associator.from ∘ τ ∘ (τ ⊗₁ id) ≈ τ ∘ associator.from {M.F.₀ X} {Y} {Z}
+    τ-strength-assoc' : ∀ {X Y Z} → M.F.₁ α⇒ ∘ τ ∘ (τ ⊗₁ id) ≈ τ ∘ α⇒ {M.F.₀ X} {Y} {Z}
     τ-strength-assoc' = begin 
-      M.F.₁ associator.from ∘ τ ∘ (τ ⊗₁ id) 
+      M.F.₁ α⇒ ∘ τ ∘ (τ ⊗₁ id) 
         ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ elimʳ associator.isoˡ ⟩ 
-      M.F.₁ associator.from ∘ τ ∘ (τ ⊗₁ id) ∘ associator.to ∘ associator.from 
+      M.F.₁ α⇒ ∘ τ ∘ (τ ⊗₁ id) ∘ α⇐ ∘ α⇒ 
         ≈˘⟨ refl⟩∘⟨ (pullˡ (RightStrength.strength-assoc rightStrength) ○ assoc²βε) ⟩ 
-      M.F.₁ associator.from ∘ M.F.₁ associator.to ∘ τ ∘ associator.from 
+      M.F.₁ α⇒ ∘ M.F.₁ α⇐ ∘ τ ∘ α⇒ 
         ≈⟨ cancelˡ (sym M.F.homomorphism ○ M.F.F-resp-≈ associator.isoʳ ○ M.F.identity) ⟩ 
-      τ ∘ associator.from 
+      τ ∘ α⇒ 
         ∎
 
-    hexagon₁' : ∀ {X Y Z} → M.F.₁ associator.to ∘ M.F.₁ (id ⊗₁ B⇐) ≈ M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ associator.to ∘ M.F.₁ B⇒ ∘ M.F.₁ (associator.to {X} {Y} {Z})
+    hexagon₁' : ∀ {X Y Z} → M.F.₁ α⇐ ∘ M.F.₁ (id ⊗₁ B⇐) ≈ M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ M.F.₁ B⇒ ∘ M.F.₁ (α⇐ {X} {Y} {Z})
     hexagon₁' = begin 
-      M.F.₁ associator.to ∘ M.F.₁ (id ⊗₁ B⇐)                                  
+      M.F.₁ α⇐ ∘ M.F.₁ (id ⊗₁ B⇐)                                  
         ≈⟨ sym M.F.homomorphism ⟩ 
-      M.F.₁ (associator.to ∘ (id ⊗₁ B⇐))                                      
+      M.F.₁ (α⇐ ∘ (id ⊗₁ B⇐))                                      
         ≈⟨ M.F.F-resp-≈ (∘-resp-≈ʳ (⊗.F-resp-≈ (refl , braiding-selfInverse))) ⟩ 
-      M.F.₁ (associator.to ∘ (id ⊗₁ B⇒))                                      
+      M.F.₁ (α⇐ ∘ (id ⊗₁ B⇒))                                      
         ≈˘⟨ M.F.F-resp-≈ (pullˡ (cancelˡ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ ((∘-resp-≈ˡ braiding-selfInverse ○ commutative) , identity²) ○ ⊗.identity))) ⟩ 
-      M.F.₁ ((B⇐ ⊗₁ id) ∘ ((B⇒ ⊗₁ id) ∘ associator.to) ∘ (id ⊗₁ B⇒))          
-        ≈⟨ M.F.F-resp-≈ (∘-resp-≈ʳ (Braided.hexagon₂ BV)) ⟩ 
-      M.F.₁ ((B⇐ ⊗₁ id) ∘ (associator.to ∘ B⇒) ∘ associator.to)               
+      M.F.₁ ((B⇐ ⊗₁ id) ∘ ((B⇒ ⊗₁ id) ∘ α⇐) ∘ (id ⊗₁ B⇒))          
+        ≈⟨ M.F.F-resp-≈ (∘-resp-≈ʳ BV.hexagon₂) ⟩ 
+      M.F.₁ ((B⇐ ⊗₁ id) ∘ (α⇐ ∘ B⇒) ∘ α⇐)               
         ≈˘⟨ ∘-resp-≈ʳ (pullˡ (sym M.F.homomorphism)) ○ (∘-resp-≈ʳ (sym M.F.homomorphism) ○ sym M.F.homomorphism) ⟩  
-      M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ associator.to ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.to 
+      M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇐ 
         ∎
 
-    hexagon₂' : ∀ {X Y Z} → M.F.₁ associator.from ∘ M.F.₁ (B⇒ ⊗₁ id) ≈ M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ associator.from ∘ M.F.₁ B⇒ ∘ M.F.₁ (associator.from {X} {Y} {Z})
+    hexagon₂' : ∀ {X Y Z} → M.F.₁ α⇒ ∘ M.F.₁ (B⇒ ⊗₁ id) ≈ M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ α⇒ ∘ M.F.₁ B⇒ ∘ M.F.₁ (α⇒ {X} {Y} {Z})
     hexagon₂' = begin 
-      M.F.₁ associator.from ∘ M.F.₁ (B⇒ ⊗₁ id)                         
+      M.F.₁ α⇒ ∘ M.F.₁ (B⇒ ⊗₁ id)                         
         ≈⟨ sym M.F.homomorphism ⟩ 
-      M.F.₁ (associator.from ∘ (B⇒ ⊗₁ id)) 
+      M.F.₁ (α⇒ ∘ (B⇒ ⊗₁ id)) 
         ≈˘⟨ M.F.F-resp-≈ (pullˡ (cancelˡ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identity² , (∘-resp-≈ˡ braiding-selfInverse ○ commutative)) ○ ⊗.identity))) ⟩
-      M.F.₁ ((id ⊗₁ B⇐) ∘ ((id ⊗₁ B⇒) ∘ associator.from) ∘ (B⇒ ⊗₁ id)) 
-        ≈⟨ M.F.F-resp-≈ (∘-resp-≈ʳ (assoc ○ (Braided.hexagon₁ BV) ○ sym-assoc)) ⟩
-      M.F.₁ ((id ⊗₁ B⇐) ∘ (associator.from ∘ B⇒) ∘ associator.from)    
+      M.F.₁ ((id ⊗₁ B⇐) ∘ ((id ⊗₁ B⇒) ∘ α⇒) ∘ (B⇒ ⊗₁ id)) 
+        ≈⟨ M.F.F-resp-≈ (∘-resp-≈ʳ (assoc ○ BV.hexagon₁ ○ sym-assoc)) ⟩
+      M.F.₁ ((id ⊗₁ B⇐) ∘ (α⇒ ∘ B⇒) ∘ α⇒)    
         ≈˘⟨ ∘-resp-≈ʳ (pullˡ (sym M.F.homomorphism)) ○ (∘-resp-≈ʳ (sym M.F.homomorphism) ○ sym M.F.homomorphism) ⟩
-      M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ associator.from ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.from 
+      M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ α⇒ ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇒ 
         ∎
 
-  τ-σ-assoc-from : ∀ {X Y Z} → M.F.₁ associator.from ∘ (τ {_} {Z}) * ∘ M.F.₁ (σ {X} {Y} ⊗₁ id) ≈ σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ associator.from
+    F-rewriteˡ : ∀ {U V X Y Z} {f : Y ⇒ Z} {g : X ⇒ Y} {h : V ⇒ X} → M.F.₁ (f ⊗₁ id) ∘ M.F.₁ (g ⊗₁ id) ∘ M.F.₁ (h ⊗₁ id) ≈ M.F.₁ ((f ∘ g ∘ h) ⊗₁ id {U})
+    F-rewriteˡ {f = f} {g} {h} = begin 
+      M.F.₁ (f ⊗₁ id) ∘ M.F.₁ (g ⊗₁ id) ∘ M.F.₁ (h ⊗₁ id) ≈⟨ ∘-resp-≈ʳ (sym M.F.homomorphism) ○ sym M.F.homomorphism ⟩ 
+      M.F.₁ ((f ⊗₁ id) ∘ (g ⊗₁ id) ∘ (h ⊗₁ id))           ≈⟨ M.F.F-resp-≈ (∘-resp-≈ʳ (sym ⊗.homomorphism) ○ sym ⊗.homomorphism) ⟩ 
+      M.F.₁ ((f ∘ g ∘ h) ⊗₁ (id ∘ id ∘ id))               ≈⟨ M.F.F-resp-≈ (⊗.F-resp-≈ (refl , (elimʳ identity²))) ⟩ 
+      M.F.₁ ((f ∘ g ∘ h) ⊗₁ id)                           ∎
+
+    F-rewriteʳ : ∀ {U V X Y Z} {f : Y ⇒ Z} {g : X ⇒ Y} {h : V ⇒ X} → M.F.₁ (id ⊗₁ f) ∘ M.F.₁ (id ⊗₁ g) ∘ M.F.₁ (id ⊗₁ h) ≈ M.F.₁ (id {U} ⊗₁ (f ∘ g ∘ h))
+    F-rewriteʳ {f = f} {g} {h} = begin 
+      M.F.₁ (id ⊗₁ f) ∘ M.F.₁ (id ⊗₁ g) ∘ M.F.₁ (id ⊗₁ h) ≈⟨ ∘-resp-≈ʳ (sym M.F.homomorphism) ○ sym M.F.homomorphism ⟩ 
+      M.F.₁ ((id ⊗₁ f) ∘ (id ⊗₁ g) ∘ (id ⊗₁ h))           ≈⟨ M.F.F-resp-≈ (∘-resp-≈ʳ (sym ⊗.homomorphism) ○ sym ⊗.homomorphism) ⟩ 
+      M.F.₁ ((id ∘ id ∘ id) ⊗₁ (f ∘ g ∘ h))               ≈⟨ M.F.F-resp-≈ (⊗.F-resp-≈ ((elimʳ identity²) , refl)) ⟩ 
+      M.F.₁ (id ⊗₁ (f ∘ g ∘ h))                           ∎
+
+    F-merge-splitˡ : ∀ {U V X Y Z} {f : Y ⇒ Z} {g : X ⇒ Y} {h : V ⇒ Z} {i : X ⇒ V} → f ∘ g ≈ h ∘ i → M.F.₁ (f ⊗₁ id) ∘ M.F.₁ (g ⊗₁ id) ≈ M.F.₁ (h ⊗₁ id) ∘ M.F.₁ (i ⊗₁ id {U})
+    F-merge-splitˡ {f = f} {g} {h} {i} f∘g≈h∘i = begin 
+      M.F.₁ (f ⊗₁ id) ∘ M.F.₁ (g ⊗₁ id)   ≈˘⟨ M.F.homomorphism ⟩ 
+      M.F.₁ ((f ⊗₁ id) ∘ (g ⊗₁ id))       ≈⟨ M.F.F-resp-≈ (sym ⊗.homomorphism) ⟩ 
+      M.F.₁ ((f ∘ g) ⊗₁ (id ∘ id))        ≈⟨ M.F.F-resp-≈ (⊗.F-resp-≈ (f∘g≈h∘i , refl)) ⟩ 
+      M.F.₁ ((h ∘ i) ⊗₁ (id ∘ id))        ≈⟨ M.F.F-resp-≈ ⊗.homomorphism ⟩ 
+      M.F.₁ ((h ⊗₁ id) ∘ (i ⊗₁ id))       ≈⟨ M.F.homomorphism ⟩ 
+      (M.F.₁ (h ⊗₁ id) ∘ M.F.₁ (i ⊗₁ id)) ∎
+
+    F-merge-splitʳ : ∀ {U V X Y Z} {f : Y ⇒ Z} {g : X ⇒ Y} {h : V ⇒ Z} {i : X ⇒ V} → f ∘ g ≈ h ∘ i → M.F.₁ (id ⊗₁ f) ∘ M.F.₁ (id ⊗₁ g) ≈ M.F.₁ (id ⊗₁ h) ∘ M.F.₁ (id {U} ⊗₁ i)
+    F-merge-splitʳ {f = f} {g} {h} {i} f∘g≈h∘i = begin 
+      M.F.₁ (id ⊗₁ f) ∘ M.F.₁ (id ⊗₁ g)   ≈˘⟨ M.F.homomorphism ⟩ 
+      M.F.₁ ((id ⊗₁ f) ∘ (id ⊗₁ g))       ≈⟨ M.F.F-resp-≈ (sym ⊗.homomorphism) ⟩ 
+      M.F.₁ ((id ∘ id) ⊗₁ (f ∘ g))        ≈⟨ M.F.F-resp-≈ (⊗.F-resp-≈ (refl , f∘g≈h∘i)) ⟩ 
+      M.F.₁ ((id ∘ id) ⊗₁ (h ∘ i))        ≈⟨ M.F.F-resp-≈ ⊗.homomorphism ⟩ 
+      M.F.₁ ((id ⊗₁ h) ∘ (id ⊗₁ i))       ≈⟨ M.F.homomorphism ⟩ 
+      (M.F.₁ (id ⊗₁ h) ∘ M.F.₁ (id ⊗₁ i)) ∎
+
+  τ-σ-assoc-from : ∀ {X Y Z} → M.F.₁ α⇒ ∘ (τ {_} {Z}) * ∘ M.F.₁ (σ {X} {Y} ⊗₁ id) ≈ σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ α⇒
   τ-σ-assoc-from = begin
-    M.F.₁ associator.from ∘ τ * ∘ M.F.₁ (σ ⊗₁ id) 
+    M.F.₁ α⇒ ∘ τ * ∘ M.F.₁ (σ ⊗₁ id) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ M.F.F-resp-≈ (σ-τ ⟩⊗⟨refl) ⟩
-    M.F.₁ associator.from ∘ τ * ∘ M.F.₁ ((M.F.₁ B⇒ ∘ τ ∘ B⇐) ⊗₁ id)
+    M.F.₁ α⇒ ∘ τ * ∘ M.F.₁ ((M.F.₁ B⇒ ∘ τ ∘ B⇐) ⊗₁ id)
       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (pullˡ (sym M.F.homomorphism ○ M.F.F-resp-≈ merge₁ˡ) ○ (sym M.F.homomorphism ○ M.F.F-resp-≈ (merge₁ˡ ○ ⊗.F-resp-≈ (assoc , refl)))) ⟩
-    M.F.₁ associator.from ∘ τ * ∘ M.F.₁ (M.F.₁ B⇒ ⊗₁ id) ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ (B⇐ ⊗₁ id) 
+    M.F.₁ α⇒ ∘ τ * ∘ M.F.₁ (M.F.₁ B⇒ ⊗₁ id) ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ (B⇐ ⊗₁ id) 
       ≈⟨ refl⟩∘⟨ extendʳ ((*∘F₁ ○ *-resp-≈ (τ.commute _)) ○ sym F₁∘*) ⟩ 
-    M.F.₁ associator.from ∘ M.F.₁ (B⇒ ⊗₁ id) ∘ τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ (B⇐ ⊗₁ id) 
+    M.F.₁ α⇒ ∘ M.F.₁ (B⇒ ⊗₁ id) ∘ τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ (B⇐ ⊗₁ id) 
       ≈⟨ extendʳ hexagon₂' ○ ∘-resp-≈ʳ assoc²βε ⟩ 
-    M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ associator.from ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.from ∘ τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ (B⇐ ⊗₁ id) 
+    M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ α⇒ ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇒ ∘ τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ (B⇐ ⊗₁ id) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ (pullˡ F₁∘* ○ (pullˡ (*∘F₁ ○ *-resp-≈ (assoc ○ τ-strength-assoc')) ○ sym (pullˡ *∘F₁))) ⟩ 
-    M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ associator.from ∘ M.F.₁ B⇒ ∘ τ * ∘ M.F.₁ associator.from ∘ M.F.₁ (B⇐ ⊗₁ id) 
+    M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ α⇒ ∘ M.F.₁ B⇒ ∘ τ * ∘ M.F.₁ α⇒ ∘ M.F.₁ (B⇐ ⊗₁ id) 
       ≈⟨ (refl⟩∘⟨ refl⟩∘⟨ extendʳ (F₁∘* ○ *-resp-≈ (∘-resp-≈ˡ (M.F.F-resp-≈ (sym braiding-selfInverse)) ○ cancelˡ (sym M.F.homomorphism ○ M.F.F-resp-≈ inv-commutative ○ M.F.identity)) ○ sym *∘F₁)) ⟩ 
-    M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ associator.from ∘ σ * ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.from ∘ M.F.₁ (B⇐ ⊗₁ id) 
+    M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ α⇒ ∘ σ * ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇒ ∘ M.F.₁ (B⇐ ⊗₁ id) 
       ≈⟨ refl⟩∘⟨ (pullˡ (F₁∘* ○ *-resp-≈ strength-assoc) ○ sym (pullˡ *∘F₁ ○ pullˡ (*∘F₁ ○ *-resp-≈ assoc))) ⟩ 
-    M.F.₁ (id ⊗₁ B⇐) ∘ σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ associator.from ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.from ∘ M.F.₁ (B⇐ ⊗₁ id) 
+    M.F.₁ (id ⊗₁ B⇐) ∘ σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ α⇒ ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇒ ∘ M.F.₁ (B⇐ ⊗₁ id) 
       ≈⟨ extendʳ (F₁∘* ○ *-resp-≈ (sym (σ.commute _)) ○ sym *∘F₁) ⟩ 
-    σ * ∘ M.F.₁ (id ⊗₁ M.F.₁ B⇐) ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ associator.from ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.from ∘ M.F.₁ (B⇐ ⊗₁ id) 
-      ≈⟨ refl⟩∘⟨ extendʳ (sym M.F.homomorphism ○ M.F.F-resp-≈ (sym ⊗.homomorphism) ○ M.F.F-resp-≈ (⊗.F-resp-≈ (identity² , left-right-braiding-comm BV)) ○ sym (sym M.F.homomorphism ○ M.F.F-resp-≈ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identity² , refl)))) ⟩ 
-    σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ associator.from ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.from ∘ M.F.₁ (B⇐ ⊗₁ id) 
+    σ * ∘ M.F.₁ (id ⊗₁ M.F.₁ B⇐) ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ α⇒ ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇒ ∘ M.F.₁ (B⇐ ⊗₁ id) 
+      ≈⟨ refl⟩∘⟨ extendʳ (F-merge-splitʳ (sym (pullʳ (cancelʳ (∘-resp-≈ʳ braiding-selfInverse ○ commutative))))) ⟩
+    σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ α⇒ ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇒ ∘ M.F.₁ (B⇐ ⊗₁ id) 
       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ ((pullˡ hexagon₂') ○ pullʳ assoc²βε) ⟩ 
-    σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ associator.from ∘ M.F.₁ (B⇒ ⊗₁ id) ∘ M.F.₁ (B⇐ ⊗₁ id) 
+    σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ α⇒ ∘ M.F.₁ (B⇒ ⊗₁ id) ∘ M.F.₁ (B⇐ ⊗₁ id) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ elimʳ (sym M.F.homomorphism ○ M.F.F-resp-≈ (merge₁ˡ ○ (⊗-resp-≈ˡ (BV.braiding.iso.isoʳ _) ○ ⊗.identity)) ○ M.F.identity) ⟩ 
-    σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ associator.from 
+    σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ α⇒ 
       ∎
 
-  σ-τ-assoc-to : ∀ {X Y Z} → M.F.₁ associator.to ∘ (σ {X}) * ∘ M.F.₁ (id ⊗₁ τ {Y} {Z}) ≈ τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ associator.to
+  σ-τ-assoc-to : ∀ {X Y Z} → M.F.₁ α⇐ ∘ (σ {X}) * ∘ M.F.₁ (id ⊗₁ τ {Y} {Z}) ≈ τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ α⇐
   σ-τ-assoc-to = begin
-    M.F.₁ associator.to ∘ σ * ∘ M.F.₁ (id ⊗₁ τ)
+    M.F.₁ α⇐ ∘ σ * ∘ M.F.₁ (id ⊗₁ τ)
       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (pullˡ (sym M.F.homomorphism ○ M.F.F-resp-≈ merge₂ˡ) ○ (sym M.F.homomorphism ○ M.F.F-resp-≈ (merge₂ˡ ○ ⊗.F-resp-≈ (refl , assoc)))) ⟩
-    M.F.₁ associator.to ∘ σ * ∘ M.F.₁ (id ⊗₁ M.F.₁ B⇐) ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ (id ⊗₁ B⇒) 
+    M.F.₁ α⇐ ∘ σ * ∘ M.F.₁ (id ⊗₁ M.F.₁ B⇐) ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ (id ⊗₁ B⇒) 
       ≈⟨ refl⟩∘⟨ extendʳ ((*∘F₁ ○ *-resp-≈ (σ.commute (id , B⇐))) ○ sym F₁∘*) ⟩ 
-    M.F.₁ associator.to ∘ M.F.₁ (id ⊗₁ B⇐) ∘ σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ (id ⊗₁ B⇒) 
+    M.F.₁ α⇐ ∘ M.F.₁ (id ⊗₁ B⇐) ∘ σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ (id ⊗₁ B⇒) 
       ≈⟨ extendʳ hexagon₁' ○ ∘-resp-≈ʳ assoc²βε ⟩ 
-    M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ associator.to ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.to ∘ σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ (id ⊗₁ B⇒) 
+    M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇐ ∘ σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ (id ⊗₁ B⇒) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ (pullˡ F₁∘* ○ (pullˡ (*∘F₁ ○ *-resp-≈ (assoc ○ σ-strength-assoc')) ○ sym (pullˡ *∘F₁))) ⟩ 
-    M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ associator.to ∘ M.F.₁ B⇒ ∘ σ * ∘ M.F.₁ associator.to ∘ M.F.₁ (id ⊗₁ B⇒) 
+    M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ M.F.₁ B⇒ ∘ σ * ∘ M.F.₁ α⇐ ∘ M.F.₁ (id ⊗₁ B⇒) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ extendʳ (F₁∘* ○ *-resp-≈ (∘-resp-≈ˡ (M.F.F-resp-≈ (sym braiding-selfInverse)) ○ left-right-braiding-comm BV) ○ sym *∘F₁ ○ ∘-resp-≈ʳ (M.F.F-resp-≈ braiding-selfInverse)) ⟩ 
-    M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ associator.to ∘ τ * ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.to ∘ M.F.₁ (id ⊗₁ B⇒) 
+    M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ τ * ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇐ ∘ M.F.₁ (id ⊗₁ B⇒) 
       ≈⟨ refl⟩∘⟨ (pullˡ (F₁∘* ○ *-resp-≈ (RightStrength.strength-assoc rightStrength)) ○ sym (pullˡ *∘F₁ ○ pullˡ (*∘F₁ ○ *-resp-≈ assoc))) ⟩ 
-    M.F.₁ (B⇐ ⊗₁ id) ∘ τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ associator.to ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.to ∘ M.F.₁ (id ⊗₁ B⇒) 
+    M.F.₁ (B⇐ ⊗₁ id) ∘ τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇐ ∘ M.F.₁ (id ⊗₁ B⇒) 
       ≈⟨ extendʳ (F₁∘* ○ *-resp-≈ (sym (τ.commute _)) ○ sym *∘F₁) ⟩ 
-    τ * ∘ M.F.₁ (M.F.₁ B⇐ ⊗₁ id) ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ associator.to ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.to ∘ M.F.₁ (id ⊗₁ B⇒) 
-      ≈⟨ refl⟩∘⟨ extendʳ (sym M.F.homomorphism ○ M.F.F-resp-≈ (sym ⊗.homomorphism) ○ M.F.F-resp-≈ (⊗.F-resp-≈ ((cancelˡ (sym M.F.homomorphism ○ M.F.F-resp-≈ inv-commutative ○ M.F.identity)) , identity²)) ○ sym (sym M.F.homomorphism ○ M.F.F-resp-≈ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ ((∘-resp-≈ʳ braiding-selfInverse) , identity²)))) ⟩ 
-    τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ associator.to ∘ M.F.₁ B⇒ ∘ M.F.₁ associator.to ∘ M.F.₁ (id ⊗₁ B⇒) 
+    τ * ∘ M.F.₁ (M.F.₁ B⇐ ⊗₁ id) ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇐ ∘ M.F.₁ (id ⊗₁ B⇒) 
+      ≈⟨ (refl⟩∘⟨ (extendʳ (F-merge-splitˡ (cancelˡ (sym M.F.homomorphism ○ M.F.F-resp-≈ inv-commutative ○ M.F.identity) ○ ∘-resp-≈ʳ (sym braiding-selfInverse))))) ⟩
+    τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ (B⇐ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ M.F.₁ B⇒ ∘ M.F.₁ α⇐ ∘ M.F.₁ (id ⊗₁ B⇒) 
       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ ((pullˡ hexagon₁') ○ pullʳ assoc²βε) ⟩ 
-    τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ associator.to ∘ M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ (id ⊗₁ B⇒)
+    τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ M.F.₁ (id ⊗₁ B⇐) ∘ M.F.₁ (id ⊗₁ B⇒)
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ elimʳ (sym M.F.homomorphism ○ M.F.F-resp-≈ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (identity² , (∘-resp-≈ˡ braiding-selfInverse ○ commutative)) ○ ⊗.identity) ○ M.F.identity) ⟩ 
-    τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ associator.to 
+    τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ α⇐ 
       ∎
   
-  ψ-assoc-to : ∀ {X Y Z} → M.F.₁ associator.to ∘ ψ ∘ (id ⊗₁ ψ) ≈ ψ {X ⊗₀ Y} {Z} ∘ (ψ ⊗₁ id) ∘ associator.to
+  ψ-assoc-to : ∀ {X Y Z} → M.F.₁ α⇐ ∘ ψ ∘ (id ⊗₁ ψ) ≈ ψ {X ⊗₀ Y} {Z} ∘ (ψ ⊗₁ id) ∘ α⇐
   ψ-assoc-to = begin 
-    M.F.₁ associator.to ∘ ψ ∘ (id ⊗₁ ψ) 
+    M.F.₁ α⇐ ∘ ψ ∘ (id ⊗₁ ψ) 
       ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ (pullˡ (sym ⊗.homomorphism) ○ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ ((elimˡ identity²) , refl))) ⟩ 
-    M.F.₁ associator.to ∘ (τ * ∘ σ) ∘ (id ⊗₁ M.μ.η _) ∘ (id ⊗₁ M.F.₁ τ) ∘ (id ⊗₁ σ) 
+    M.F.₁ α⇐ ∘ (τ * ∘ σ) ∘ (id ⊗₁ M.μ.η _) ∘ (id ⊗₁ M.F.₁ τ) ∘ (id ⊗₁ σ) 
       ≈⟨ pullˡ (pullˡ (F₁∘* ○ *-resp-≈ (RightStrength.strength-assoc rightStrength) ○ *-resp-≈ sym-assoc)) ○ sym (pullˡ *∘F₁ ○ (pullˡ *∘F₁ ○ sym-assoc)) ⟩
-    τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ associator.to ∘ σ ∘ (id ⊗₁ M.μ.η _) ∘ (id ⊗₁ M.F.₁ τ) ∘ (id ⊗₁ σ) 
+    τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ σ ∘ (id ⊗₁ M.μ.η _) ∘ (id ⊗₁ M.F.₁ τ) ∘ (id ⊗₁ σ) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ extendʳ ((sym μ-η-comm) ○ sym-assoc) ⟩ 
-    τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ associator.to ∘ σ * ∘ σ ∘ (id ⊗₁ M.F.₁ τ) ∘ (id ⊗₁ σ) 
+    τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ σ * ∘ σ ∘ (id ⊗₁ M.F.₁ τ) ∘ (id ⊗₁ σ) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ extendʳ (σ.commute _) ⟩ 
-    τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ associator.to ∘ σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ σ ∘ (id ⊗₁ σ) 
+    τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ σ ∘ (id ⊗₁ σ) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ (sym-assoc ○ pullˡ (assoc ○ σ-τ-assoc-to) ○ pullʳ assoc) ⟩ 
-    τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ associator.to ∘ σ ∘ (id ⊗₁ σ) 
+    τ * ∘ M.F.₁ (τ ⊗₁ id) ∘ τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ σ ∘ (id ⊗₁ σ) 
       ≈⟨ refl⟩∘⟨ extendʳ (F₁∘* ○ (*-resp-≈ (sym (τ.commute _)) ○ sym *∘F₁)) ⟩ 
-    τ * ∘ τ * ∘ M.F.₁ (M.F.₁ τ ⊗₁ id) ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ associator.to ∘ σ ∘ (id ⊗₁ σ) 
+    τ * ∘ τ * ∘ M.F.₁ (M.F.₁ τ ⊗₁ id) ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ σ ∘ (id ⊗₁ σ) 
       ≈⟨ extendʳ (*-sym-assoc ○ *-resp-≈ (assoc ○ RightStrength.μ-η-comm rightStrength) ○ sym *∘F₁) ⟩ 
-    τ * ∘ M.F.₁ (M.μ.η _ ⊗₁ id) ∘ M.F.₁ (M.F.₁ τ ⊗₁ id) ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ associator.to ∘ σ ∘ (id ⊗₁ σ) 
-      ≈⟨ refl⟩∘⟨ (pullˡ (sym M.F.homomorphism) ○ pullˡ (sym M.F.homomorphism) ○ ∘-resp-≈ˡ (M.F.F-resp-≈ (∘-resp-≈ˡ (sym ⊗.homomorphism) ○ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (refl , (elimˡ identity²)))))) ⟩ 
-    τ * ∘ M.F.₁ (ψ ⊗₁ id) ∘ M.F.₁ associator.to ∘ σ ∘ (id ⊗₁ σ) 
+    τ * ∘ M.F.₁ (M.μ.η _ ⊗₁ id) ∘ M.F.₁ (M.F.₁ τ ⊗₁ id) ∘ M.F.₁ (σ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ σ ∘ (id ⊗₁ σ) 
+      ≈⟨ refl⟩∘⟨ (sym-assoc ○ pullˡ (assoc ○ (F-rewriteˡ ○ M.F.F-resp-≈ (⊗.F-resp-≈ (sym-assoc , refl))))) ⟩
+    τ * ∘ M.F.₁ (ψ ⊗₁ id) ∘ M.F.₁ α⇐ ∘ σ ∘ (id ⊗₁ σ) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ σ-strength-assoc' ⟩ 
-    τ * ∘ M.F.₁ (ψ ⊗₁ id) ∘ σ ∘ associator.to 
+    τ * ∘ M.F.₁ (ψ ⊗₁ id) ∘ σ ∘ α⇐ 
       ≈⟨ ∘-resp-≈ʳ (extendʳ (sym (σ.commute _))) ○ (sym-assoc ○ ∘-resp-≈ʳ (∘-resp-≈ˡ (⊗.F-resp-≈ (refl , M.F.identity)))) ⟩ 
-    ψ ∘ (ψ ⊗₁ id) ∘ associator.to 
+    ψ ∘ (ψ ⊗₁ id) ∘ α⇐ 
       ∎
 
-  ψ-assoc-from : ∀ {X Y Z} → M.F.₁ associator.from ∘ ψ {X ⊗₀ Y} {Z} ∘ (ψ ⊗₁ id) ≈ ψ ∘ (id ⊗₁ ψ) ∘ associator.from
+  ψ-assoc-from : ∀ {X Y Z} → M.F.₁ α⇒ ∘ ψ {X ⊗₀ Y} {Z} ∘ (ψ ⊗₁ id) ≈ ψ ∘ (id ⊗₁ ψ) ∘ α⇒
   ψ-assoc-from = begin 
-    M.F.₁ associator.from ∘ (τ * ∘ σ) ∘ (ψ ⊗₁ id) 
+    M.F.₁ α⇒ ∘ (τ * ∘ σ) ∘ (ψ ⊗₁ id) 
       ≈˘⟨ refl⟩∘⟨ sym commutes ⟩∘⟨ (pullˡ (sym ⊗.homomorphism) ○ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (sym commutes , (elimˡ identity²)))) ⟩ 
-    M.F.₁ associator.from ∘ (σ * ∘ τ) ∘ (M.μ.η _ ⊗₁ id) ∘ (M.F.₁ σ ⊗₁ id) ∘ (τ ⊗₁ id) 
+    M.F.₁ α⇒ ∘ (σ * ∘ τ) ∘ (M.μ.η _ ⊗₁ id) ∘ (M.F.₁ σ ⊗₁ id) ∘ (τ ⊗₁ id) 
       ≈⟨ pullˡ (pullˡ (F₁∘* ○ *-resp-≈ strength-assoc ○ *-resp-≈ sym-assoc)) ○ sym (pullˡ *∘F₁ ○ (pullˡ *∘F₁ ○ sym-assoc)) ⟩
-    σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ associator.from ∘ τ ∘ (M.μ.η _ ⊗₁ id) ∘ (M.F.₁ σ ⊗₁ id) ∘ (τ ⊗₁ id) 
+    σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ α⇒ ∘ τ ∘ (M.μ.η _ ⊗₁ id) ∘ (M.F.₁ σ ⊗₁ id) ∘ (τ ⊗₁ id) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ extendʳ ((sym (RightStrength.μ-η-comm rightStrength)) ○ sym-assoc) ⟩
-    σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ associator.from ∘ τ * ∘ τ ∘ (M.F.₁ σ ⊗₁ id) ∘ (τ ⊗₁ id) 
+    σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ α⇒ ∘ τ * ∘ τ ∘ (M.F.₁ σ ⊗₁ id) ∘ (τ ⊗₁ id) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ extendʳ (τ.commute _) ⟩
-    σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ associator.from ∘ τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ τ ∘ (τ ⊗₁ id) 
+    σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ M.F.₁ α⇒ ∘ τ * ∘ M.F.₁ (σ ⊗₁ id) ∘ τ ∘ (τ ⊗₁ id) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ (sym-assoc ○ pullˡ (assoc ○ τ-σ-assoc-from) ○ pullʳ assoc) ⟩
-    σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ associator.from ∘ τ ∘ (τ ⊗₁ id) 
+    σ * ∘ M.F.₁ (id ⊗₁ σ) ∘ σ * ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ α⇒ ∘ τ ∘ (τ ⊗₁ id) 
       ≈⟨ refl⟩∘⟨ extendʳ (F₁∘* ○ (*-resp-≈ (sym (σ.commute _)) ○ sym *∘F₁)) ⟩
-    σ * ∘ σ * ∘ M.F.₁ (id ⊗₁ M.F.₁ σ) ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ associator.from ∘ τ ∘ (τ ⊗₁ id) 
+    σ * ∘ σ * ∘ M.F.₁ (id ⊗₁ M.F.₁ σ) ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ α⇒ ∘ τ ∘ (τ ⊗₁ id) 
       ≈⟨ extendʳ (*-sym-assoc ○ *-resp-≈ (assoc ○ μ-η-comm) ○ sym *∘F₁) ⟩
-    σ * ∘ M.F.₁ (id ⊗₁ M.μ.η _) ∘ M.F.₁ (id ⊗₁ M.F.₁ σ) ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ associator.from ∘ τ ∘ (τ ⊗₁ id) 
-      ≈⟨ (refl⟩∘⟨ (pullˡ (sym M.F.homomorphism) ○ pullˡ (sym M.F.homomorphism) ○ ∘-resp-≈ˡ (M.F.F-resp-≈ (∘-resp-≈ˡ (sym ⊗.homomorphism) ○ (sym ⊗.homomorphism ○ ⊗.F-resp-≈ (elimˡ identity² , sym commutes)))))) ⟩
-    σ * ∘ M.F.₁ (id ⊗₁ ψ) ∘ M.F.₁ associator.from ∘ τ ∘ (τ ⊗₁ id) 
+    σ * ∘ M.F.₁ (id ⊗₁ M.μ.η _) ∘ M.F.₁ (id ⊗₁ M.F.₁ σ) ∘ M.F.₁ (id ⊗₁ τ) ∘ M.F.₁ α⇒ ∘ τ ∘ (τ ⊗₁ id) 
+      ≈⟨ refl⟩∘⟨ (sym-assoc ○ pullˡ (assoc ○ (F-rewriteʳ ○ M.F.F-resp-≈ (⊗.F-resp-≈ (refl , (sym-assoc ○ sym commutes)))))) ⟩
+    σ * ∘ M.F.₁ (id ⊗₁ ψ) ∘ M.F.₁ α⇒ ∘ τ ∘ (τ ⊗₁ id) 
       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ τ-strength-assoc' ⟩
-    σ * ∘ M.F.₁ (id ⊗₁ ψ) ∘ τ ∘ associator.from 
+    σ * ∘ M.F.₁ (id ⊗₁ ψ) ∘ τ ∘ α⇒ 
       ≈⟨ (∘-resp-≈ʳ (extendʳ (sym (τ.commute _))) ○ (sym-assoc ○ extendʳ (sym commutes ⟩∘⟨ ⊗.F-resp-≈ (M.F.identity , refl)))) ⟩
-    ψ ∘ (id ⊗₁ ψ) ∘ associator.from 
+    ψ ∘ (id ⊗₁ ψ) ∘ α⇒ 
       ∎


### PR DESCRIPTION
This second part of #473 shows that the kleisli category of a commutative monad is monoidal and symmetric.
