### PR TITLE
add missing options pragma

### DIFF
--- a/src/Categories/Object/NaturalNumbers/Parametrized/Properties/F-Algebras.agda
+++ b/src/Categories/Object/NaturalNumbers/Parametrized/Properties/F-Algebras.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --without-K --safe #-}
+
 open import Level
 open import Categories.Category.Core
 open import Categories.Object.Terminal using (Terminal)


### PR DESCRIPTION
Hiya, I somehow missed this options pragma a few months ago when working on natural numbers objects.

I was surprised that this went through, but it makes sense, since this file is not imported anywhere yet.
Would adding the pragma to `Everything.agda` catch such oversights?