### PR TITLE
Remove --auto-inline from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test Everything.agda clean
+.PHONY: test html Everything.agda clean profile
 
 AGDA_EXEC = agda
 OTHEROPTS = -Werror


### PR DESCRIPTION
The original intent in #305 was to pass the CI, but CI does not use Makefile at all. Since the Agda Standard Library does not use `--autoinline`, enabling this switch causes `make html` to re-check lots of files in the Standard Library.

Furthermore, adding `--autoline` requires the user to re-check the affected files in the Standard Library after `make html` finishes. Thus, remove `--autoinline` from Makefile.

This commit also changes Makefile to use [agda-stdlib style variables](https://github.com/agda/agda-stdlib/blob/v2.3/GNUmakefile#L1-L4).

-----

I have tested this PR using these commands:

```bash
make -C libs/agda-stdlib-2.3 listings AGDA_EXEC=agda-2.8.0 AGDA_OPTIONS=
find libs/agda-stdlib-2.3 -name '*.agdai' -exec chmod u-w {} \+
chmod u-w libs/agda-stdlib-2.3/_build/2.8.0/agda/src
make -C libs/agda-categories html AGDA_EXEC=agda-2.8.0 OTHEROPTS=
```

These commands are based on how Homebrew packages Agda and friends (in https://github.com/Homebrew/homebrew-core/blob/1ac77ca9ebc0e4e8c9bd19e741a24f318207da4e/Formula/a/agda.rb#L133-L140).
