### PR TITLE
change definition of exponentials

### DIFF
--- a/src/Categories/Category/BinaryCoproducts.agda
+++ b/src/Categories/Category/BinaryCoproducts.agda
@@ -68,6 +68,7 @@ record BinaryCoproducts : Set (levelOfTerm 𝒞) where
              ; assocˡ∘assocʳ to +-assocˡ∘+-assocʳ
              ; assocʳ∘assocˡ to +-assocʳ∘+-assocˡ
              ; swap         to +-swap
+             ; id⁂id        to id+₁id
              ; first        to +-first
              ; second       to +-second
              ; π₁∘⁂         to +₁∘i₁

--- a/src/Categories/Category/BinaryProducts.agda
+++ b/src/Categories/Category/BinaryProducts.agda
@@ -14,7 +14,7 @@ open HomReasoning
 
 open import Categories.Object.Product 𝒞
 open import Categories.Morphism 𝒞 using (_≅_; module Iso; Mono; Epi)
-open import Categories.Morphism.Reasoning 𝒞 using (pullʳ; pullˡ; elimʳ; cancelˡ; cancelʳ; introˡ; introʳ)
+open import Categories.Morphism.Reasoning 𝒞 using (pullʳ; pullˡ; elimʳ; cancelˡ; cancelʳ; introˡ; introʳ; id-comm)
 open import Categories.Category.Monoidal.Core using (Monoidal)
 
 open import Categories.Functor using (Functor) renaming (id to idF)
@@ -70,6 +70,9 @@ record BinaryProducts : Set (levelOfTerm 𝒞) where
 
   swap : A × B ⇒ B × A
   swap = ⟨ π₂ , π₁ ⟩
+
+  id⁂id : id {A} ⁂ id {B} ≈ id
+  id⁂id = unique id-comm id-comm
 
   -- TODO: this is probably harder to use than necessary because of this definition. Maybe make a version
   -- that doesn't have an explicit id in it, too?

--- a/src/Categories/Category/CartesianClosed.agda
+++ b/src/Categories/Category/CartesianClosed.agda
@@ -17,10 +17,11 @@ open import Categories.NaturalTransformation hiding (id)
 open import Categories.NaturalTransformation.Properties
 open import Categories.Object.Product 𝒞
   hiding (repack≡id; repack∘; repack-cancel; up-to-iso; transport-by-iso)
-open import Categories.Object.Exponential 𝒞 hiding (repack)
 open import Categories.Object.Terminal using (Terminal)
 open import Categories.Morphism 𝒞
 open import Categories.Morphism.Reasoning 𝒞
+
+import Categories.Object.Exponential.Canonical as Exponentials
 
 private
   module 𝒞 = Category 𝒞
@@ -40,9 +41,14 @@ record CartesianClosed : Set (levelOfTerm 𝒞) where
 
   field
     cartesian : Cartesian
+
+  open Exponentials cartesian hiding (repack)
+
+  field
     exp       : Exponential A B
 
-  module exp {A B} = Exponential (exp {A} {B})
+  private
+    module exp {A B} = Exponential (exp {A} {B})
 
   _^_ : Obj → Obj → Obj
   B ^ A = exp.B^A {A} {B}
@@ -54,135 +60,54 @@ record CartesianClosed : Set (levelOfTerm 𝒞) where
     module cartesian = Cartesian cartesian
 
   open CartesianMonoidal cartesian using (A×⊤≅A)
-  open BinaryProducts cartesian.products using (_×_; product; π₁; π₂; ⟨_,_⟩;
-    project₁; project₂; η; ⟨⟩-cong₂; ⟨⟩∘; _⁂_; ⟨⟩-congˡ; ⟨⟩-congʳ;
-    first∘first; firstid; first; second; first↔second; second∘second; ⁂-cong₂; -×_)
-  open Terminal cartesian.terminal using (⊤; !; !-unique₂; ⊤-id)
+  open Cartesian cartesian using (_×_; product; π₁; π₂; ⟨_,_⟩;
+    project₁; project₂; η; ⟨⟩-cong₂; ⟨⟩∘; _⁂_; ⟨⟩-congˡ; ⟨⟩-congʳ; id⁂id;
+    first∘first; firstid; first; second; first↔second; second∘second; ⁂-cong₂; -×_;
+    ⊤; !; !-unique₂; ⊤-id)
+    renaming (unique to ×-unique)
 
-  B^A×A : ∀ B A → Product (B ^ A) A
-  B^A×A B A = exp.product {A} {B}
-
-  eval : Product.A×B (B^A×A B A) ⇒ B
-  eval = exp.eval
-
-  λg : C × A ⇒ B → C ⇒ B ^ A
-  λg f = exp.λg product f
-
-  λ-cong : f ≈ g → λg f ≈ λg g
-  λ-cong eq = exp.λ-cong product eq
-
-  λ-inj : λg f ≈ λg g → f ≈ g
-  λ-inj = exp.λ-inj product
-
-  _×id : (f : C ⇒ B ^ A) → C × A ⇒ [[ B^A×A B A ]]
-  f ×id = [ product ⇒ exp.product ] f ×id
-
-  β : eval ∘ λg f ×id ≈ f
-  β = exp.β product
-
-  subst : λg f ∘ g ≈ λg (f ∘ (g ⁂ id))
-  subst = exp.subst product product
-
-  η-exp : λg (eval ∘ f ×id) ≈ f
-  η-exp = exp.η product
-
-  λ-unique : eval ∘ f ×id ≈ g → f ≈ λg g
-  λ-unique = exp.λ-unique product
-
-  λ-unique₂ : eval ∘ f ×id ≈ eval ∘ g ×id → f ≈ g
-  λ-unique₂ = exp.λ-unique′ product
-
-  -- the annoying detail is that B^A×A is NOT the same as B ^ A × A, but they are isomorphic.
-  -- make some infra so that the latter (which is more intuitive) can be used.
-
-  B^A×A-iso : Product.A×B (B^A×A B A) ≅ B ^ A × A
-  B^A×A-iso {B = B} {A = A} = record
-    { from = repack exp.product product
-    ; to   = repack product exp.product
-    ; iso  = record
-      { isoˡ = begin
-        repack product exp.product ∘ repack exp.product product
-          ≈⟨ [ exp.product ]⟨⟩∘ ⟩
-        [ exp.product ]⟨ π₁ ∘ repack exp.product product , π₂ ∘ repack exp.product product ⟩
-          ≈⟨ Product.⟨⟩-cong₂ exp.product project₁ project₂ ⟩
-        [ exp.product ]⟨ [ exp.product ]π₁ , [ exp.product ]π₂ ⟩
-          ≈⟨ Product.η exp.product ⟩
-        id
-          ∎
-      ; isoʳ = begin
-        repack exp.product product ∘ repack product exp.product
-          ≈⟨ ⟨⟩∘ ⟩
-        ⟨ [ exp.product ]π₁ ∘ repack product exp.product , [ exp.product ]π₂ ∘ repack product exp.product ⟩
-          ≈⟨ ⟨⟩-cong₂ (Product.project₁ exp.product) (Product.project₂ exp.product) ⟩
-        ⟨ π₁ , π₂ ⟩
-          ≈⟨ η ⟩
-        id
-          ∎
-      }
-    }
-
-  eval′ : B ^ A × A ⇒ B
-  eval′ = eval ∘ to
-    where open _≅_ B^A×A-iso
-
-  λ-unique′ : eval′ ∘ (f ⁂ id) ≈ g → f ≈ λg g
-  λ-unique′ eq = exp.λ-unique product (⟺ (pullʳ [ product ⇒ product ⇒ exp.product ]repack∘×) ○ eq)
-
-  λ-unique₂′ : eval′ ∘ (f ⁂ id) ≈ eval′ ∘ (g ⁂ id) → f ≈ g
-  λ-unique₂′ eq = (λ-unique′ eq) ○ ⟺ (λ-unique′ refl)
-
-  β′ : eval′ ∘ (λg f ⁂ id) ≈ f
-  β′ {f = f} = begin
-    eval′ ∘ (λg f ⁂ id) ≈⟨ pullʳ [ product ⇒ product ⇒ exp.product ]repack∘× ⟩
-    eval ∘ λg f ×id     ≈⟨ β ⟩
-    f                   ∎
-
-  η-exp′ : λg (eval′ ∘ (f ⁂ id)) ≈ f
-  η-exp′ = sym (λ-unique′ refl)
-
-  η-id′ : λg (eval′ {B = B} {A = A}) ≈ id
-  η-id′ = sym (λ-unique′ (elimʳ (id×id product)))
+  open exp public renaming (η to η-exp)
 
   ⊤^A≅⊤ : ⊤ ^ A ≅ ⊤
   ⊤^A≅⊤ = record
     { from = !
     ; to   = λg !
     ; iso  = record
-      { isoˡ = λ-unique₂ !-unique₂
+      { isoˡ = λ-unique′ !-unique₂
       ; isoʳ = ⊤-id _
       }
     }
 
   A^⊤≅A : A ^ ⊤ ≅ A
   A^⊤≅A = record
-    { from = let open _≅_ A×⊤≅A in eval′ ∘ to
+    { from = let open _≅_ A×⊤≅A in eval ∘ to
     ; to   = let open _≅_ A×⊤≅A in λg from
     ; iso  = record
-      { isoˡ = λ-unique₂′ $ begin
-        eval′ ∘ ((λg π₁ ∘ eval′ ∘ ⟨ id , ! ⟩) ⁂ id)          ≈˘⟨ refl⟩∘⟨ first∘first ⟩
-        eval′ ∘ ((λg π₁ ⁂ id) ∘ ((eval′ ∘ ⟨ id , ! ⟩) ⁂ id)) ≈⟨ pullˡ β′ ⟩
-        π₁ ∘ ((eval′ ∘ ⟨ id , ! ⟩) ⁂ id)                     ≈⟨ helper ⟩
-        eval′ ∘ (id ⁂ id)                                    ∎
+      { isoˡ = λ-unique′ $ begin
+        eval ∘ ((λg π₁ ∘ eval ∘ ⟨ id , ! ⟩) ⁂ id)          ≈˘⟨ refl⟩∘⟨ first∘first ⟩
+        eval ∘ ((λg π₁ ⁂ id) ∘ ((eval ∘ ⟨ id , ! ⟩) ⁂ id)) ≈⟨ pullˡ β ⟩
+        π₁ ∘ ((eval ∘ ⟨ id , ! ⟩) ⁂ id)                    ≈⟨ helper ⟩
+        eval ∘ (id ⁂ id)                                   ∎
       ; isoʳ = firstid ! $ begin
-        ((eval′ ∘ ⟨ id , ! ⟩) ∘ λg π₁) ⁂ id                  ≈˘⟨ first∘first ⟩
-        (eval′ ∘ ⟨ id , ! ⟩ ⁂ id) ∘ (λg π₁ ⁂ id)             ≈⟨ helper′ ⟩∘⟨refl ⟩
-        (⟨ id , ! ⟩ ∘ eval′) ∘ (λg π₁ ⁂ id)                  ≈⟨ pullʳ β′ ⟩
-        ⟨ id , ! ⟩ ∘ π₁                                      ≈⟨ ⟨⟩∘ ⟩
-        ⟨ id ∘ π₁ , ! ∘ π₁ ⟩                                 ≈⟨ ⟨⟩-cong₂ identityˡ !-unique₂ ⟩
-        ⟨ π₁ , π₂ ⟩                                          ≈⟨ η ⟩
-        id                                                   ∎
+        ((eval ∘ ⟨ id , ! ⟩) ∘ λg π₁) ⁂ id      ≈˘⟨ first∘first ⟩
+        (eval ∘ ⟨ id , ! ⟩ ⁂ id) ∘ (λg π₁ ⁂ id) ≈⟨ helper′ ⟩∘⟨refl ⟩
+        (⟨ id , ! ⟩ ∘ eval) ∘ (λg π₁ ⁂ id)      ≈⟨ pullʳ β ⟩
+        ⟨ id , ! ⟩ ∘ π₁                         ≈⟨ ⟨⟩∘ ⟩
+        ⟨ id ∘ π₁ , ! ∘ π₁ ⟩                    ≈⟨ ⟨⟩-cong₂ identityˡ !-unique₂ ⟩
+        ⟨ π₁ , π₂ ⟩                             ≈⟨ η ⟩
+        id                                      ∎
       }
     }
     where helper = begin
-            π₁ ∘ ((eval′ ∘ ⟨ id , ! ⟩) ⁂ id)                 ≈⟨ project₁ ⟩
-            (eval′ ∘ ⟨ id , ! ⟩) ∘ π₁                        ≈⟨ pullʳ ⟨⟩∘ ⟩
-            eval′ ∘ ⟨ id ∘ π₁ , ! ∘ π₁ ⟩                     ≈⟨ refl⟩∘⟨ ⟨⟩-congˡ !-unique₂ ⟩
-            eval′ ∘ (id ⁂ id)                                ∎
+            π₁ ∘ ((eval ∘ ⟨ id , ! ⟩) ⁂ id)                 ≈⟨ project₁ ⟩
+            (eval ∘ ⟨ id , ! ⟩) ∘ π₁                        ≈⟨ pullʳ ⟨⟩∘ ⟩
+            eval ∘ ⟨ id ∘ π₁ , ! ∘ π₁ ⟩                     ≈⟨ refl⟩∘⟨ ⟨⟩-congˡ !-unique₂ ⟩
+            eval ∘ (id ⁂ id)                                ∎
           helper′ = let open _≅_ A×⊤≅A in begin
-            (eval′ ∘ ⟨ id , ! ⟩) ⁂ id                        ≈⟨ introˡ isoˡ ⟩
-            (⟨ id , ! ⟩ ∘ π₁) ∘ ((eval′ ∘ ⟨ id , ! ⟩) ⁂ id)  ≈⟨ pullʳ helper ⟩
-            ⟨ id , ! ⟩ ∘ (eval′ ∘ (id ⁂ id))                 ≈⟨ refl⟩∘⟨ elimʳ (id×id product) ⟩
-            ⟨ id , ! ⟩ ∘ eval′                               ∎
+            (eval ∘ ⟨ id , ! ⟩) ⁂ id                        ≈⟨ introˡ isoˡ ⟩
+            (⟨ id , ! ⟩ ∘ π₁) ∘ ((eval ∘ ⟨ id , ! ⟩) ⁂ id)  ≈⟨ pullʳ helper ⟩
+            ⟨ id , ! ⟩ ∘ (eval ∘ (id ⁂ id))                 ≈⟨ refl⟩∘⟨ elimʳ id⁂id ⟩
+            ⟨ id , ! ⟩ ∘ eval                               ∎
 
   -- we use -⇨- to represent the bifunctor.
   -- -^- would generate a bifunctor of type Bifunctor 𝒞 𝒞.op 𝒞 which is not very typical.
@@ -190,24 +115,24 @@ record CartesianClosed : Set (levelOfTerm 𝒞) where
   -⇨- = record
     { F₀           = uncurry _⇨_
     ; F₁           = λ where
-      (f , g) → λg (g ∘ eval′ ∘ second f)
-    ; identity     = λ-cong (identityˡ ○ (elimʳ (id×id product))) ○ η-id′
-    ; homomorphism = λ-unique₂′ helper
+      (f , g) → λg (g ∘ eval ∘ second f)
+    ; identity     = λ-cong (identityˡ ○ (elimʳ id⁂id)) ○ η-id
+    ; homomorphism = λ-unique′ helper
     ; F-resp-≈     = λ where
       (eq₁ , eq₂) → λ-cong (∘-resp-≈ eq₂ (∘-resp-≈ʳ (⁂-cong₂ refl eq₁)))
     }
-    where helper : eval′ ∘ first (λg ((g ∘ f) ∘ eval′ ∘ second (h ∘ i)))
-                 ≈ eval′ ∘ first (λg (g ∘ eval′ ∘ second i) ∘ λg (f ∘ eval′ ∘ second h))
+    where helper : eval ∘ first (λg ((g ∘ f) ∘ eval ∘ second (h ∘ i)))
+                 ≈ eval ∘ first (λg (g ∘ eval ∘ second i) ∘ λg (f ∘ eval ∘ second h))
           helper {g = g} {f = f} {h = h} {i = i} = begin
-            eval′ ∘ first (λg ((g ∘ f) ∘ eval′ ∘ second (h ∘ i)))                         ≈⟨ β′ ⟩
-            (g ∘ f) ∘ eval′ ∘ second (h ∘ i)                                              ≈˘⟨ refl⟩∘⟨ pullʳ second∘second ⟩
-            (g ∘ f) ∘ (eval′ ∘ second h) ∘ second i                                       ≈⟨ center refl ⟩
-            g ∘ (f ∘ eval′ ∘ second h) ∘ second i                                         ≈˘⟨ refl⟩∘⟨ pullˡ β′ ⟩
-            g ∘ eval′ ∘ first (λg (f ∘ eval′ ∘ second h)) ∘ second i                      ≈⟨ refl⟩∘⟨ pushʳ first↔second ⟩
-            g ∘ (eval′ ∘ second i) ∘ first (λg (f ∘ eval′ ∘ second h))                    ≈⟨ sym-assoc ⟩
-            (g ∘ eval′ ∘ second i) ∘ first (λg (f ∘ eval′ ∘ second h))                    ≈˘⟨ pullˡ β′ ⟩
-            eval′ ∘ first (λg (g ∘ eval′ ∘ second i)) ∘ first (λg (f ∘ eval′ ∘ second h)) ≈⟨ refl⟩∘⟨ first∘first ⟩
-            eval′ ∘ first (λg (g ∘ eval′ ∘ second i) ∘ λg (f ∘ eval′ ∘ second h))         ∎
+            eval ∘ first (λg ((g ∘ f) ∘ eval ∘ second (h ∘ i)))                        ≈⟨ β ⟩
+            (g ∘ f) ∘ eval ∘ second (h ∘ i)                                            ≈˘⟨ refl⟩∘⟨ pullʳ second∘second ⟩
+            (g ∘ f) ∘ (eval ∘ second h) ∘ second i                                     ≈⟨ center refl ⟩
+            g ∘ (f ∘ eval ∘ second h) ∘ second i                                       ≈˘⟨ refl⟩∘⟨ pullˡ β ⟩
+            g ∘ eval ∘ first (λg (f ∘ eval ∘ second h)) ∘ second i                     ≈⟨ refl⟩∘⟨ pushʳ first↔second ⟩
+            g ∘ (eval ∘ second i) ∘ first (λg (f ∘ eval ∘ second h))                   ≈⟨ sym-assoc ⟩
+            (g ∘ eval ∘ second i) ∘ first (λg (f ∘ eval ∘ second h))                   ≈˘⟨ pullˡ β ⟩
+            eval ∘ first (λg (g ∘ eval ∘ second i)) ∘ first (λg (f ∘ eval ∘ second h)) ≈⟨ refl⟩∘⟨ first∘first ⟩
+            eval ∘ first (λg (g ∘ eval ∘ second i) ∘ λg (f ∘ eval ∘ second h))         ∎
 
   _⇨- : Obj → Endofunctor 𝒞
   _⇨- = appˡ -⇨-
@@ -222,7 +147,7 @@ module CartesianMonoidalClosed (cartesianClosed : CartesianClosed) where
   open CartesianClosed cartesianClosed
   open CartesianMonoidal cartesian using (monoidal)
   open BinaryProducts (Cartesian.products cartesian)
-    using (-×_; first; first∘first; second; first↔second; product)
+    using (-×_; first; first∘first; second; first↔second; product; id⁂id)
 
   private
     A⇨[-×A] : Obj → Endofunctor 𝒞
@@ -241,50 +166,53 @@ module CartesianMonoidalClosed (cartesianClosed : CartesianClosed) where
     ; adjoint = λ {A} → record
       { unit   = ntHelper record
         { η       = λ _ → λg id
-        ; commute = λ f → λ-unique₂′ $ begin
-          eval′ ∘ first (λg id ∘ f)                     ≈˘⟨ refl⟩∘⟨ first∘first ⟩
-          eval′ ∘ first (λg id) ∘ first f               ≈⟨ cancelˡ β′ ⟩
-          first f                                       ≈˘⟨ cancelʳ β′ ⟩
-          (first f ∘ eval′)  ∘ first (λg id)            ≈˘⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
-          (first f ∘ eval′ ∘ first id)  ∘ first (λg id) ≈˘⟨ pullˡ β′ ⟩
-          eval′ ∘ first (A⇨[-×A].F₁ f) ∘ first (λg id)  ≈⟨ refl⟩∘⟨ first∘first ⟩
-          eval′ ∘ first (A⇨[-×A].F₁ f ∘ λg id)          ∎
+        ; commute = λ f → λ-unique′ $ begin
+          eval ∘ first (λg id ∘ f)                     ≈˘⟨ refl⟩∘⟨ first∘first ⟩
+          eval ∘ first (λg id) ∘ first f               ≈⟨ cancelˡ β ⟩
+          first f                                      ≈˘⟨ cancelʳ β ⟩
+          (first f ∘ eval) ∘ first (λg id)             ≈˘⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
+          (first f ∘ eval ∘ first id)  ∘ first (λg id) ≈˘⟨ pullˡ β ⟩
+          eval ∘ first (A⇨[-×A].F₁ f) ∘ first (λg id)  ≈⟨ refl⟩∘⟨ first∘first ⟩
+          eval ∘ first (A⇨[-×A].F₁ f ∘ λg id)          ∎
         }
       ; counit = ntHelper record
-        { η       = λ _ → eval′
+        { η       = λ _ → eval
         ; commute = λ f → begin
-          eval′ ∘ [A⇨-]×A.F₁ f ≈⟨ β′ ⟩
-          f ∘ eval′ ∘ first id ≈⟨ refl⟩∘⟨ elimʳ (id×id product) ⟩
-          f ∘ eval′            ∎
+          eval ∘ [A⇨-]×A.F₁ f ≈⟨ β ⟩
+          f ∘ eval ∘ first id ≈⟨ refl⟩∘⟨ elimʳ (id×id product) ⟩
+          f ∘ eval            ∎
         }
-      ; zig    = β′
-      ; zag    = λ-unique₂′ $ begin
-        eval′ ∘ first (λg (eval′ ∘ eval′ ∘ second id) ∘ λg id)
-                                        ≈˘⟨ refl⟩∘⟨ first∘first ⟩
-        eval′ ∘ first (λg (eval′ ∘ eval′ ∘ second id)) ∘ first (λg id)
-                                        ≈⟨ pullˡ β′ ⟩
-        (eval′ ∘ eval′ ∘ second id) ∘ first (λg id)
-                                        ≈⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
-        (eval′ ∘ eval′) ∘ first (λg id) ≈⟨ cancelʳ β′ ⟩
-        eval′                           ≈˘⟨ elimʳ (id×id product) ⟩
-        eval′ ∘ first id                ∎
+      ; zig    = β
+      ; zag    = λ-unique′ $ begin
+        eval ∘ first (λg (eval ∘ eval ∘ second id) ∘ λg id)
+          ≈˘⟨ refl⟩∘⟨ first∘first ⟩
+        eval ∘ first (λg (eval ∘ eval ∘ second id)) ∘ first (λg id)
+          ≈⟨ pullˡ β ⟩
+        (eval ∘ eval ∘ second id) ∘ first (λg id)
+          ≈⟨ ∘-resp-≈ʳ (elimʳ id⁂id) ⟩∘⟨refl ⟩
+        (eval ∘ eval) ∘ first (λg id) 
+          ≈⟨ cancelʳ β ⟩
+        eval
+          ≈˘⟨ elimʳ (id×id product) ⟩
+        eval ∘ first id
+          ∎
       }
     ; mate    = λ {X Y} f → record
-      { commute₁ = λ-unique₂′ $ begin
-        eval′ ∘ first (λg (second f ∘ eval′ ∘ second id) ∘ λg id)         ≈˘⟨ refl⟩∘⟨ first∘first ⟩
-        eval′ ∘ first (λg (second f ∘ eval′ ∘ second id)) ∘ first (λg id) ≈⟨ pullˡ β′ ⟩
-        (second f ∘ eval′ ∘ second id) ∘ first (λg id)                    ≈⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
-        (second f ∘ eval′) ∘ first (λg id)                                ≈⟨ cancelʳ β′ ⟩
-        second f                                                          ≈˘⟨ cancelˡ β′ ⟩
-        eval′ ∘ first (λg id) ∘ second f                                  ≈⟨ pushʳ first↔second ⟩
-        (eval′ ∘ second f) ∘ first (λg id)                                ≈˘⟨ identityˡ ⟩∘⟨refl ⟩
-        (id ∘ eval′ ∘ second f) ∘ first (λg id)                           ≈˘⟨ pullˡ β′ ⟩
-        eval′ ∘ first (λg (id ∘ eval′ ∘ second f)) ∘ first (λg id)        ≈⟨ refl⟩∘⟨ first∘first ⟩
-        eval′ ∘ first (λg (id ∘ eval′ ∘ second f) ∘ λg id)                ∎
+      { commute₁ = λ-unique′ $ begin
+        eval ∘ first (λg (second f ∘ eval ∘ second id) ∘ λg id)         ≈˘⟨ refl⟩∘⟨ first∘first ⟩
+        eval ∘ first (λg (second f ∘ eval ∘ second id)) ∘ first (λg id) ≈⟨ pullˡ β ⟩
+        (second f ∘ eval ∘ second id) ∘ first (λg id)                   ≈⟨ ∘-resp-≈ʳ (elimʳ (id×id product)) ⟩∘⟨refl ⟩
+        (second f ∘ eval) ∘ first (λg id)                               ≈⟨ cancelʳ β ⟩
+        second f                                                        ≈˘⟨ cancelˡ β ⟩
+        eval ∘ first (λg id) ∘ second f                                 ≈⟨ pushʳ first↔second ⟩
+        (eval ∘ second f) ∘ first (λg id)                               ≈˘⟨ identityˡ ⟩∘⟨refl ⟩
+        (id ∘ eval ∘ second f) ∘ first (λg id)                          ≈˘⟨ pullˡ β ⟩
+        eval ∘ first (λg (id ∘ eval ∘ second f)) ∘ first (λg id)        ≈⟨ refl⟩∘⟨ first∘first ⟩
+        eval ∘ first (λg (id ∘ eval ∘ second f) ∘ λg id)                ∎
       ; commute₂ = begin
-        eval′ ∘ first (λg (id ∘ eval′ ∘ second f)) ≈⟨ β′ ⟩
-        id ∘ eval′ ∘ second f                      ≈⟨ identityˡ ⟩
-        eval′ ∘ second f                           ∎
+        eval ∘ first (λg (id ∘ eval ∘ second f)) ≈⟨ β ⟩
+        id ∘ eval ∘ second f                     ≈⟨ identityˡ ⟩
+        eval ∘ second f                          ∎
       }
     }
 

--- a/src/Categories/Category/CartesianClosed/Canonical.agda
+++ b/src/Categories/Category/CartesianClosed/Canonical.agda
@@ -22,7 +22,7 @@ open import Function using (flip)
 open import Categories.Category.BinaryProducts 𝒞
 open import Categories.Category.Cartesian 𝒞 using (Cartesian)
 import Categories.Category.CartesianClosed 𝒞 as 𝒞-CC
-open import Categories.Object.Exponential 𝒞 using (Exponential)
+import Categories.Object.Exponential.Canonical as Exponentials
 open import Categories.Object.Product 𝒞
 open import Categories.Object.Terminal 𝒞 using (Terminal)
 open import Categories.Morphism.Reasoning 𝒞
@@ -82,6 +82,8 @@ record CartesianClosed : Set (levelOfTerm 𝒞) where
 
   open Cartesian isCartesian using (_⁂_)
 
+  open Exponentials isCartesian using (Exponential)
+
   field
 
     -- Canonical exponentials (w.r.t. the canonical products)
@@ -98,33 +100,14 @@ record CartesianClosed : Set (levelOfTerm 𝒞) where
   curry-resp-≈ f≈g = curry-unique (eval-comp ○ f≈g)
 
   -- The above defines canonical exponentials, making 𝒞 cartesian closed.
-  --
-  -- NOTE: below we use "⊗" to indicate "non-canonical" products.
 
   ^-exponential : ∀ {A B} → Exponential A B
   ^-exponential {A} {B} = record
     { B^A      = B ^ A
-    ; product  = ×-product
     ; eval     = eval
-    ; λg       = λ C⊗A f → curry (f ∘ repack ×-product C⊗A)
-    ; β        = λ {C} C⊗A {g} →
-      begin
-        eval ∘ [ C⊗A ⇒ ×-product ] curry (g ∘ repack ×-product C⊗A) ×id
-      ≈˘⟨ pullʳ [ ×-product ⇒ ×-product ]×∘⟨⟩ ⟩
-        (eval ∘ (curry (g ∘ repack ×-product C⊗A) ⁂ id)) ∘ repack C⊗A ×-product
-      ≈⟨ eval-comp ⟩∘⟨refl ⟩
-        (g ∘ repack ×-product C⊗A) ∘ repack C⊗A ×-product
-      ≈⟨ cancelʳ (repack∘repack≈id ×-product C⊗A) ⟩
-        g
-      ∎
-    ; λ-unique = λ {C} C⊗A {g} {f} hyp →
-      curry-unique (begin
-        eval ∘ (f ⁂ id)
-      ≈˘⟨ pullʳ [ C⊗A ⇒ ×-product ]×∘⟨⟩ ⟩
-        (eval ∘ [ C⊗A ⇒ ×-product ] f ×id) ∘ repack ×-product C⊗A
-      ≈⟨ hyp ⟩∘⟨refl ⟩
-        g ∘ repack ×-product C⊗A
-      ∎)
+    ; λg       = λ f → curry f
+    ; β        = eval-comp
+    ; λ-unique = curry-unique
     }
 
 module Equivalence where
@@ -151,10 +134,10 @@ module Equivalence where
     ; π₂-comp    = project₂
     ; ⟨,⟩-unique = unique
     ; _^_   = _^_
-    ; eval  = eval′
+    ; eval  = eval
     ; curry = λg
-    ; eval-comp    = β′
-    ; curry-unique = λ-unique′
+    ; eval-comp    = β
+    ; curry-unique = λ-unique
     }
     where
       open CartesianClosed′ cc

--- a/src/Categories/Category/CartesianClosed/Locally.agda
+++ b/src/Categories/Category/CartesianClosed/Locally.agda
@@ -15,7 +15,7 @@ open import Categories.Category.Slice C
 open import Categories.Category.Slice.Properties C
 
 open import Categories.Object.Product
-open import Categories.Object.Exponential
+import Categories.Object.Exponential.Canonical as Exponentials
 open import Categories.Object.Terminal
 import Categories.Diagram.Pullback as P
 import Categories.Diagram.Pullback.Properties C as Pₚ
@@ -69,57 +69,52 @@ record Locally : Set (levelOfTerm C) where
 
 module _ (LCCC : Locally) (t : Terminal C) where
   open Locally LCCC
-  open Terminal t
   open HomReasoning
   open Equiv
 
   cartesian : Cartesian C
   cartesian = record
     { terminal = t
-    ; products = record { product = Pₚ.pullback-⊤⇒product t (product⇒pullback (sliceProd.product ⊤)) }
+    ; products = record { product = Pₚ.pullback-⊤⇒product t (product⇒pullback (sliceProd.product (Terminal.⊤ t))) }
     }
+
+  open Cartesian cartesian
 
   cartesianClosed : CartesianClosed C
   cartesianClosed = record
     { cartesian = cartesian
     ; exp       = λ {A B} →
       let open Exponential (exp {sliceobj (! {A})} {sliceobj (! {B})})
+               renaming (eval to slice-eval; λg to slice-λg; β to slice-β)
       in record
       { B^A      = Y B^A
-      ; product  =
-        -- this is tricky. how product is implemented requires special care. for example, the following
-        -- code also gives a product that type checks, but it is impossible to work with.
-        -- Pₚ.pullback-⊤⇒product t (Pₚ.pullback-resp-≈ (product⇒pullback product) !-unique₂ refl)
-        --
-        -- another quirk of proof relevance.
-        let open Product (Slice ⊤) (exp.product {sliceobj (! {A})} {sliceobj (! {B})})
-        in record
-           { A×B      = Y A×B
-           ; π₁       = h π₁
-           ; π₂       = h π₂
-           ; ⟨_,_⟩    = λ f g → h ⟨ slicearr {h = f} (⟺ (!-unique _)) , slicearr {h = g} (⟺ (!-unique _)) ⟩
-           ; project₁ = project₁
-           ; project₂ = project₂
-           ; unique   = unique {h = slicearr (⟺ (!-unique _))}
-           }
-      ; eval     = h eval
-      ; λg       = λ {X} p f → h (λg (pullback⇒product′ t (Pₚ.product⇒pullback-⊤ t p)) (lift t f))
-                         -- what looks like an identity proof below is not quite, as it is not
-                         -- "proof relevant", the 2 underlying arrows contain different proofs.
-      ; β        = λ p → ∘-resp-≈ʳ (exp.product.⟨⟩-cong₂ refl refl) ○
-                         β (pullback⇒product′ t (Pₚ.product⇒pullback-⊤ t p))
-      ; λ-unique = λ p eq → λ-unique (pullback⇒product′ t (Pₚ.product⇒pullback-⊤ t p))
-                                     {h = slicearr (⟺ (!-unique _))}
-                                     (∘-resp-≈ʳ (exp.product.⟨⟩-cong₂ refl refl) ○ eq)
+      ; eval     = h (slice-eval ∘ˢ ⟨ slicearr {h = π₁} (⟺ (!-unique _)) , slicearr {h = π₂} (⟺ (!-unique _)) ⟩ˢ)
+      ; λg       = λ {X} f → h (slice-λg (slicearr {h = f} (Terminal.!-unique₂ t))) 
+      ; β        = λ {g = g} → begin 
+        h (slice-eval ∘ˢ ⟨ slicearr {h = π₁} (⟺ (!-unique _)) , slicearr {h = π₂} (⟺ (!-unique _)) ⟩ˢ) ∘ (h (slice-λg (slicearr (Terminal.!-unique₂ t))) ⁂ id) 
+          ≈⟨ refl ⟩ 
+        (h slice-eval ∘ h ⟨ slicearr {h = π₁} (⟺ (!-unique _)) , slicearr {h = π₂} (⟺ (!-unique _)) ⟩ˢ) ∘ (h (slice-λg (slicearr (Terminal.!-unique₂ t))) ⁂ id) 
+          ≈⟨ pullʳ (sym (uniqueˢ {h = slicearr !-unique₂} (pullˡ project₁ˢ ○ project₁) (pullˡ project₂ˢ ○ project₂))) ⟩ 
+        h slice-eval ∘ h (slice-λg (slicearr (Terminal.!-unique₂ t)) ⁂ˢ idˢ) ≈⟨ slice-β ⟩ 
+        g ∎
+      ; λ-unique = λ {g = f} {g} eq → λ-unique (begin
+        h slice-eval ∘ h (slicearr {h = g} !-unique₂ ⁂ˢ idˢ) 
+          ≈˘⟨ pullʳ (⟨⟩∘ˢ {h = slicearr !-unique₂} ○ ⟨⟩-cong₂ˢ project₁ project₂) ⟩ 
+        h (slice-eval ∘ˢ ⟨ slicearr {h = π₁} (⟺ (!-unique _)) , slicearr {h = π₂} (⟺ (!-unique _)) ⟩ˢ) ∘ (g ⁂ id) 
+          ≈⟨ eq ⟩ 
+        f ∎)
       }
     }
-    where open sliceCCC ⊤ using (exp)
+    where open sliceCCC ⊤ using (exp) renaming (cartesian to sliceCartesian)
+          open Exponentials sliceCartesian
           open SliceObj
           open Slice⇒
+          open MR C
+          open Cartesian sliceCartesian renaming 
+            (π₁ to π₁ˢ; π₂ to π₂ˢ; ⟨_,_⟩ to ⟨_,_⟩ˢ; _⁂_ to _⁂ˢ_; unique to uniqueˢ
+            ; project₁ to project₁ˢ; project₂ to project₂ˢ; ⟨⟩∘ to ⟨⟩∘ˢ; ⟨⟩-cong₂ to ⟨⟩-cong₂ˢ) 
+            using ()
+          open Category (Slice _) renaming (_∘_ to _∘ˢ_; id to idˢ) using ()
 
   finitelyComplete : FinitelyComplete
-  finitelyComplete = record
-    { cartesian = cartesian
-    ; equalizer = λ f g → prods×pullbacks⇒equalizers (Cartesian.products cartesian)
-                                                     (λ {_ _ X} h i → product⇒pullback (sliceProd.product X))
-    }
+  finitelyComplete = Pₚ.pullback-⊤⇒FinitelyComplete pullbacks t

--- a/src/Categories/Category/CartesianClosed/Properties.agda
+++ b/src/Categories/Category/CartesianClosed/Properties.agda
@@ -56,11 +56,11 @@ lawvere-fixed-point {A = A} {B = B} ϕ surjective f = g ∘ x , g-fixed-point
 
     g-fixed-point : f ∘ (g ∘ x) ≈ g ∘ x
     g-fixed-point = begin
-      f ∘ g ∘ x                       ≈˘⟨ refl⟩∘⟨ g-surjective ⟩
+      f ∘ g ∘ x                      ≈˘⟨ refl⟩∘⟨ g-surjective ⟩
       f ∘ eval ∘ first ϕ ∘ ⟨ x , x ⟩ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ lemma ϕ id x ⟩
       f ∘ eval ∘ ⟨ ϕ , id ⟩ ∘ x      ≈⟨ ∘-resp-≈ʳ sym-assoc ○ sym-assoc ⟩
       (f ∘ eval ∘ ⟨ ϕ , id ⟩) ∘ x    ≡⟨⟩
-      g ∘ x                           ∎
+      g ∘ x                          ∎
 
 initial→product-initial : ∀ {⊥ A} → IsInitial ⊥ → IsInitial (⊥ × A)
 initial→product-initial {⊥} {A} i = initial.⊥-is-initial

--- a/src/Categories/Category/CartesianClosed/Properties.agda
+++ b/src/Categories/Category/CartesianClosed/Properties.agda
@@ -23,7 +23,7 @@ open import Categories.Object.StrictInitial 𝒞 using (IsStrictInitial)
 open import Categories.Object.Terminal using (Terminal)
 
 open Category 𝒞
-open CartesianClosed 𝓥 using (_^_; eval′; cartesian)
+open CartesianClosed 𝓥 using (_^_; eval; cartesian)
 open Cartesian cartesian using (_×_; ⟨_,_⟩; π₁; π₂; project₁; project₂; first; _⁂_; ⊤; ⟨⟩∘; ⁂∘⟨⟩; -×_)
 open CartesianMonoidalClosed 𝒞 𝓥 using (closedMonoidal)
 
@@ -34,18 +34,18 @@ private
 
 PointSurjective : ∀ {A X Y : Obj} → (X ⇒ Y ^ A) → Set (ℓ ⊔ e)
 PointSurjective {A = A} {X = X} {Y = Y} ϕ =
-  ∀ (f : A ⇒ Y) → Σ[ x ∈ ⊤ ⇒ X ] (∀ (a : ⊤ ⇒ A) → eval′ ∘ first ϕ ∘ ⟨ x , a ⟩ ≈ f ∘ a)
+  ∀ (f : A ⇒ Y) → Σ[ x ∈ ⊤ ⇒ X ] (∀ (a : ⊤ ⇒ A) → eval ∘ first ϕ ∘ ⟨ x , a ⟩ ≈ f ∘ a)
 
 lawvere-fixed-point : ∀ {A B : Obj} → (ϕ : A ⇒ B ^ A) → PointSurjective ϕ → (f : B ⇒ B) → Σ[ s ∈ ⊤ ⇒ B ] f ∘ s ≈ s
 lawvere-fixed-point {A = A} {B = B} ϕ surjective f = g ∘ x , g-fixed-point
   where
     g : A ⇒ B
-    g = f ∘ eval′ ∘ ⟨ ϕ , id ⟩
+    g = f ∘ eval ∘ ⟨ ϕ , id ⟩
 
     x : ⊤ ⇒ A
     x = proj₁ (surjective  g)
 
-    g-surjective : eval′ ∘ first ϕ ∘ ⟨ x , x ⟩ ≈ g ∘ x
+    g-surjective : eval ∘ first ϕ ∘ ⟨ x , x ⟩ ≈ g ∘ x
     g-surjective = proj₂ (surjective g) x
 
     lemma : ∀ {A B C D} → (f : B ⇒ C) → (g : B ⇒ D) → (h : A ⇒ B) → (f ⁂ g) ∘ ⟨ h , h ⟩ ≈ ⟨ f , g ⟩ ∘ h
@@ -57,9 +57,9 @@ lawvere-fixed-point {A = A} {B = B} ϕ surjective f = g ∘ x , g-fixed-point
     g-fixed-point : f ∘ (g ∘ x) ≈ g ∘ x
     g-fixed-point = begin
       f ∘ g ∘ x                       ≈˘⟨ refl⟩∘⟨ g-surjective ⟩
-      f ∘ eval′ ∘ first ϕ ∘ ⟨ x , x ⟩ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ lemma ϕ id x ⟩
-      f ∘ eval′ ∘ ⟨ ϕ , id ⟩ ∘ x      ≈⟨ ∘-resp-≈ʳ sym-assoc ○ sym-assoc ⟩
-      (f ∘ eval′ ∘ ⟨ ϕ , id ⟩) ∘ x    ≡⟨⟩
+      f ∘ eval ∘ first ϕ ∘ ⟨ x , x ⟩ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ lemma ϕ id x ⟩
+      f ∘ eval ∘ ⟨ ϕ , id ⟩ ∘ x      ≈⟨ ∘-resp-≈ʳ sym-assoc ○ sym-assoc ⟩
+      (f ∘ eval ∘ ⟨ ϕ , id ⟩) ∘ x    ≡⟨⟩
       g ∘ x                           ∎
 
 initial→product-initial : ∀ {⊥ A} → IsInitial ⊥ → IsInitial (⊥ × A)

--- a/src/Categories/Functor/CartesianClosed.agda
+++ b/src/Categories/Functor/CartesianClosed.agda
@@ -20,14 +20,14 @@ record IsCartesianClosedF (C : CartesianClosedCategory o ℓ e) (D : CartesianCl
   private
     module C = CartesianClosedCategory C using (cartesianCategory; cartesianClosed)
     module D = CartesianClosedCategory D using (cartesianCategory; cartesianClosed; _⇒_; _∘_; U)
-    module CC = CartesianClosed C.cartesianClosed using (_^_; eval′)
+    module CC = CartesianClosed C.cartesianClosed using (_^_; eval)
     module DC = CartesianClosed D.cartesianClosed using (_^_; λg)
   field
     F-cartesian : IsCartesianF C.cartesianCategory D.cartesianCategory F
   open Functor F
   open IsCartesianF F-cartesian
   F-mor : ∀ A B → F₀ (A CC.^ B) D.⇒ F₀ A DC.^ F₀ B
-  F-mor A B = DC.λg (F₁ CC.eval′ D.∘ ×-iso.to (A CC.^ B) B)
+  F-mor A B = DC.λg (F₁ CC.eval D.∘ ×-iso.to (A CC.^ B) B)
   field
     F-closed : ∀ {A B} → M.IsIso D.U (F-mor A B)
 

--- a/src/Categories/Object/Exponential.agda
+++ b/src/Categories/Object/Exponential.agda
@@ -3,7 +3,9 @@ open import Categories.Category
 
 -- Exponential Object
 
--- TODO: Where is the notation from? It is neither from Wikipedia nor the nLab.
+-- NOTE: when working in a cartesian category, 
+-- you probably want to use Categories.Object.Exponential.Canonical
+
 module Categories.Object.Exponential {o ℓ e} (𝒞 : Category o ℓ e) where
 
 open Category 𝒞

--- a/src/Categories/Object/Exponential.agda
+++ b/src/Categories/Object/Exponential.agda
@@ -3,6 +3,7 @@ open import Categories.Category
 
 -- Exponential Object
 
+-- TODO: Where is the notation from? It is neither from Wikipedia nor the nLab.
 module Categories.Object.Exponential {o ℓ e} (𝒞 : Category o ℓ e) where
 
 open Category 𝒞
@@ -21,160 +22,158 @@ private
   variable
     A B C D X Y : Obj
 
-record Exponential (A B : Obj) (products : ∀ C → Product C A) : Set (o ⊔ ℓ ⊔ e) where
+record Exponential (A B : Obj) : Set (o ⊔ ℓ ⊔ e) where
   field
     B^A : Obj
+    product : Product B^A A
 
-  module product {X} = Product (products X)
+  module product = Product product
 
-  private 
-    _×A : Obj → Obj
-    X ×A = product.A×B {X}
-
-    _⁂id : ∀ {X Y : Obj} (f : X ⇒ Y) → (X ×A) ⇒ (Y ×A)
-    _⁂id {X} {Y} f = [ products X ⇒ products Y ] f × id 
+  B^A×A : Obj
+  B^A×A = product.A×B
 
   field
-    eval     : B^A ×A ⇒ B
-    λg       : (X ×A ⇒ B) → (X ⇒ B^A)
-    β        : ∀ {g : X ×A ⇒ B} → eval ∘ (λg g ⁂id) ≈ g
-    λ-unique : ∀ {g : X ×A ⇒ B} {h : X ⇒ B^A} →
-                 (eval ∘ (h ⁂id) ≈ g) → (h ≈ λg g)
+    eval     : B^A×A ⇒ B
+    λg       : ∀ (X×A : Product X A) → (Product.A×B X×A ⇒ B) → (X ⇒ B^A)
+    β        : ∀ (X×A : Product X A) {g : Product.A×B X×A ⇒ B} →
+                 (eval ∘ [ X×A ⇒ product ] λg X×A g ×id ≈ g)
+    λ-unique : ∀ (X×A : Product X A) {g : Product.A×B X×A ⇒ B} {h : X ⇒ B^A} →
+                 (eval ∘ [ X×A ⇒ product ] h ×id ≈ g) → (h ≈ λg X×A g)
 
-  η : ∀ {f : X ⇒ B^A } → λg (eval ∘ f ⁂id) ≈ f
-  η {f} = ⟺ (λ-unique Equiv.refl)
+  η : ∀ (X×A : Product X A) {f : X ⇒ B^A } → λg X×A (eval ∘ [ X×A ⇒ product ] f ×id) ≈ f
+  η X×A {f} = ⟺ (λ-unique X×A Equiv.refl)
 
-  λ-cong : ∀ {X : Obj} {f g : X ×A ⇒ B} →
-             f ≈ g → λg f ≈ λg g
-  λ-cong {f = f} {g = g} f≡g = λ-unique (β ○ f≡g)
+  λ-cong : ∀ {X : Obj} (X×A : Product X A) {f g} →
+             f ≈ g → λg X×A f ≈ λg X×A g
+  λ-cong X×A {f = f} {g = g} f≡g = λ-unique X×A (β X×A ○ f≡g)
 
-  λ-inj : ∀ {X : Obj} {f g : X ×A ⇒ B} → λg f ≈ λg g → f ≈ g
-  λ-inj {X} {f = f} {g = g} eq = begin
-    f                                      ≈˘⟨ β ⟩
-    eval ∘ λg f ⁂id                        ≈⟨ refl⟩∘⟨ [ products X ⇒ products B^A  ]×-cong₂ eq Equiv.refl ⟩
-    eval ∘ λg g ⁂id                        ≈⟨ β ⟩
+  λ-inj : ∀ {X : Obj} (X×A : Product X A) {f g} → λg X×A f ≈ λg X×A g → f ≈ g
+  λ-inj X×A {f = f} {g = g} eq = begin
+    f                                      ≈˘⟨ β X×A ⟩
+    eval ∘ [ X×A ⇒ product ] λg X×A f ×id  ≈⟨ refl⟩∘⟨ [ X×A ⇒ product  ]×-cong₂ eq Equiv.refl ⟩
+    eval ∘ [ X×A ⇒ product ] λg X×A g × id ≈⟨ β X×A ⟩
     g                                      ∎
 
-  subst : ∀ {Z} {f : B^A ×A ⇒ B} {g : Z ⇒ B^A} →
-            λg f ∘ g ≈ λg (f ∘ (g ⁂id))
-  subst {Z} {f} {g} = λ-unique (begin
-    eval ∘ (λg f ∘ g) ⁂id
-                           ≈˘⟨ refl⟩∘⟨ [ products Z ⇒ products B^A ⇒ products B^A ]×id∘×id ⟩
-    eval ∘ λg f ⁂id ∘ g ⁂id
-                           ≈⟨ pullˡ β ⟩
-    f ∘ g ⁂id ∎)
+  subst : ∀ (p₂ : Product C A) (p₃ : Product D A) {f g} →
+            λg p₃ f ∘ g ≈ λg p₂ (f ∘ [ p₂ ⇒ p₃ ] g ×id)
+  subst p₂ p₃ {f} {g} = λ-unique p₂ (begin
+    eval ∘ [ p₂ ⇒ product ] λg p₃ f ∘ g ×id
+                           ≈˘⟨ refl⟩∘⟨ [ p₂ ⇒ p₃ ⇒ product ]×id∘×id ⟩
+    eval ∘ [ p₃ ⇒ product ] λg p₃ f ×id ∘ [ p₂ ⇒ p₃ ] g ×id
+                           ≈⟨ pullˡ (β p₃) ⟩
+    f ∘ [ p₂ ⇒ p₃ ] g ×id ∎)
 
-  η-id : λg eval ≈ id
+  η-id : λg product eval ≈ id
   η-id = begin
-    λg eval            ≈˘⟨ identityʳ ⟩
-    λg eval ∘ id       ≈⟨ subst ⟩
-    λg (eval ∘ id ⁂id) ≈⟨ η ⟩
-    id                 ∎
+    λg product eval                                  ≈˘⟨ identityʳ ⟩
+    λg product eval ∘ id                             ≈⟨ subst _ _ ⟩
+    λg product (eval ∘ [ product ⇒ product ] id ×id) ≈⟨ η product ⟩
+    id                                               ∎
 
-  λ-unique′ : ∀ {h i : X ⇒ B^A} →
-                eval ∘ h ⁂id ≈ eval ∘ i ⁂id → h ≈ i
-  λ-unique′ eq = λ-unique eq ○ (⟺ (λ-unique Equiv.refl))
+  λ-unique′ : ∀ (X×A : Product X A) {h i : X ⇒ B^A} →
+                eval ∘ [ X×A ⇒ product ] h ×id ≈ eval ∘ [ X×A ⇒ product ] i ×id → h ≈ i
+  λ-unique′ p eq = λ-unique p eq ○ (⟺ (λ-unique p Equiv.refl))
 
--- -- some aliases to make proof signatures less ugly
--- [_]eval : ∀{A B}(e₁ : Exponential A B) → ? ⇒ B
--- [ e₁ ]eval = Exponential.eval e₁
+-- some aliases to make proof signatures less ugly
+[_]eval : ∀{A B}(e₁ : Exponential A B) → Exponential.B^A×A e₁ ⇒ B
+[ e₁ ]eval = Exponential.eval e₁
 
--- [_]λ : ∀{A B}(e₁ : Exponential A B)
---   → {X : Obj} → (X×A : Product X A) → (Product.A×B X×A ⇒ B) → (X ⇒ Exponential.B^A e₁)
--- [ e₁ ]λ = Exponential.λg e₁
+[_]λ : ∀{A B}(e₁ : Exponential A B)
+  → {X : Obj} → (X×A : Product X A) → (Product.A×B X×A ⇒ B) → (X ⇒ Exponential.B^A e₁)
+[ e₁ ]λ = Exponential.λg e₁
 
--- {-
---    D×C --id × f--> D×A --g--> B
+{-
+   D×C --id × f--> D×A --g--> B
 
---    D --λ (g ∘ id × f)--> B^C
---     \                   ^
---      \                 /
---      λ g       λ (e ∘ id × f)
---        \        /
---         v      /
---           B^A
--- -}
--- λ-distrib : ∀ (e₁ : Exponential C B) (e₂ : Exponential A B)
---               (p₃ : Product D C) (p₄ : Product D A) (p₅ : Product (Exponential.B^A e₂) C)
---               {f} {g : Product.A×B p₄ ⇒ B} →
---               [ e₁ ]λ p₃ (g ∘ [ p₃ ⇒ p₄ ]id× f)
---               ≈ [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ Exponential.product e₂ ]id× f) ∘ [ e₂ ]λ p₄ g
--- λ-distrib e₁ e₂ p₃ p₄ p₅ {f} {g} = ⟺ $ e₁.λ-unique p₃ $ begin
---   [ e₁ ]eval ∘ ([ p₃ ⇒ p₁ ] [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f) ∘ [ e₂ ]λ p₄ g ×id)
---                        ≈˘⟨ refl⟩∘⟨ [ p₃ ⇒ p₅ ⇒ p₁ ]×id∘×id ⟩
---   [ e₁ ]eval ∘ [ p₅ ⇒ p₁ ] [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f) ×id
---              ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
---                        ≈⟨ pullˡ (e₁.β p₅) ⟩
---   ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f)
---               ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
---                        ≈⟨ assoc ⟩
---   [ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f
---              ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
---                        ≈˘⟨ refl⟩∘⟨ [ p₄ ⇒ p₂ , p₃ ⇒ p₅ ]first↔second ⟩
---   [ e₂ ]eval ∘ [ p₄ ⇒ p₂ ] [ e₂ ]λ p₄ g ×id ∘ [ p₃ ⇒ p₄ ]id× f
---                        ≈⟨ pullˡ (e₂.β p₄) ⟩
---   g ∘ [ p₃ ⇒ p₄ ]id× f ∎
---   where module e₁ = Exponential e₁
---         module e₂ = Exponential e₂
---         p₁        = e₁.product
---         p₂        = e₂.product
+   D --λ (g ∘ id × f)--> B^C
+    \                   ^
+     \                 /
+     λ g       λ (e ∘ id × f)
+       \        /
+        v      /
+          B^A
+-}
+λ-distrib : ∀ (e₁ : Exponential C B) (e₂ : Exponential A B)
+              (p₃ : Product D C) (p₄ : Product D A) (p₅ : Product (Exponential.B^A e₂) C)
+              {f} {g : Product.A×B p₄ ⇒ B} →
+              [ e₁ ]λ p₃ (g ∘ [ p₃ ⇒ p₄ ]id× f)
+              ≈ [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ Exponential.product e₂ ]id× f) ∘ [ e₂ ]λ p₄ g
+λ-distrib e₁ e₂ p₃ p₄ p₅ {f} {g} = ⟺ $ e₁.λ-unique p₃ $ begin
+  [ e₁ ]eval ∘ ([ p₃ ⇒ p₁ ] [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f) ∘ [ e₂ ]λ p₄ g ×id)
+                       ≈˘⟨ refl⟩∘⟨ [ p₃ ⇒ p₅ ⇒ p₁ ]×id∘×id ⟩
+  [ e₁ ]eval ∘ [ p₅ ⇒ p₁ ] [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f) ×id
+             ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
+                       ≈⟨ pullˡ (e₁.β p₅) ⟩
+  ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f)
+              ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
+                       ≈⟨ assoc ⟩
+  [ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f
+             ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
+                       ≈˘⟨ refl⟩∘⟨ [ p₄ ⇒ p₂ , p₃ ⇒ p₅ ]first↔second ⟩
+  [ e₂ ]eval ∘ [ p₄ ⇒ p₂ ] [ e₂ ]λ p₄ g ×id ∘ [ p₃ ⇒ p₄ ]id× f
+                       ≈⟨ pullˡ (e₂.β p₄) ⟩
+  g ∘ [ p₃ ⇒ p₄ ]id× f ∎
+  where module e₁ = Exponential e₁
+        module e₂ = Exponential e₂
+        p₁        = e₁.product
+        p₂        = e₂.product
 
--- repack : ∀{A B} (e₁ e₂ : Exponential A B) → Exponential.B^A e₁ ⇒ Exponential.B^A e₂
--- repack e₁ e₂ = e₂.λg e₁.product e₁.eval
---   where
---     module e₁ = Exponential e₁
---     module e₂ = Exponential e₂
+repack : ∀{A B} (e₁ e₂ : Exponential A B) → Exponential.B^A e₁ ⇒ Exponential.B^A e₂
+repack e₁ e₂ = e₂.λg e₁.product e₁.eval
+  where
+    module e₁ = Exponential e₁
+    module e₂ = Exponential e₂
 
--- repack≡id : ∀{A B} (e : Exponential A B) → repack e e ≈ id
--- repack≡id = Exponential.η-id
+repack≡id : ∀{A B} (e : Exponential A B) → repack e e ≈ id
+repack≡id = Exponential.η-id
 
--- repack∘ : ∀ (e₁ e₂ e₃ : Exponential A B) → repack e₂ e₃ ∘ repack e₁ e₂ ≈ repack e₁ e₃
--- repack∘ e₁ e₂ e₃ =
---   let p₁ = product e₁ in
---   let p₂ = product e₂ in
---   begin
---       [ e₃ ]λ p₂ [ e₂ ]eval
---     ∘ [ e₂ ]λ p₁ [ e₁ ]eval
---   ≈⟨ λ-cong e₃ p₂ (introʳ (second-id p₂)) ⟩∘⟨refl ⟩
---       [ e₃ ]λ p₂ ([ e₂ ]eval ∘ [ p₂ ⇒ p₂ ]id× id)
---     ∘ [ e₂ ]λ p₁ [ e₁ ]eval
---   ≈˘⟨ λ-distrib e₃ e₂ p₁ p₁ p₂ ⟩
---     [ e₃ ]λ p₁ ([ e₁ ]eval ∘ [ p₁ ⇒ p₁ ]id× id)
---   ≈⟨ λ-cong e₃ p₁ (⟺ (introʳ (second-id (product e₁)))) ⟩
---     [ e₃ ]λ p₁ [ e₁ ]eval
---   ∎
---   where open Exponential
+repack∘ : ∀ (e₁ e₂ e₃ : Exponential A B) → repack e₂ e₃ ∘ repack e₁ e₂ ≈ repack e₁ e₃
+repack∘ e₁ e₂ e₃ =
+  let p₁ = product e₁ in
+  let p₂ = product e₂ in
+  begin
+      [ e₃ ]λ p₂ [ e₂ ]eval
+    ∘ [ e₂ ]λ p₁ [ e₁ ]eval
+  ≈⟨ λ-cong e₃ p₂ (introʳ (second-id p₂)) ⟩∘⟨refl ⟩
+      [ e₃ ]λ p₂ ([ e₂ ]eval ∘ [ p₂ ⇒ p₂ ]id× id)
+    ∘ [ e₂ ]λ p₁ [ e₁ ]eval
+  ≈˘⟨ λ-distrib e₃ e₂ p₁ p₁ p₂ ⟩
+    [ e₃ ]λ p₁ ([ e₁ ]eval ∘ [ p₁ ⇒ p₁ ]id× id)
+  ≈⟨ λ-cong e₃ p₁ (⟺ (introʳ (second-id (product e₁)))) ⟩
+    [ e₃ ]λ p₁ [ e₁ ]eval
+  ∎
+  where open Exponential
 
--- repack-cancel : ∀{A B} (e₁ e₂ : Exponential A B) → repack e₁ e₂ ∘ repack e₂ e₁ ≈ id
--- repack-cancel e₁ e₂ = repack∘ e₂ e₁ e₂ ○ repack≡id e₂
+repack-cancel : ∀{A B} (e₁ e₂ : Exponential A B) → repack e₁ e₂ ∘ repack e₂ e₁ ≈ id
+repack-cancel e₁ e₂ = repack∘ e₂ e₁ e₂ ○ repack≡id e₂
 
--- up-to-iso : ∀{A B} (e₁ e₂ : Exponential A B) → Exponential.B^A e₁ ≅ Exponential.B^A e₂
--- up-to-iso e₁ e₂ = record
---   { from = repack e₁ e₂
---   ; to   = repack e₂ e₁
---   ; iso  = record
---     { isoˡ = repack-cancel e₂ e₁
---     ; isoʳ = repack-cancel e₁ e₂
---     }
---   }
+up-to-iso : ∀{A B} (e₁ e₂ : Exponential A B) → Exponential.B^A e₁ ≅ Exponential.B^A e₂
+up-to-iso e₁ e₂ = record
+  { from = repack e₁ e₂
+  ; to   = repack e₂ e₁
+  ; iso  = record
+    { isoˡ = repack-cancel e₂ e₁
+    ; isoʳ = repack-cancel e₁ e₂
+    }
+  }
 
--- transport-by-iso : ∀ (e : Exponential A B) → Exponential.B^A e ≅ X → Exponential A B
--- transport-by-iso {X = X} e e≅X = record
---   { B^A             = X
---   ; product         = X×A
---   ; eval            = e.eval
---   ; λg              = λ Y×A Y×A⇒B → from ∘ (e.λg Y×A Y×A⇒B)
---   ; β               = λ Y×A {h} → begin
---     e.eval ∘ [ Y×A ⇒ X×A ] from ∘ e.λg Y×A h ×id ≈⟨ refl⟩∘⟨ e.product.⟨⟩-cong₂ (pullˡ (cancelˡ isoˡ))
---                                                                               (elimˡ Equiv.refl) ⟩
---     e.eval ∘ [ Y×A ⇒ e.product ] e.λg Y×A h ×id  ≈⟨ e.β Y×A ⟩
---     h                                            ∎
---   ; λ-unique        = λ Y×A {h} {i} eq →
---     switch-tofromˡ e≅X $ e.λ-unique Y×A $ begin
---       e.eval ∘ [ Y×A ⇒ e.product ] to ∘ i ×id    ≈⟨ refl⟩∘⟨ e.product.⟨⟩-cong₂ assoc (introˡ Equiv.refl) ⟩
---       e.eval ∘ [ Y×A ⇒ X×A ] i ×id               ≈⟨ eq ⟩
---       h                                          ∎
---   }
---   where module e = Exponential e
---         X×A      = Mobile e.product e≅X ≅.refl
---         open _≅_ e≅X
+transport-by-iso : ∀ (e : Exponential A B) → Exponential.B^A e ≅ X → Exponential A B
+transport-by-iso {X = X} e e≅X = record
+  { B^A             = X
+  ; product         = X×A
+  ; eval            = e.eval
+  ; λg              = λ Y×A Y×A⇒B → from ∘ (e.λg Y×A Y×A⇒B)
+  ; β               = λ Y×A {h} → begin
+    e.eval ∘ [ Y×A ⇒ X×A ] from ∘ e.λg Y×A h ×id ≈⟨ refl⟩∘⟨ e.product.⟨⟩-cong₂ (pullˡ (cancelˡ isoˡ))
+                                                                              (elimˡ Equiv.refl) ⟩
+    e.eval ∘ [ Y×A ⇒ e.product ] e.λg Y×A h ×id  ≈⟨ e.β Y×A ⟩
+    h                                            ∎
+  ; λ-unique        = λ Y×A {h} {i} eq →
+    switch-tofromˡ e≅X $ e.λ-unique Y×A $ begin
+      e.eval ∘ [ Y×A ⇒ e.product ] to ∘ i ×id    ≈⟨ refl⟩∘⟨ e.product.⟨⟩-cong₂ assoc (introˡ Equiv.refl) ⟩
+      e.eval ∘ [ Y×A ⇒ X×A ] i ×id               ≈⟨ eq ⟩
+      h                                          ∎
+  }
+  where module e = Exponential e
+        X×A      = Mobile e.product e≅X ≅.refl
+        open _≅_ e≅X

--- a/src/Categories/Object/Exponential.agda
+++ b/src/Categories/Object/Exponential.agda
@@ -3,7 +3,6 @@ open import Categories.Category
 
 -- Exponential Object
 
--- TODO: Where is the notation from? It is neither from Wikipedia nor the nLab.
 module Categories.Object.Exponential {o ℓ e} (𝒞 : Category o ℓ e) where
 
 open Category 𝒞
@@ -22,158 +21,160 @@ private
   variable
     A B C D X Y : Obj
 
-record Exponential (A B : Obj) : Set (o ⊔ ℓ ⊔ e) where
+record Exponential (A B : Obj) (products : ∀ C → Product C A) : Set (o ⊔ ℓ ⊔ e) where
   field
     B^A : Obj
-    product : Product B^A A
 
-  module product = Product product
+  module product {X} = Product (products X)
 
-  B^A×A : Obj
-  B^A×A = product.A×B
+  private 
+    _×A : Obj → Obj
+    X ×A = product.A×B {X}
+
+    _⁂id : ∀ {X Y : Obj} (f : X ⇒ Y) → (X ×A) ⇒ (Y ×A)
+    _⁂id {X} {Y} f = [ products X ⇒ products Y ] f × id 
 
   field
-    eval     : B^A×A ⇒ B
-    λg       : ∀ (X×A : Product X A) → (Product.A×B X×A ⇒ B) → (X ⇒ B^A)
-    β        : ∀ (X×A : Product X A) {g : Product.A×B X×A ⇒ B} →
-                 (eval ∘ [ X×A ⇒ product ] λg X×A g ×id ≈ g)
-    λ-unique : ∀ (X×A : Product X A) {g : Product.A×B X×A ⇒ B} {h : X ⇒ B^A} →
-                 (eval ∘ [ X×A ⇒ product ] h ×id ≈ g) → (h ≈ λg X×A g)
+    eval     : B^A ×A ⇒ B
+    λg       : (X ×A ⇒ B) → (X ⇒ B^A)
+    β        : ∀ {g : X ×A ⇒ B} → eval ∘ (λg g ⁂id) ≈ g
+    λ-unique : ∀ {g : X ×A ⇒ B} {h : X ⇒ B^A} →
+                 (eval ∘ (h ⁂id) ≈ g) → (h ≈ λg g)
 
-  η : ∀ (X×A : Product X A) {f : X ⇒ B^A } → λg X×A (eval ∘ [ X×A ⇒ product ] f ×id) ≈ f
-  η X×A {f} = ⟺ (λ-unique X×A Equiv.refl)
+  η : ∀ {f : X ⇒ B^A } → λg (eval ∘ f ⁂id) ≈ f
+  η {f} = ⟺ (λ-unique Equiv.refl)
 
-  λ-cong : ∀ {X : Obj} (X×A : Product X A) {f g} →
-             f ≈ g → λg X×A f ≈ λg X×A g
-  λ-cong X×A {f = f} {g = g} f≡g = λ-unique X×A (β X×A ○ f≡g)
+  λ-cong : ∀ {X : Obj} {f g : X ×A ⇒ B} →
+             f ≈ g → λg f ≈ λg g
+  λ-cong {f = f} {g = g} f≡g = λ-unique (β ○ f≡g)
 
-  λ-inj : ∀ {X : Obj} (X×A : Product X A) {f g} → λg X×A f ≈ λg X×A g → f ≈ g
-  λ-inj X×A {f = f} {g = g} eq = begin
-    f                                      ≈˘⟨ β X×A ⟩
-    eval ∘ [ X×A ⇒ product ] λg X×A f ×id  ≈⟨ refl⟩∘⟨ [ X×A ⇒ product  ]×-cong₂ eq Equiv.refl ⟩
-    eval ∘ [ X×A ⇒ product ] λg X×A g × id ≈⟨ β X×A ⟩
+  λ-inj : ∀ {X : Obj} {f g : X ×A ⇒ B} → λg f ≈ λg g → f ≈ g
+  λ-inj {X} {f = f} {g = g} eq = begin
+    f                                      ≈˘⟨ β ⟩
+    eval ∘ λg f ⁂id                        ≈⟨ refl⟩∘⟨ [ products X ⇒ products B^A  ]×-cong₂ eq Equiv.refl ⟩
+    eval ∘ λg g ⁂id                        ≈⟨ β ⟩
     g                                      ∎
 
-  subst : ∀ (p₂ : Product C A) (p₃ : Product D A) {f g} →
-            λg p₃ f ∘ g ≈ λg p₂ (f ∘ [ p₂ ⇒ p₃ ] g ×id)
-  subst p₂ p₃ {f} {g} = λ-unique p₂ (begin
-    eval ∘ [ p₂ ⇒ product ] λg p₃ f ∘ g ×id
-                           ≈˘⟨ refl⟩∘⟨ [ p₂ ⇒ p₃ ⇒ product ]×id∘×id ⟩
-    eval ∘ [ p₃ ⇒ product ] λg p₃ f ×id ∘ [ p₂ ⇒ p₃ ] g ×id
-                           ≈⟨ pullˡ (β p₃) ⟩
-    f ∘ [ p₂ ⇒ p₃ ] g ×id ∎)
+  subst : ∀ {Z} {f : B^A ×A ⇒ B} {g : Z ⇒ B^A} →
+            λg f ∘ g ≈ λg (f ∘ (g ⁂id))
+  subst {Z} {f} {g} = λ-unique (begin
+    eval ∘ (λg f ∘ g) ⁂id
+                           ≈˘⟨ refl⟩∘⟨ [ products Z ⇒ products B^A ⇒ products B^A ]×id∘×id ⟩
+    eval ∘ λg f ⁂id ∘ g ⁂id
+                           ≈⟨ pullˡ β ⟩
+    f ∘ g ⁂id ∎)
 
-  η-id : λg product eval ≈ id
+  η-id : λg eval ≈ id
   η-id = begin
-    λg product eval                                  ≈˘⟨ identityʳ ⟩
-    λg product eval ∘ id                             ≈⟨ subst _ _ ⟩
-    λg product (eval ∘ [ product ⇒ product ] id ×id) ≈⟨ η product ⟩
-    id                                               ∎
+    λg eval            ≈˘⟨ identityʳ ⟩
+    λg eval ∘ id       ≈⟨ subst ⟩
+    λg (eval ∘ id ⁂id) ≈⟨ η ⟩
+    id                 ∎
 
-  λ-unique′ : ∀ (X×A : Product X A) {h i : X ⇒ B^A} →
-                eval ∘ [ X×A ⇒ product ] h ×id ≈ eval ∘ [ X×A ⇒ product ] i ×id → h ≈ i
-  λ-unique′ p eq = λ-unique p eq ○ (⟺ (λ-unique p Equiv.refl))
+  λ-unique′ : ∀ {h i : X ⇒ B^A} →
+                eval ∘ h ⁂id ≈ eval ∘ i ⁂id → h ≈ i
+  λ-unique′ eq = λ-unique eq ○ (⟺ (λ-unique Equiv.refl))
 
--- some aliases to make proof signatures less ugly
-[_]eval : ∀{A B}(e₁ : Exponential A B) → Exponential.B^A×A e₁ ⇒ B
-[ e₁ ]eval = Exponential.eval e₁
+-- -- some aliases to make proof signatures less ugly
+-- [_]eval : ∀{A B}(e₁ : Exponential A B) → ? ⇒ B
+-- [ e₁ ]eval = Exponential.eval e₁
 
-[_]λ : ∀{A B}(e₁ : Exponential A B)
-  → {X : Obj} → (X×A : Product X A) → (Product.A×B X×A ⇒ B) → (X ⇒ Exponential.B^A e₁)
-[ e₁ ]λ = Exponential.λg e₁
+-- [_]λ : ∀{A B}(e₁ : Exponential A B)
+--   → {X : Obj} → (X×A : Product X A) → (Product.A×B X×A ⇒ B) → (X ⇒ Exponential.B^A e₁)
+-- [ e₁ ]λ = Exponential.λg e₁
 
-{-
-   D×C --id × f--> D×A --g--> B
+-- {-
+--    D×C --id × f--> D×A --g--> B
 
-   D --λ (g ∘ id × f)--> B^C
-    \                   ^
-     \                 /
-     λ g       λ (e ∘ id × f)
-       \        /
-        v      /
-          B^A
--}
-λ-distrib : ∀ (e₁ : Exponential C B) (e₂ : Exponential A B)
-              (p₃ : Product D C) (p₄ : Product D A) (p₅ : Product (Exponential.B^A e₂) C)
-              {f} {g : Product.A×B p₄ ⇒ B} →
-              [ e₁ ]λ p₃ (g ∘ [ p₃ ⇒ p₄ ]id× f)
-              ≈ [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ Exponential.product e₂ ]id× f) ∘ [ e₂ ]λ p₄ g
-λ-distrib e₁ e₂ p₃ p₄ p₅ {f} {g} = ⟺ $ e₁.λ-unique p₃ $ begin
-  [ e₁ ]eval ∘ ([ p₃ ⇒ p₁ ] [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f) ∘ [ e₂ ]λ p₄ g ×id)
-                       ≈˘⟨ refl⟩∘⟨ [ p₃ ⇒ p₅ ⇒ p₁ ]×id∘×id ⟩
-  [ e₁ ]eval ∘ [ p₅ ⇒ p₁ ] [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f) ×id
-             ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
-                       ≈⟨ pullˡ (e₁.β p₅) ⟩
-  ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f)
-              ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
-                       ≈⟨ assoc ⟩
-  [ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f
-             ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
-                       ≈˘⟨ refl⟩∘⟨ [ p₄ ⇒ p₂ , p₃ ⇒ p₅ ]first↔second ⟩
-  [ e₂ ]eval ∘ [ p₄ ⇒ p₂ ] [ e₂ ]λ p₄ g ×id ∘ [ p₃ ⇒ p₄ ]id× f
-                       ≈⟨ pullˡ (e₂.β p₄) ⟩
-  g ∘ [ p₃ ⇒ p₄ ]id× f ∎
-  where module e₁ = Exponential e₁
-        module e₂ = Exponential e₂
-        p₁        = e₁.product
-        p₂        = e₂.product
+--    D --λ (g ∘ id × f)--> B^C
+--     \                   ^
+--      \                 /
+--      λ g       λ (e ∘ id × f)
+--        \        /
+--         v      /
+--           B^A
+-- -}
+-- λ-distrib : ∀ (e₁ : Exponential C B) (e₂ : Exponential A B)
+--               (p₃ : Product D C) (p₄ : Product D A) (p₅ : Product (Exponential.B^A e₂) C)
+--               {f} {g : Product.A×B p₄ ⇒ B} →
+--               [ e₁ ]λ p₃ (g ∘ [ p₃ ⇒ p₄ ]id× f)
+--               ≈ [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ Exponential.product e₂ ]id× f) ∘ [ e₂ ]λ p₄ g
+-- λ-distrib e₁ e₂ p₃ p₄ p₅ {f} {g} = ⟺ $ e₁.λ-unique p₃ $ begin
+--   [ e₁ ]eval ∘ ([ p₃ ⇒ p₁ ] [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f) ∘ [ e₂ ]λ p₄ g ×id)
+--                        ≈˘⟨ refl⟩∘⟨ [ p₃ ⇒ p₅ ⇒ p₁ ]×id∘×id ⟩
+--   [ e₁ ]eval ∘ [ p₅ ⇒ p₁ ] [ e₁ ]λ p₅ ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f) ×id
+--              ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
+--                        ≈⟨ pullˡ (e₁.β p₅) ⟩
+--   ([ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f)
+--               ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
+--                        ≈⟨ assoc ⟩
+--   [ e₂ ]eval ∘ [ p₅ ⇒ p₂ ]id× f
+--              ∘ [ p₃ ⇒ p₅ ] [ e₂ ]λ p₄ g ×id
+--                        ≈˘⟨ refl⟩∘⟨ [ p₄ ⇒ p₂ , p₃ ⇒ p₅ ]first↔second ⟩
+--   [ e₂ ]eval ∘ [ p₄ ⇒ p₂ ] [ e₂ ]λ p₄ g ×id ∘ [ p₃ ⇒ p₄ ]id× f
+--                        ≈⟨ pullˡ (e₂.β p₄) ⟩
+--   g ∘ [ p₃ ⇒ p₄ ]id× f ∎
+--   where module e₁ = Exponential e₁
+--         module e₂ = Exponential e₂
+--         p₁        = e₁.product
+--         p₂        = e₂.product
 
-repack : ∀{A B} (e₁ e₂ : Exponential A B) → Exponential.B^A e₁ ⇒ Exponential.B^A e₂
-repack e₁ e₂ = e₂.λg e₁.product e₁.eval
-  where
-    module e₁ = Exponential e₁
-    module e₂ = Exponential e₂
+-- repack : ∀{A B} (e₁ e₂ : Exponential A B) → Exponential.B^A e₁ ⇒ Exponential.B^A e₂
+-- repack e₁ e₂ = e₂.λg e₁.product e₁.eval
+--   where
+--     module e₁ = Exponential e₁
+--     module e₂ = Exponential e₂
 
-repack≡id : ∀{A B} (e : Exponential A B) → repack e e ≈ id
-repack≡id = Exponential.η-id
+-- repack≡id : ∀{A B} (e : Exponential A B) → repack e e ≈ id
+-- repack≡id = Exponential.η-id
 
-repack∘ : ∀ (e₁ e₂ e₃ : Exponential A B) → repack e₂ e₃ ∘ repack e₁ e₂ ≈ repack e₁ e₃
-repack∘ e₁ e₂ e₃ =
-  let p₁ = product e₁ in
-  let p₂ = product e₂ in
-  begin
-      [ e₃ ]λ p₂ [ e₂ ]eval
-    ∘ [ e₂ ]λ p₁ [ e₁ ]eval
-  ≈⟨ λ-cong e₃ p₂ (introʳ (second-id p₂)) ⟩∘⟨refl ⟩
-      [ e₃ ]λ p₂ ([ e₂ ]eval ∘ [ p₂ ⇒ p₂ ]id× id)
-    ∘ [ e₂ ]λ p₁ [ e₁ ]eval
-  ≈˘⟨ λ-distrib e₃ e₂ p₁ p₁ p₂ ⟩
-    [ e₃ ]λ p₁ ([ e₁ ]eval ∘ [ p₁ ⇒ p₁ ]id× id)
-  ≈⟨ λ-cong e₃ p₁ (⟺ (introʳ (second-id (product e₁)))) ⟩
-    [ e₃ ]λ p₁ [ e₁ ]eval
-  ∎
-  where open Exponential
+-- repack∘ : ∀ (e₁ e₂ e₃ : Exponential A B) → repack e₂ e₃ ∘ repack e₁ e₂ ≈ repack e₁ e₃
+-- repack∘ e₁ e₂ e₃ =
+--   let p₁ = product e₁ in
+--   let p₂ = product e₂ in
+--   begin
+--       [ e₃ ]λ p₂ [ e₂ ]eval
+--     ∘ [ e₂ ]λ p₁ [ e₁ ]eval
+--   ≈⟨ λ-cong e₃ p₂ (introʳ (second-id p₂)) ⟩∘⟨refl ⟩
+--       [ e₃ ]λ p₂ ([ e₂ ]eval ∘ [ p₂ ⇒ p₂ ]id× id)
+--     ∘ [ e₂ ]λ p₁ [ e₁ ]eval
+--   ≈˘⟨ λ-distrib e₃ e₂ p₁ p₁ p₂ ⟩
+--     [ e₃ ]λ p₁ ([ e₁ ]eval ∘ [ p₁ ⇒ p₁ ]id× id)
+--   ≈⟨ λ-cong e₃ p₁ (⟺ (introʳ (second-id (product e₁)))) ⟩
+--     [ e₃ ]λ p₁ [ e₁ ]eval
+--   ∎
+--   where open Exponential
 
-repack-cancel : ∀{A B} (e₁ e₂ : Exponential A B) → repack e₁ e₂ ∘ repack e₂ e₁ ≈ id
-repack-cancel e₁ e₂ = repack∘ e₂ e₁ e₂ ○ repack≡id e₂
+-- repack-cancel : ∀{A B} (e₁ e₂ : Exponential A B) → repack e₁ e₂ ∘ repack e₂ e₁ ≈ id
+-- repack-cancel e₁ e₂ = repack∘ e₂ e₁ e₂ ○ repack≡id e₂
 
-up-to-iso : ∀{A B} (e₁ e₂ : Exponential A B) → Exponential.B^A e₁ ≅ Exponential.B^A e₂
-up-to-iso e₁ e₂ = record
-  { from = repack e₁ e₂
-  ; to   = repack e₂ e₁
-  ; iso  = record
-    { isoˡ = repack-cancel e₂ e₁
-    ; isoʳ = repack-cancel e₁ e₂
-    }
-  }
+-- up-to-iso : ∀{A B} (e₁ e₂ : Exponential A B) → Exponential.B^A e₁ ≅ Exponential.B^A e₂
+-- up-to-iso e₁ e₂ = record
+--   { from = repack e₁ e₂
+--   ; to   = repack e₂ e₁
+--   ; iso  = record
+--     { isoˡ = repack-cancel e₂ e₁
+--     ; isoʳ = repack-cancel e₁ e₂
+--     }
+--   }
 
-transport-by-iso : ∀ (e : Exponential A B) → Exponential.B^A e ≅ X → Exponential A B
-transport-by-iso {X = X} e e≅X = record
-  { B^A             = X
-  ; product         = X×A
-  ; eval            = e.eval
-  ; λg              = λ Y×A Y×A⇒B → from ∘ (e.λg Y×A Y×A⇒B)
-  ; β               = λ Y×A {h} → begin
-    e.eval ∘ [ Y×A ⇒ X×A ] from ∘ e.λg Y×A h ×id ≈⟨ refl⟩∘⟨ e.product.⟨⟩-cong₂ (pullˡ (cancelˡ isoˡ))
-                                                                              (elimˡ Equiv.refl) ⟩
-    e.eval ∘ [ Y×A ⇒ e.product ] e.λg Y×A h ×id  ≈⟨ e.β Y×A ⟩
-    h                                            ∎
-  ; λ-unique        = λ Y×A {h} {i} eq →
-    switch-tofromˡ e≅X $ e.λ-unique Y×A $ begin
-      e.eval ∘ [ Y×A ⇒ e.product ] to ∘ i ×id    ≈⟨ refl⟩∘⟨ e.product.⟨⟩-cong₂ assoc (introˡ Equiv.refl) ⟩
-      e.eval ∘ [ Y×A ⇒ X×A ] i ×id               ≈⟨ eq ⟩
-      h                                          ∎
-  }
-  where module e = Exponential e
-        X×A      = Mobile e.product e≅X ≅.refl
-        open _≅_ e≅X
+-- transport-by-iso : ∀ (e : Exponential A B) → Exponential.B^A e ≅ X → Exponential A B
+-- transport-by-iso {X = X} e e≅X = record
+--   { B^A             = X
+--   ; product         = X×A
+--   ; eval            = e.eval
+--   ; λg              = λ Y×A Y×A⇒B → from ∘ (e.λg Y×A Y×A⇒B)
+--   ; β               = λ Y×A {h} → begin
+--     e.eval ∘ [ Y×A ⇒ X×A ] from ∘ e.λg Y×A h ×id ≈⟨ refl⟩∘⟨ e.product.⟨⟩-cong₂ (pullˡ (cancelˡ isoˡ))
+--                                                                               (elimˡ Equiv.refl) ⟩
+--     e.eval ∘ [ Y×A ⇒ e.product ] e.λg Y×A h ×id  ≈⟨ e.β Y×A ⟩
+--     h                                            ∎
+--   ; λ-unique        = λ Y×A {h} {i} eq →
+--     switch-tofromˡ e≅X $ e.λ-unique Y×A $ begin
+--       e.eval ∘ [ Y×A ⇒ e.product ] to ∘ i ×id    ≈⟨ refl⟩∘⟨ e.product.⟨⟩-cong₂ assoc (introˡ Equiv.refl) ⟩
+--       e.eval ∘ [ Y×A ⇒ X×A ] i ×id               ≈⟨ eq ⟩
+--       h                                          ∎
+--   }
+--   where module e = Exponential e
+--         X×A      = Mobile e.product e≅X ≅.refl
+--         open _≅_ e≅X

--- a/src/Categories/Object/Exponential/Canonical.agda
+++ b/src/Categories/Object/Exponential/Canonical.agda
@@ -1,0 +1,151 @@
+{-# OPTIONS --without-K --safe #-}
+open import Categories.Category.Core
+open import Categories.Category.Cartesian using (Cartesian)
+
+-- Exponential Objects in a Cartesian Category
+
+module Categories.Object.Exponential.Canonical {o ℓ e} {𝒞 : Category o ℓ e} (cartesian : Cartesian 𝒞) where
+
+open Category 𝒞
+open Cartesian cartesian using (_×_; _⁂_; ⁂-cong₂; ⁂∘⁂; first↔second; unique; ⟨⟩-cong₂; ⟨_,_⟩; π₁; π₂; id⁂id)
+
+open import Level
+
+open import Categories.Morphism.Reasoning 𝒞
+open import Categories.Morphism 𝒞
+
+open HomReasoning
+open Equiv
+
+private
+  variable
+    A B C D X Y : Obj
+
+record Exponential (A B : Obj) : Set (o ⊔ ℓ ⊔ e) where
+  field
+    B^A : Obj
+
+  field
+    eval     : B^A × A ⇒ B
+    λg       : (X × A ⇒ B) → (X ⇒ B^A)
+    β        : {g : X × A ⇒ B} →
+                 (eval ∘ (λg g ⁂ id) ≈ g)
+    λ-unique : ∀ {g : X × A ⇒ B} {h : X ⇒ B^A} →
+                 (eval ∘ (h ⁂ id) ≈ g) → (h ≈ λg g)
+
+  η : ∀ {f : X ⇒ B^A} → λg (eval ∘ (f ⁂ id)) ≈ f
+  η = ⟺ (λ-unique refl)
+
+  λ-cong : ∀ {f g : X × A ⇒ B} → f ≈ g → λg f ≈ λg g
+  λ-cong {f = f} {g = g} f≡g = λ-unique (β ○ f≡g)
+
+  λ-inj : ∀ {f g : X × A ⇒ B} → λg f ≈ λg g → f ≈ g
+  λ-inj {f = f} {g = g} eq = begin
+    f                                      ≈˘⟨ β ⟩
+    eval ∘ (λg f ⁂ id)  ≈⟨ refl⟩∘⟨ ⁂-cong₂ eq refl ⟩
+    eval ∘ (λg g ⁂ id) ≈⟨ β ⟩
+    g                                      ∎
+
+  subst : {f : X × A ⇒ B} {g : Y ⇒ X} → λg f ∘ g ≈ λg (f ∘ (g ⁂ id))
+  subst {f = f} {g = g} = λ-unique (begin
+    eval ∘ (λg f ∘ g ⁂ id)        ≈˘⟨ refl⟩∘⟨ (⁂∘⁂ ○ ⁂-cong₂ refl identityʳ) ⟩
+    eval ∘ (λg f ⁂ id) ∘ (g ⁂ id) ≈⟨ pullˡ β ⟩
+    f ∘ (g ⁂ id)                  ∎)
+
+  η-id : λg eval ≈ id
+  η-id = begin
+    λg eval               ≈˘⟨ identityʳ ⟩
+    λg eval ∘ id          ≈⟨ subst ⟩
+    λg (eval ∘ (id ⁂ id)) ≈⟨ η ⟩
+    id                    ∎
+
+  λ-unique′ : ∀ {h i : X ⇒ B^A} →
+                eval ∘ (h ⁂ id) ≈ eval ∘ (i ⁂ id) → h ≈ i
+  λ-unique′ eq = λ-unique eq ○ (⟺ (λ-unique refl))
+
+-- aliases for working with multiple exponentials
+[_]eval : ∀{A B} (e₁ : Exponential A B) → Exponential.B^A e₁ × A ⇒ B
+[ e₁ ]eval = Exponential.eval e₁
+
+[_]λ : ∀{A B} (e₁ : Exponential A B)
+  → {X : Obj} → (X × A ⇒ B) → (X ⇒ Exponential.B^A e₁)
+[ e₁ ]λ = Exponential.λg e₁
+
+{-
+   D×C --id × f--> D×A --g--> B
+
+   D --λ (g ∘ id × f)--> B^C
+    \                   ^
+     \                 /
+     λ g       λ (e ∘ id × f)
+       \        /
+        v      /
+          B^A
+-}
+λ-distrib : ∀ (e₁ : Exponential C B) (e₂ : Exponential A B)
+              {f} {g : D × A ⇒ B} →
+              [ e₁ ]λ  (g ∘ (id ⁂ f))
+              ≈ [ e₁ ]λ ([ e₂ ]eval ∘ (id ⁂ f)) ∘ [ e₂ ]λ g
+λ-distrib e₁ e₂ {f} {g} = ⟺ (e₁.λ-unique (begin 
+  e₁.eval ∘ (e₁.λg (e₂.eval ∘ (id ⁂ f)) ∘ e₂.λg g ⁂ id)        ≈˘⟨ refl⟩∘⟨ (⁂∘⁂ ○ ⁂-cong₂ refl identity²) ⟩ 
+  e₁.eval ∘ (e₁.λg (e₂.eval ∘ (id ⁂ f)) ⁂ id) ∘ (e₂.λg g ⁂ id) ≈⟨ pullˡ e₁.β ⟩ 
+  (e₂.eval ∘ (id ⁂ f)) ∘ (e₂.λg g ⁂ id)                        ≈⟨ assoc ⟩ 
+  e₂.eval ∘ (id ⁂ f) ∘ (e₂.λg g ⁂ id)                          ≈˘⟨ refl⟩∘⟨ first↔second ⟩ 
+  e₂.eval ∘ (e₂.λg g ⁂ id) ∘ (id ⁂ f)                          ≈⟨ pullˡ e₂.β ⟩ 
+  g ∘ (id ⁂ f)                                                 ∎))
+  where module e₁ = Exponential e₁
+        module e₂ = Exponential e₂
+
+repack : ∀ {A B} (e₁ e₂ : Exponential A B) → Exponential.B^A e₁ ⇒ Exponential.B^A e₂
+repack e₁ e₂ = e₂.λg e₁.eval
+  where
+    module e₁ = Exponential e₁
+    module e₂ = Exponential e₂
+
+repack≡id : ∀{A B} (e : Exponential A B) → repack e e ≈ id
+repack≡id = Exponential.η-id
+
+repack∘ : ∀ (e₁ e₂ e₃ : Exponential A B) → repack e₂ e₃ ∘ repack e₁ e₂ ≈ repack e₁ e₃
+repack∘ e₁ e₂ e₃ =
+  begin
+      [ e₃ ]λ [ e₂ ]eval
+    ∘ [ e₂ ]λ [ e₁ ]eval
+  ≈⟨ λ-cong e₃ (introʳ (id⁂id)) ⟩∘⟨refl ⟩
+      [ e₃ ]λ ([ e₂ ]eval ∘ (id ⁂ id))
+    ∘ [ e₂ ]λ [ e₁ ]eval
+  ≈˘⟨ λ-distrib e₃ e₂ ⟩
+    [ e₃ ]λ  ([ e₁ ]eval ∘ (id ⁂ id))
+  ≈⟨ λ-cong e₃ (⟺ (introʳ (id⁂id))) ⟩
+    [ e₃ ]λ [ e₁ ]eval
+  ∎
+  where open Exponential
+
+repack-cancel : ∀{A B} (e₁ e₂ : Exponential A B) → repack e₁ e₂ ∘ repack e₂ e₁ ≈ id
+repack-cancel e₁ e₂ = repack∘ e₂ e₁ e₂ ○ repack≡id e₂
+
+up-to-iso : ∀{A B} (e₁ e₂ : Exponential A B) → Exponential.B^A e₁ ≅ Exponential.B^A e₂
+up-to-iso e₁ e₂ = record
+  { from = repack e₁ e₂
+  ; to   = repack e₂ e₁
+  ; iso  = record
+    { isoˡ = repack-cancel e₂ e₁
+    ; isoʳ = repack-cancel e₁ e₂
+    }
+  }
+
+transport-by-iso : ∀ (e : Exponential A B) → Exponential.B^A e ≅ X → Exponential A B
+transport-by-iso {X = X} e e≅X = record
+  { B^A             = X
+  ; eval            = e.eval ∘ (to ⁂ id)
+  ; λg              = λ g → from ∘ e.λg g
+  ; β               = λ {g = g} → begin  
+    (e.eval ∘ (to ⁂ id)) ∘ (from ∘ e.λg g ⁂ id) ≈⟨ pullʳ (⁂∘⁂ ○ ⁂-cong₂ (cancelˡ isoˡ) identity²) ⟩
+    e.eval ∘ (e.λg g ⁂ id)                      ≈⟨ e.β ⟩ 
+    g                                           ∎
+  ; λ-unique        = λ {g = g} {h = h} eq → switch-tofromˡ e≅X (e.λ-unique (begin 
+    e.eval ∘ (to ∘ h ⁂ id)          ≈˘⟨ pullʳ (⁂∘⁂ ○ ⁂-cong₂ refl identity²) ⟩ 
+    (e.eval ∘ (to ⁂ id)) ∘ (h ⁂ id) ≈⟨ eq ⟩
+    g                               ∎))
+  }
+  where module e = Exponential e
+        open _≅_ e≅X

--- a/src/Categories/Object/NaturalNumbers/Properties/Parametrized.agda
+++ b/src/Categories/Object/NaturalNumbers/Properties/Parametrized.agda
@@ -13,7 +13,7 @@ open import Categories.Category.CartesianClosed using (CartesianClosed)
 module Categories.Object.NaturalNumbers.Properties.Parametrized {o ℓ e} (𝒞 : Category o ℓ e) (𝒞-CartesianClosed : CartesianClosed 𝒞) (𝒞-Coproducts : BinaryCoproducts 𝒞) where
 
 open Category 𝒞
-open CartesianClosed 𝒞-CartesianClosed using (cartesian; λg; eval′; β′; λ-inj; λ-cong; η-exp′; λ-unique′; subst)
+open CartesianClosed 𝒞-CartesianClosed using (cartesian; λg; eval; β; λ-inj; λ-cong; η-exp; λ-unique; subst)
 open Cartesian cartesian renaming (unique′ to bp-unique′)
 
 open import Categories.Object.NaturalNumbers 𝒞 terminal using (NNO)
@@ -30,7 +30,7 @@ NNO×CCC⇒PNNO nno = record
   ; isParametrizedNNO = record
     { z = z
     ; s = s
-    ; universal = λ {A} {X} f g → (eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id)) ∘ swap
+    ; universal = λ {A} {X} f g → (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap
     ; commute₁ = commute₁'
     ; commute₂ = commute₂'
     ; unique = unique'
@@ -39,39 +39,39 @@ NNO×CCC⇒PNNO nno = record
   where
   open NNO nno renaming (unique to nno-unique)
 
-  commute₁' : ∀ {A X} {f : A ⇒ X} {g : X ⇒ X} → f ≈ ((eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id)) ∘ swap) ∘ ⟨ id , z ∘ ! ⟩
+  commute₁' : ∀ {A X} {f : A ⇒ X} {g : X ⇒ X} → f ≈ ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ ⟨ id , z ∘ ! ⟩
   commute₁' {A} {X} {f} {g} = begin
     f                                                                                   ≈⟨ introʳ project₂ ⟩
-    f ∘ π₂ ∘ ⟨ ! , id ⟩                                                                 ≈⟨ pullˡ (⟺ β′) ⟩
-    (eval′ ∘ (λg (f ∘ π₂) ⁂ id)) ∘ ⟨ ! , id ⟩                                           ≈⟨ pullʳ ⁂∘⟨⟩ ⟩
-    eval′ ∘ ⟨ λg (f ∘ π₂) ∘ ! , id ∘ id ⟩                                               ≈⟨ refl⟩∘⟨ ⟨⟩-congʳ (∘-resp-≈ˡ z-commute) ⟩
-    eval′ ∘ ⟨ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ∘ z) ∘ ! , id ∘ id ⟩            ≈⟨ refl⟩∘⟨ (⟨⟩-congʳ assoc ○ ⟺ ⁂∘⟨⟩) ⟩
-    eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id) ∘ ⟨ z ∘ ! , id ⟩            ≈⟨ sym-assoc ○ pushʳ (⟺ swap∘⟨⟩) ⟩
-    ((eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id)) ∘ swap) ∘ ⟨ id , z ∘ ! ⟩ ∎
+    f ∘ π₂ ∘ ⟨ ! , id ⟩                                                                 ≈⟨ pullˡ (⟺ β) ⟩
+    (eval ∘ (λg (f ∘ π₂) ⁂ id)) ∘ ⟨ ! , id ⟩                                           ≈⟨ pullʳ ⁂∘⟨⟩ ⟩
+    eval ∘ ⟨ λg (f ∘ π₂) ∘ ! , id ∘ id ⟩                                               ≈⟨ refl⟩∘⟨ ⟨⟩-congʳ (∘-resp-≈ˡ z-commute) ⟩
+    eval ∘ ⟨ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ∘ z) ∘ ! , id ∘ id ⟩            ≈⟨ refl⟩∘⟨ (⟨⟩-congʳ assoc ○ ⟺ ⁂∘⟨⟩) ⟩
+    eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id) ∘ ⟨ z ∘ ! , id ⟩            ≈⟨ sym-assoc ○ pushʳ (⟺ swap∘⟨⟩) ⟩
+    ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ ⟨ id , z ∘ ! ⟩ ∎
 
   commute₂' : ∀ {A X} {f : A ⇒ X} {g : X ⇒ X}
-    → g ∘ ((eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id)) ∘ swap) ≈ ((eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id)) ∘ swap) ∘ (id ⁂ s)
+    → g ∘ ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ≈ ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ (id ⁂ s)
   commute₂' {A} {X} {f} {g} = begin
-    g ∘ (eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id)) ∘ swap                       ≈⟨ pullˡ (pullˡ (⟺ β′)) ⟩
-    ((eval′ ∘ (λg (g ∘ eval′) ⁂ id)) ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id)) ∘ swap ≈⟨ (pullʳ ⁂∘⁂) ⟩∘⟨refl ⟩
-    (eval′ ∘ (λg (g ∘ eval′) ∘  universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id ∘ id)) ∘ swap    ≈⟨ (refl⟩∘⟨ (⁂-cong₂ s-commute refl)) ⟩∘⟨refl ⟩
-    (eval′ ∘ (universal (λg (f ∘ π₂))  (λg (g ∘ eval′)) ∘ s ⁂ id ∘ id)) ∘ swap                 ≈⟨ (refl⟩∘⟨ (⟺ ⁂∘⁂)) ⟩∘⟨refl ⟩
-    (eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id) ∘ (s ⁂ id)) ∘ swap                ≈⟨ pullʳ (pullʳ (⟺ swap∘⁂)) ⟩
-    eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id) ∘ swap ∘ (id ⁂ s)                  ≈⟨ sym-assoc ○ sym-assoc ⟩
-    ((eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id)) ∘ swap) ∘ (id ⁂ s)              ∎
+    g ∘ (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap                       ≈⟨ pullˡ (pullˡ (⟺ β)) ⟩
+    ((eval ∘ (λg (g ∘ eval) ⁂ id)) ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap ≈⟨ (pullʳ ⁂∘⁂) ⟩∘⟨refl ⟩
+    (eval ∘ (λg (g ∘ eval) ∘  universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id ∘ id)) ∘ swap    ≈⟨ (refl⟩∘⟨ (⁂-cong₂ s-commute refl)) ⟩∘⟨refl ⟩
+    (eval ∘ (universal (λg (f ∘ π₂))  (λg (g ∘ eval)) ∘ s ⁂ id ∘ id)) ∘ swap                 ≈⟨ (refl⟩∘⟨ (⟺ ⁂∘⁂)) ⟩∘⟨refl ⟩
+    (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id) ∘ (s ⁂ id)) ∘ swap                ≈⟨ pullʳ (pullʳ (⟺ swap∘⁂)) ⟩
+    eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id) ∘ swap ∘ (id ⁂ s)                  ≈⟨ sym-assoc ○ sym-assoc ⟩
+    ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ (id ⁂ s)              ∎
 
   unique' : ∀ {A X} {f : A ⇒ X} {g : X ⇒ X} {u : A × N ⇒ X}
-    → f ≈ u ∘ ⟨ id , z ∘ ! ⟩ → g ∘ u ≈ u ∘ (id ⁂ s) → u ≈ (eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id)) ∘ swap
+    → f ≈ u ∘ ⟨ id , z ∘ ! ⟩ → g ∘ u ≈ u ∘ (id ⁂ s) → u ≈ (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap
   unique' {A} {X} {f} {g} {u} eqᶻ eqˢ = swap-epi _ _ (λ-inj (begin
     λg (u ∘ swap)                                                                  ≈⟨ nno-unique (⟺ z-commutes) s-commutes ⟩
-    universal (λg (f ∘ π₂)) (λg (g ∘ eval′))                                       ≈˘⟨ η-exp′ ⟩
-    λg (eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id))                   ≈˘⟨ λ-cong (cancelʳ swap∘swap) ⟩
-    λg (((eval′ ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval′)) ⁂ id)) ∘ swap) ∘ swap) ∎))
+    universal (λg (f ∘ π₂)) (λg (g ∘ eval))                                       ≈˘⟨ η-exp ⟩
+    λg (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id))                   ≈˘⟨ λ-cong (cancelʳ swap∘swap) ⟩
+    λg (((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ swap) ∎))
     where
     z-commutes : λg (u ∘ swap) ∘ z ≈ λg (f ∘ π₂)
-    z-commutes = λ-unique′ (begin
-      eval′ ∘ (λg (u ∘ swap) ∘ z ⁂ id)        ≈˘⟨ refl⟩∘⟨ (⁂∘⁂ ○ ⁂-cong₂ refl identity²) ⟩
-      eval′ ∘ (λg (u ∘ swap) ⁂ id) ∘ (z ⁂ id) ≈⟨ extendʳ β′ ⟩
+    z-commutes = λ-unique (begin
+      eval ∘ (λg (u ∘ swap) ∘ z ⁂ id)        ≈˘⟨ refl⟩∘⟨ (⁂∘⁂ ○ ⁂-cong₂ refl identity²) ⟩
+      eval ∘ (λg (u ∘ swap) ⁂ id) ∘ (z ⁂ id) ≈⟨ extendʳ β ⟩
       u ∘ swap ∘ (z ⁂ id)                     ≈⟨ refl⟩∘⟨ swap∘⁂ ⟩
       u ∘ (id ⁂ z) ∘ swap                     ≈⟨ refl⟩∘⟨ (bp-unique′ π₁-commutes π₂-commutes) ⟩
       u ∘ ⟨ id , z ∘ ! ⟩ ∘ π₂                 ≈⟨ pullˡ (⟺ eqᶻ) ⟩
@@ -90,10 +90,10 @@ NNO×CCC⇒PNNO nno = record
         z ∘ π₁                   ≈⟨ refl⟩∘⟨ !-unique₂ ⟩
         z ∘ ! ∘ π₂               ≈˘⟨ extendʳ project₂ ⟩
         π₂ ∘ ⟨ id , z ∘ ! ⟩ ∘ π₂ ∎
-    s-commutes : λg (g ∘ eval′) ∘ λg (u ∘ swap) ≈ λg (u ∘ swap) ∘ s
+    s-commutes : λg (g ∘ eval) ∘ λg (u ∘ swap) ≈ λg (u ∘ swap) ∘ s
     s-commutes = begin
-      λg (g ∘ eval′) ∘ λg (u ∘ swap)          ≈⟨ subst ⟩
-      λg ((g ∘ eval′) ∘ (λg (u ∘ swap) ⁂ id)) ≈⟨ λ-cong (pullʳ β′ ○ pullˡ eqˢ) ⟩
+      λg (g ∘ eval) ∘ λg (u ∘ swap)          ≈⟨ subst ⟩
+      λg ((g ∘ eval) ∘ (λg (u ∘ swap) ⁂ id)) ≈⟨ λ-cong (pullʳ β ○ pullˡ eqˢ) ⟩
       λg ((u ∘ (id ⁂ s)) ∘ swap)              ≈⟨ λ-cong (pullʳ (⟺ swap∘⁂) ○ sym-assoc) ⟩
       λg ((u ∘ swap) ∘ (s ⁂ id))              ≈˘⟨ subst ⟩
       λg (u ∘ swap) ∘ s                       ∎

--- a/src/Categories/Object/NaturalNumbers/Properties/Parametrized.agda
+++ b/src/Categories/Object/NaturalNumbers/Properties/Parametrized.agda
@@ -41,10 +41,10 @@ NNO×CCC⇒PNNO nno = record
 
   commute₁' : ∀ {A X} {f : A ⇒ X} {g : X ⇒ X} → f ≈ ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ ⟨ id , z ∘ ! ⟩
   commute₁' {A} {X} {f} {g} = begin
-    f                                                                                   ≈⟨ introʳ project₂ ⟩
-    f ∘ π₂ ∘ ⟨ ! , id ⟩                                                                 ≈⟨ pullˡ (⟺ β) ⟩
-    (eval ∘ (λg (f ∘ π₂) ⁂ id)) ∘ ⟨ ! , id ⟩                                           ≈⟨ pullʳ ⁂∘⟨⟩ ⟩
-    eval ∘ ⟨ λg (f ∘ π₂) ∘ ! , id ∘ id ⟩                                               ≈⟨ refl⟩∘⟨ ⟨⟩-congʳ (∘-resp-≈ˡ z-commute) ⟩
+    f                                                                                 ≈⟨ introʳ project₂ ⟩
+    f ∘ π₂ ∘ ⟨ ! , id ⟩                                                               ≈⟨ pullˡ (⟺ β) ⟩
+    (eval ∘ (λg (f ∘ π₂) ⁂ id)) ∘ ⟨ ! , id ⟩                                          ≈⟨ pullʳ ⁂∘⟨⟩ ⟩
+    eval ∘ ⟨ λg (f ∘ π₂) ∘ ! , id ∘ id ⟩                                              ≈⟨ refl⟩∘⟨ ⟨⟩-congʳ (∘-resp-≈ˡ z-commute) ⟩
     eval ∘ ⟨ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ∘ z) ∘ ! , id ∘ id ⟩            ≈⟨ refl⟩∘⟨ (⟨⟩-congʳ assoc ○ ⟺ ⁂∘⟨⟩) ⟩
     eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id) ∘ ⟨ z ∘ ! , id ⟩            ≈⟨ sym-assoc ○ pushʳ (⟺ swap∘⟨⟩) ⟩
     ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ ⟨ id , z ∘ ! ⟩ ∎
@@ -52,19 +52,19 @@ NNO×CCC⇒PNNO nno = record
   commute₂' : ∀ {A X} {f : A ⇒ X} {g : X ⇒ X}
     → g ∘ ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ≈ ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ (id ⁂ s)
   commute₂' {A} {X} {f} {g} = begin
-    g ∘ (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap                       ≈⟨ pullˡ (pullˡ (⟺ β)) ⟩
+    g ∘ (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap                      ≈⟨ pullˡ (pullˡ (⟺ β)) ⟩
     ((eval ∘ (λg (g ∘ eval) ⁂ id)) ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap ≈⟨ (pullʳ ⁂∘⁂) ⟩∘⟨refl ⟩
     (eval ∘ (λg (g ∘ eval) ∘  universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id ∘ id)) ∘ swap    ≈⟨ (refl⟩∘⟨ (⁂-cong₂ s-commute refl)) ⟩∘⟨refl ⟩
-    (eval ∘ (universal (λg (f ∘ π₂))  (λg (g ∘ eval)) ∘ s ⁂ id ∘ id)) ∘ swap                 ≈⟨ (refl⟩∘⟨ (⟺ ⁂∘⁂)) ⟩∘⟨refl ⟩
-    (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id) ∘ (s ⁂ id)) ∘ swap                ≈⟨ pullʳ (pullʳ (⟺ swap∘⁂)) ⟩
-    eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id) ∘ swap ∘ (id ⁂ s)                  ≈⟨ sym-assoc ○ sym-assoc ⟩
-    ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ (id ⁂ s)              ∎
+    (eval ∘ (universal (λg (f ∘ π₂))  (λg (g ∘ eval)) ∘ s ⁂ id ∘ id)) ∘ swap                ≈⟨ (refl⟩∘⟨ (⟺ ⁂∘⁂)) ⟩∘⟨refl ⟩
+    (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id) ∘ (s ⁂ id)) ∘ swap               ≈⟨ pullʳ (pullʳ (⟺ swap∘⁂)) ⟩
+    eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id) ∘ swap ∘ (id ⁂ s)                 ≈⟨ sym-assoc ○ sym-assoc ⟩
+    ((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ (id ⁂ s)             ∎
 
   unique' : ∀ {A X} {f : A ⇒ X} {g : X ⇒ X} {u : A × N ⇒ X}
     → f ≈ u ∘ ⟨ id , z ∘ ! ⟩ → g ∘ u ≈ u ∘ (id ⁂ s) → u ≈ (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap
   unique' {A} {X} {f} {g} {u} eqᶻ eqˢ = swap-epi _ _ (λ-inj (begin
-    λg (u ∘ swap)                                                                  ≈⟨ nno-unique (⟺ z-commutes) s-commutes ⟩
-    universal (λg (f ∘ π₂)) (λg (g ∘ eval))                                       ≈˘⟨ η-exp ⟩
+    λg (u ∘ swap)                                                                ≈⟨ nno-unique (⟺ z-commutes) s-commutes ⟩
+    universal (λg (f ∘ π₂)) (λg (g ∘ eval))                                      ≈˘⟨ η-exp ⟩
     λg (eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id))                   ≈˘⟨ λ-cong (cancelʳ swap∘swap) ⟩
     λg (((eval ∘ (universal (λg (f ∘ π₂)) (λg (g ∘ eval)) ⁂ id)) ∘ swap) ∘ swap) ∎))
     where
@@ -72,10 +72,10 @@ NNO×CCC⇒PNNO nno = record
     z-commutes = λ-unique (begin
       eval ∘ (λg (u ∘ swap) ∘ z ⁂ id)        ≈˘⟨ refl⟩∘⟨ (⁂∘⁂ ○ ⁂-cong₂ refl identity²) ⟩
       eval ∘ (λg (u ∘ swap) ⁂ id) ∘ (z ⁂ id) ≈⟨ extendʳ β ⟩
-      u ∘ swap ∘ (z ⁂ id)                     ≈⟨ refl⟩∘⟨ swap∘⁂ ⟩
-      u ∘ (id ⁂ z) ∘ swap                     ≈⟨ refl⟩∘⟨ (bp-unique′ π₁-commutes π₂-commutes) ⟩
-      u ∘ ⟨ id , z ∘ ! ⟩ ∘ π₂                 ≈⟨ pullˡ (⟺ eqᶻ) ⟩
-      f ∘ π₂                                  ∎)
+      u ∘ swap ∘ (z ⁂ id)                    ≈⟨ refl⟩∘⟨ swap∘⁂ ⟩
+      u ∘ (id ⁂ z) ∘ swap                    ≈⟨ refl⟩∘⟨ (bp-unique′ π₁-commutes π₂-commutes) ⟩
+      u ∘ ⟨ id , z ∘ ! ⟩ ∘ π₂                ≈⟨ pullˡ (⟺ eqᶻ) ⟩
+      f ∘ π₂                                 ∎)
       where
       π₁-commutes : π₁ ∘ (id ⁂ z) ∘ swap ≈ π₁ ∘ ⟨ id , z ∘ ! ⟩ ∘ π₂
       π₁-commutes = begin
@@ -94,6 +94,6 @@ NNO×CCC⇒PNNO nno = record
     s-commutes = begin
       λg (g ∘ eval) ∘ λg (u ∘ swap)          ≈⟨ subst ⟩
       λg ((g ∘ eval) ∘ (λg (u ∘ swap) ⁂ id)) ≈⟨ λ-cong (pullʳ β ○ pullˡ eqˢ) ⟩
-      λg ((u ∘ (id ⁂ s)) ∘ swap)              ≈⟨ λ-cong (pullʳ (⟺ swap∘⁂) ○ sym-assoc) ⟩
-      λg ((u ∘ swap) ∘ (s ⁂ id))              ≈˘⟨ subst ⟩
-      λg (u ∘ swap) ∘ s                       ∎
+      λg ((u ∘ (id ⁂ s)) ∘ swap)             ≈⟨ λ-cong (pullʳ (⟺ swap∘⁂) ○ sym-assoc) ⟩
+      λg ((u ∘ swap) ∘ (s ⁂ id))             ≈˘⟨ subst ⟩
+      λg (u ∘ swap) ∘ s                      ∎


### PR DESCRIPTION
Exponentials are really hard to use at the moment, because [λg](https://agda.github.io/agda-categories/Categories.Object.Exponential.html#792) requires a product to be passed to it.
In CCCs there are helper definitions that alleviate this, but working with a single exponential object in a cartesian category is painful.

Instead, for B^A we should require that all binary products `-×A` exist (thats how exponentials are defined in wikipedia and nlab).

Also, I've moved the product requirement to be a parameter instead of a record field, so that when assuming an exponential object in a cartesian category, the products do not clash.

I've started adjusting the definitions, but since this is a bigger design decision, I'd like some feedback first before I proceed @JacquesCarette.