### PR TITLE
Refactor cocartesian

### DIFF
--- a/src/Categories/Category/BinaryCoproducts.agda
+++ b/src/Categories/Category/BinaryCoproducts.agda
@@ -1,0 +1,119 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core using (Category)
+
+-- Defines BinaryCoproducts -- for when a Category has all Binary Coproducts
+
+-- Most of the work is dual to Categories.Category.BinaryProducts, so the idea
+-- in this module is to make use of duality
+
+module Categories.Category.BinaryCoproducts {o ℓ e} (𝒞 : Category o ℓ e) where
+
+open import Level using (levelOfTerm)
+
+open Category 𝒞
+
+open import Categories.Object.Coproduct 𝒞
+open import Categories.Category.BinaryProducts using (BinaryProducts)
+open import Categories.Morphism 𝒞 using (_≅_)
+open import Categories.Morphism.Duality 𝒞
+open import Categories.Object.Duality 𝒞
+
+open import Categories.Functor using (Functor) renaming (id to idF)
+open import Categories.Functor.Bifunctor using (Bifunctor; appʳ; appˡ)
+
+private
+  variable
+    A B C : Obj
+
+record BinaryCoproducts : Set (levelOfTerm 𝒞) where
+  field
+    coproduct : ∀ {A B} → Coproduct A B
+
+  module _ (A B : Obj) where 
+    open Coproduct (coproduct {A} {B})
+      renaming (A+B to infixr 6 _+_)
+      using ()
+      public
+
+  module _ {A B : Obj} where
+    open Coproduct (coproduct {A} {B})
+      using (i₁; i₂; [_,_]; inject₁; inject₂; []-cong₂; ∘-distribˡ-[]) 
+      renaming (unique to +-unique; η to +-η; g-η to +-g-η) 
+      public 
+
+  module Dual where
+    op-binaryProducts : BinaryProducts op
+    op-binaryProducts = record { product = Coproduct⇒coProduct coproduct }
+
+    module op-binaryProducts = BinaryProducts op-binaryProducts
+
+  open Dual
+
+  +-comm : A + B ≅ B + A
+  +-comm = op-≅⇒≅ (op-binaryProducts.×-comm)
+
+  +-assoc : A + B + C ≅ (A + B) + C
+  +-assoc = op-≅⇒≅ (op-binaryProducts.×-assoc)
+
+  -- Don't use Dual.op-binaryProducts here, since it makes Agda solve with
+  -- Dual.op-binaryProducts._⁂_ instead of +₁
+  open BinaryProducts record { product = Coproduct⇒coProduct coproduct }
+    using ()
+    renaming ( _⁂_          to infixr 7 _+₁_
+             ; ⟨⟩-congʳ     to []-congʳ
+             ; ⟨⟩-congˡ     to []-congˡ
+             ; assocˡ       to +-assocʳ
+             ; assocʳ       to +-assocˡ
+             ; assocˡ∘assocʳ to +-assocˡ∘+-assocʳ
+             ; assocʳ∘assocˡ to +-assocʳ∘+-assocˡ
+             ; swap         to +-swap
+             ; first        to +-first
+             ; second       to +-second
+             ; π₁∘⁂         to +₁∘i₁
+             ; π₂∘⁂         to +₁∘i₂
+             ; ⁂-cong₂      to +₁-cong₂
+             ; ⁂∘⟨⟩         to []∘+₁
+             ; first∘⟨⟩     to []∘+-first
+             ; second∘⟨⟩    to []∘+-second
+             ; ⁂∘⁂          to +₁∘+₁
+             ; ⟨⟩∘          to ∘[]
+             ; first∘first  to +-first∘+-first
+             ; second∘second to +-second∘+-second
+             ; first∘second to +-first∘+-second
+             ; second∘first to +-second∘+-first
+             ; first↔second to +-second↔+-first
+             ; firstid      to +-firstid
+             ; swap∘⟨⟩      to []∘+-swap
+             ; swap∘⁂       to +₁∘+-swap
+             ; swap∘swap    to +-swap∘+-swap
+             ; swap-epi     to +-swap-epi
+             ; swap-mono    to +-swap-mono
+             ; assocʳ∘⟨⟩    to []∘+-assocʳ
+             ; assocˡ∘⟨⟩    to []∘+-assocˡ
+             ; assocʳ∘⁂     to +₁∘+-assocʳ
+             ; assocˡ∘⁂     to +₁∘+-assocˡ
+             ; Δ            to ∇
+             ; Δ∘           to ∘∇
+             ; ⁂∘Δ          to ∇∘+₁
+             )
+    public
+
+  -- since op-×- has type Bifunctor 𝒞.op 𝒞.op 𝒞.op,
+  -- need to rewrap in order to type check
+  -+- : Bifunctor 𝒞 𝒞 𝒞
+  -+- = record
+    { F₀           = op-×-.F₀
+    ; F₁           = op-×-.F₁
+    ; identity     = op-×-.identity
+    ; homomorphism = op-×-.homomorphism
+    ; F-resp-≈     = op-×-.F-resp-≈
+    }
+    where op-×- = op-binaryProducts.-×-
+          module op-×- = Functor op-×-
+
+  -+_ : Obj → Functor 𝒞 𝒞
+  -+_ = appʳ -+-
+
+  _+- : Obj → Functor 𝒞 𝒞
+  _+- = appˡ -+-

--- a/src/Categories/Category/BinaryProducts.agda
+++ b/src/Categories/Category/BinaryProducts.agda
@@ -6,7 +6,7 @@ open import Categories.Category.Core using (Category)
 
 module Categories.Category.BinaryProducts {o ℓ e} (𝒞 : Category o ℓ e) where
 
-open import Level hiding (suc)
+open import Level using (levelOfTerm)
 open import Data.Product using (uncurry)
 
 open Category 𝒞
@@ -29,7 +29,6 @@ record BinaryProducts : Set (levelOfTerm 𝒞) where
 
   infixr 7 _×_
   infixr 8 _⁂_
-  infix 11 ⟨_,_⟩
 
   field
     product : ∀ {A B} → Product A B
@@ -46,11 +45,7 @@ record BinaryProducts : Set (levelOfTerm 𝒞) where
   ×-assoc : X × Y × Z ≅ (X × Y) × Z
   ×-assoc = Associative product product product product
 
-  open product hiding (⟨_,_⟩; ∘-distribʳ-⟨⟩) public
-
-  -- define it like this instead of reexporting to redefine fixity
-  ⟨_,_⟩ : X ⇒ A → X ⇒ B → X ⇒ A × B
-  ⟨_,_⟩ = Product.⟨_,_⟩ product
+  open product renaming (⟨_,_⟩ to infix 11 ⟨_,_⟩) public
 
   _⁂_ : A ⇒ B → C ⇒ D → A × C ⇒ B × D
   f ⁂ g = [ product ⇒ product ] f × g

--- a/src/Categories/Category/Cartesian.agda
+++ b/src/Categories/Category/Cartesian.agda
@@ -10,25 +10,24 @@ open import Categories.Category using (Category)
 module Categories.Category.Cartesian {o ℓ e} (𝒞 : Category o ℓ e) where
 
 open import Level using (levelOfTerm)
-open import Data.Nat using (ℕ; zero; suc)
-
-open Category 𝒞
-open HomReasoning
+open import Data.Nat using (ℕ; suc)
 
 open import Categories.Category.BinaryProducts 𝒞 using (BinaryProducts; module BinaryProducts)
 open import Categories.Object.Terminal 𝒞 using (Terminal)
 
 private
+  open Category 𝒞
   variable
-    A B C D W X Y Z : Obj
-    f f′ g g′ h i : A ⇒ B
+    A : Obj
 
 -- Cartesian monoidal category
 record Cartesian : Set (levelOfTerm 𝒞) where
   field
     terminal : Terminal
     products : BinaryProducts
-  open BinaryProducts products using (_×_)
+  
+  open Terminal terminal public
+  open BinaryProducts products public
 
   power : Obj → ℕ → Obj
   power A 0 = Terminal.⊤ terminal

--- a/src/Categories/Category/Cartesian/Monoidal.agda
+++ b/src/Categories/Category/Cartesian/Monoidal.agda
@@ -30,12 +30,12 @@ private
 
 module CartesianMonoidal (cartesian : Cartesian 𝒞) where
   open Commutation 𝒞
-  open Terminal (Cartesian.terminal cartesian)  using (⊤; !; !-unique; !-unique₂)
-  open BinaryProducts (Cartesian.products cartesian) using (π₁; π₂; ⟨_,_⟩; _×_; _⁂_;
+  open Cartesian cartesian using (π₁; π₂; ⟨_,_⟩; _×_; _⁂_;
     _×-; -×_; ⟨⟩∘; ⟨⟩-cong₂; -×-; ×-assoc; assocˡ∘⁂; assocʳ∘⁂; ⁂∘⟨⟩;
     first∘⟨⟩; second∘⟨⟩; ⟨⟩-congˡ; ⟨⟩-congʳ; π₁∘⁂; π₂∘⁂; assocˡ∘⟨⟩;
     assocˡ; assocʳ;
-    η; unique; project₁; project₂)
+    η; unique; project₁; project₂;
+    ⊤; !; !-unique; !-unique₂)
 
   ⊤×A≅A : ⊤ × A ≅ A
   ⊤×A≅A = record

--- a/src/Categories/Category/Cartesian/Properties.agda
+++ b/src/Categories/Category/Cartesian/Properties.agda
@@ -87,8 +87,6 @@ module _ (prods : BinaryProducts) (pullbacks : ∀ {A B X} (f : A ⇒ X) (g : B 
 
 module Prods (car : Cartesian) where
   open Cartesian car
-  open BinaryProducts products
-  open Terminal terminal
 
   -- for lists
 

--- a/src/Categories/Category/Cartesian/SymmetricMonoidal.agda
+++ b/src/Categories/Category/Cartesian/SymmetricMonoidal.agda
@@ -5,11 +5,9 @@ open import Categories.Category.Cartesian using (Cartesian)
 
 -- Defines the following properties of a Category:
 -- Cartesian.SymmetricMonoidal
---    a Cartesian category is Symmetric Monoidal if its induced monoidal structure is symmetric
+--    a Cartesian category is Symmetric Monoidal
 
 module Categories.Category.Cartesian.SymmetricMonoidal {o ℓ e} (𝒞 : Category o ℓ e) (cartesian : Cartesian 𝒞) where
-
-open import Data.Product using (_,_)
 
 open Category 𝒞
 open Commutation 𝒞
@@ -26,11 +24,10 @@ private
   variable
     W X Y Z : Obj
 
-open Cartesian cartesian using (products)
+open Cartesian cartesian
 open CartesianMonoidal cartesian using (monoidal)
 open Sym monoidal using (Symmetric; symmetricHelper)
 open Monoidal monoidal using (_⊗₀_; _⊗₁_; module associator)
-open BinaryProducts products
 
 private
   B : ∀ {X Y} → X ⊗₀ Y ⇒ Y ⊗₀ X

--- a/src/Categories/Category/Cartesian/SymmetricMonoidal.agda
+++ b/src/Categories/Category/Cartesian/SymmetricMonoidal.agda
@@ -24,7 +24,8 @@ private
   variable
     W X Y Z : Obj
 
-open Cartesian cartesian
+open Cartesian cartesian using (π₁; π₂; ⟨_,_⟩; ⟨⟩-congʳ; ⟨⟩-congˡ; ⟨⟩-cong₂; 
+  swap; swap∘⟨⟩; swap∘swap; assocˡ; assocˡ∘⟨⟩; ⁂∘⟨⟩; ⟨⟩∘; swap∘⁂)
 open CartesianMonoidal cartesian using (monoidal)
 open Sym monoidal using (Symmetric; symmetricHelper)
 open Monoidal monoidal using (_⊗₀_; _⊗₁_; module associator)
@@ -42,7 +43,7 @@ hexagon : [ (X ⊗₀ Y) ⊗₀ Z ⇒ Y ⊗₀ Z ⊗₀ X ]⟨
             associator.from
           ⟩
 hexagon = begin
-      id ⊗₁ swap ∘ assocˡ ∘ swap ⊗₁ id                        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟨⟩-congʳ ⟨⟩∘ ⟩
+      id ⊗₁ swap ∘ assocˡ ∘ swap ⊗₁ id                          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟨⟩-congʳ ⟨⟩∘ ⟩
       id ⊗₁ swap ∘ assocˡ ∘ ⟨ ⟨ π₂ ∘ π₁ , π₁ ∘ π₁ ⟩ , id ∘ π₂ ⟩ ≈⟨ refl⟩∘⟨ assocˡ∘⟨⟩ ⟩
       id ⊗₁ swap ∘ ⟨ π₂ ∘ π₁ , ⟨ π₁ ∘ π₁ , id ∘ π₂ ⟩ ⟩          ≈⟨ ⁂∘⟨⟩ ⟩
       ⟨ id ∘ π₂ ∘ π₁ , swap ∘ ⟨ π₁ ∘ π₁ , id ∘ π₂ ⟩ ⟩           ≈⟨ ⟨⟩-cong₂ identityˡ swap∘⟨⟩ ⟩

--- a/src/Categories/Category/CartesianClosed/Canonical.agda
+++ b/src/Categories/Category/CartesianClosed/Canonical.agda
@@ -81,7 +81,7 @@ record CartesianClosed : Set (levelOfTerm 𝒞) where
     }
 
   open Cartesian isCartesian
-  open BinaryProducts products using (_⁂_)
+   using (_⁂_)
 
   field
 

--- a/src/Categories/Category/CartesianClosed/Canonical.agda
+++ b/src/Categories/Category/CartesianClosed/Canonical.agda
@@ -80,8 +80,7 @@ record CartesianClosed : Set (levelOfTerm 𝒞) where
     ; products = record { product = ×-product }
     }
 
-  open Cartesian isCartesian
-   using (_⁂_)
+  open Cartesian isCartesian using (_⁂_)
 
   field
 

--- a/src/Categories/Category/CartesianClosed/Properties.agda
+++ b/src/Categories/Category/CartesianClosed/Properties.agda
@@ -24,10 +24,9 @@ open import Categories.Object.Terminal using (Terminal)
 
 open Category 𝒞
 open CartesianClosed 𝓥 using (_^_; eval′; cartesian)
-open Cartesian cartesian using (products; terminal)
+open Cartesian cartesian hiding (!; !-unique₂)
 open CartesianMonoidalClosed 𝒞 𝓥 using (closedMonoidal)
-open BinaryProducts products
-open Terminal terminal using (⊤)
+
 open HomReasoning
 
 private
@@ -35,7 +34,7 @@ private
 
 PointSurjective : ∀ {A X Y : Obj} → (X ⇒ Y ^ A) → Set (ℓ ⊔ e)
 PointSurjective {A = A} {X = X} {Y = Y} ϕ =
-  ∀ (f : A ⇒ Y) → Σ[ x ∈ ⊤ ⇒ X ] (∀ (a : ⊤ ⇒ A) → eval′ ∘ first ϕ ∘ ⟨ x , a ⟩  ≈ f ∘ a)
+  ∀ (f : A ⇒ Y) → Σ[ x ∈ ⊤ ⇒ X ] (∀ (a : ⊤ ⇒ A) → eval′ ∘ first ϕ ∘ ⟨ x , a ⟩ ≈ f ∘ a)
 
 lawvere-fixed-point : ∀ {A B : Obj} → (ϕ : A ⇒ B ^ A) → PointSurjective ϕ → (f : B ⇒ B) → Σ[ s ∈ ⊤ ⇒ B ] f ∘ s ≈ s
 lawvere-fixed-point {A = A} {B = B} ϕ surjective f = g ∘ x , g-fixed-point

--- a/src/Categories/Category/CartesianClosed/Properties.agda
+++ b/src/Categories/Category/CartesianClosed/Properties.agda
@@ -24,7 +24,7 @@ open import Categories.Object.Terminal using (Terminal)
 
 open Category 𝒞
 open CartesianClosed 𝓥 using (_^_; eval′; cartesian)
-open Cartesian cartesian hiding (!; !-unique₂)
+open Cartesian cartesian using (_×_; ⟨_,_⟩; π₁; π₂; project₁; project₂; first; _⁂_; ⊤; ⟨⟩∘; ⁂∘⟨⟩; -×_)
 open CartesianMonoidalClosed 𝒞 𝓥 using (closedMonoidal)
 
 open HomReasoning
@@ -56,11 +56,11 @@ lawvere-fixed-point {A = A} {B = B} ϕ surjective f = g ∘ x , g-fixed-point
 
     g-fixed-point : f ∘ (g ∘ x) ≈ g ∘ x
     g-fixed-point = begin
-      f ∘ g ∘ x                       ≈˘⟨  refl⟩∘⟨ g-surjective ⟩
-      f ∘ eval′ ∘ first ϕ ∘ ⟨ x , x ⟩  ≈⟨ refl⟩∘⟨ refl⟩∘⟨ lemma ϕ id x ⟩
-      f ∘ eval′ ∘ ⟨ ϕ , id ⟩ ∘ x       ≈⟨ ∘-resp-≈ʳ sym-assoc ○ sym-assoc ⟩
-      (f ∘ eval′ ∘ ⟨ ϕ , id ⟩) ∘ x     ≡⟨⟩
-      g ∘ x                            ∎
+      f ∘ g ∘ x                       ≈˘⟨ refl⟩∘⟨ g-surjective ⟩
+      f ∘ eval′ ∘ first ϕ ∘ ⟨ x , x ⟩ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ lemma ϕ id x ⟩
+      f ∘ eval′ ∘ ⟨ ϕ , id ⟩ ∘ x      ≈⟨ ∘-resp-≈ʳ sym-assoc ○ sym-assoc ⟩
+      (f ∘ eval′ ∘ ⟨ ϕ , id ⟩) ∘ x    ≡⟨⟩
+      g ∘ x                           ∎
 
 initial→product-initial : ∀ {⊥ A} → IsInitial ⊥ → IsInitial (⊥ × A)
 initial→product-initial {⊥} {A} i = initial.⊥-is-initial
@@ -81,10 +81,10 @@ initial→strict-initial {⊥} i .is-strict f = record
   ; to = !
   ; iso = record
     { isoˡ = begin
-      ! ∘ f                ≈˘⟨ refl⟩∘⟨ project₁ ⟩
-      ! ∘ π₁ ∘ ⟨ f , id ⟩   ≈⟨ pullˡ (initial-product.!-unique₂ (! ∘ π₁) π₂)  ⟩
-      π₂ ∘ ⟨ f , id ⟩       ≈⟨ project₂ ⟩
-      id                    ∎
+      ! ∘ f               ≈˘⟨ refl⟩∘⟨ project₁ ⟩
+      ! ∘ π₁ ∘ ⟨ f , id ⟩ ≈⟨ pullˡ (initial-product.!-unique₂ (! ∘ π₁) π₂)  ⟩
+      π₂ ∘ ⟨ f , id ⟩     ≈⟨ project₂ ⟩
+      id                  ∎
     ; isoʳ = !-unique₂ (f ∘ !) id
     }
   }

--- a/src/Categories/Category/Cocartesian.agda
+++ b/src/Categories/Category/Cocartesian.agda
@@ -2,133 +2,46 @@
 
 open import Categories.Category.Core using (Category)
 
--- BinaryCoproducts -- a category with all binary coproducts
--- Cocartesian -- a category with all coproducts
+-- Defines the following properties of a Category:
+-- Cocartesian -- a Cocartesian category is a category with all coproducts
 
--- since most of the work is dual to Categories.Category.Cartesian, so the idea
+-- Most of the work is dual to Categories.Category.Cartesian, so the idea
 -- in this module is to make use of duality
+
 module Categories.Category.Cocartesian {o ℓ e} (𝒞 : Category o ℓ e) where
 
-open import Level
+open import Level using (levelOfTerm)
+open import Data.Nat using (ℕ; suc)
+
 
 private
   module 𝒞 = Category 𝒞
-  open Category 𝒞
-  open HomReasoning
+  open 𝒞
   variable
-    A B C D : Obj
-    f g h i : A ⇒ B
+    A : Obj
 
-open import Categories.Category.BinaryProducts using (BinaryProducts)
+open import Categories.Category.BinaryCoproducts 𝒞
 open import Categories.Category.Cartesian 𝒞.op
-open import Categories.Category.Cartesian.Monoidal using (module CartesianMonoidal)
-import Categories.Category.Cartesian.SymmetricMonoidal as CSM
-open import Categories.Category.Monoidal using (Monoidal)
-open import Categories.Category.Monoidal.Symmetric
-open import Categories.Morphism 𝒞
-open import Categories.Morphism.Properties 𝒞
-open import Categories.Morphism.Duality 𝒞
-open import Categories.Morphism.Reasoning 𝒞
-open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism)
 open import Categories.Object.Initial 𝒞 using (Initial)
-open import Categories.Object.Coproduct 𝒞
 open import Categories.Object.Duality 𝒞
-
-open import Categories.Functor renaming (id to idF)
-open import Categories.Functor.Properties
-open import Categories.Functor.Bifunctor
-
-record BinaryCoproducts : Set (levelOfTerm 𝒞) where
-
-  infixr 6 _+_
-  infixr 7 _+₁_
-
-  field
-    coproduct : ∀ {A B} → Coproduct A B
-
-  module coproduct {A} {B} = Coproduct (coproduct {A} {B})
-
-  _+_ : Obj → Obj → Obj
-  A + B = coproduct.A+B {A} {B}
-
-  open coproduct
-    using (i₁; i₂; [_,_]; inject₁; inject₂; []-cong₂; ∘-distribˡ-[])
-    renaming (unique to +-unique; η to +-η; g-η to +-g-η)
-    public
-
-  module Dual where
-    op-binaryProducts : BinaryProducts op
-    op-binaryProducts = record { product = Coproduct⇒coProduct coproduct }
-
-    module op-binaryProducts = BinaryProducts op-binaryProducts
-
-  open Dual
-
-  +-comm : A + B ≅ B + A
-  +-comm = op-≅⇒≅ (op-binaryProducts.×-comm)
-
-  +-assoc : A + B + C ≅ (A + B) + C
-  +-assoc = op-≅⇒≅ (op-binaryProducts.×-assoc)
-
-  _+₁_ : A ⇒ B → C ⇒ D → A + C ⇒ B + D
-  _+₁_ = op-binaryProducts._⁂_
-
-  open op-binaryProducts
-    using ()
-    renaming ( ⟨⟩-congʳ     to []-congʳ
-             ; ⟨⟩-congˡ     to []-congˡ
-             ; assocˡ       to +-assocʳ
-             ; assocʳ       to +-assocˡ
-             ; swap         to +-swap
-             ; first        to +-first
-             ; second       to +-second
-             ; π₁∘⁂         to +₁∘i₁
-             ; π₂∘⁂         to +₁∘i₂
-             ; ⁂-cong₂      to +₁-cong₂
-             ; ⁂∘⟨⟩         to []∘+₁
-             ; ⁂∘⁂          to +₁∘+₁
-             ; ⟨⟩∘          to ∘[]
-             ; first↔second to +-second↔first
-             ; swap∘⁂       to +₁∘+-swap
-             ; swap∘swap    to +-swap∘swap
-             )
-    public
-
-  -- since op-×- has type Bifunctor 𝒞.op 𝒞.op 𝒞.op,
-  -- need to rewrap in order to type check
-  -+- : Bifunctor 𝒞 𝒞 𝒞
-  -+- = record
-    { F₀           = op-×-.F₀
-    ; F₁           = op-×-.F₁
-    ; identity     = op-×-.identity
-    ; homomorphism = op-×-.homomorphism
-    ; F-resp-≈     = op-×-.F-resp-≈
-    }
-    where op-×- = op-binaryProducts.-×-
-          module op-×- = Functor op-×-
-
-  -+_ : Obj → Functor 𝒞 𝒞
-  -+_ = appʳ -+-
-
-  _+- : Obj → Functor 𝒞 𝒞
-  _+- = appˡ -+-
-
 
 record Cocartesian : Set (levelOfTerm 𝒞) where
   field
     initial    : Initial
     coproducts : BinaryCoproducts
 
-  module initial    = Initial initial
-  module coproducts = BinaryCoproducts coproducts
-
-  open initial
+  open Initial initial
     renaming (! to ¡; !-unique to ¡-unique; !-unique₂ to ¡-unique₂)
     public
-  open coproducts hiding (module Dual) public
+  open BinaryCoproducts coproducts hiding (module Dual) public
+
+  times : Obj → ℕ → Obj
+  times A 0 = Initial.⊥ initial
+  times A 1 = A
+  times A (suc (suc n)) = A + times A (suc n)
 
   module Dual where
-    open coproducts.Dual public
+    open BinaryCoproducts.Dual coproducts public
 
     op-cartesian : Cartesian
     op-cartesian = record
@@ -137,92 +50,3 @@ record Cocartesian : Set (levelOfTerm 𝒞) where
       }
 
     module op-cartesian = Cartesian op-cartesian
-
--- The op-cartesian structure induces a monoidal one.
-
-module CocartesianMonoidal (cocartesian : Cocartesian) where
-  open Cocartesian cocartesian
-  private module op-cartesianMonoidal = CartesianMonoidal Dual.op-cartesian
-
-  ⊥+A≅A : ⊥ + A ≅ A
-  ⊥+A≅A = op-≅⇒≅ (op-cartesianMonoidal.⊤×A≅A)
-
-  A+⊥≅A : A + ⊥ ≅ A
-  A+⊥≅A = op-≅⇒≅ (op-cartesianMonoidal.A×⊤≅A)
-
-  open op-cartesianMonoidal using (monoidal; ⊤×--id; -×⊤-id)
-  open NaturalIsomorphism using (op′)
-
-  ⊥+--id : NaturalIsomorphism (⊥ +-) idF
-  ⊥+--id = op′ ⊤×--id
-
-  -+⊥-id : NaturalIsomorphism (-+ ⊥) idF
-  -+⊥-id = op′ -×⊤-id
-
-  open Monoidal monoidal using (unit; unitorˡ-commute-to; unitorˡ-commute-from; unitorʳ-commute-to;
-    unitorʳ-commute-from; assoc-commute-to; assoc-commute-from; triangle; pentagon)
-
-  +-monoidal : Monoidal 𝒞
-  +-monoidal = record
-    { ⊗                    = -+-
-    ; unit                 = unit
-    ; unitorˡ              = ⊥+A≅A
-    ; unitorʳ              = A+⊥≅A
-    ; associator           = ≅.sym +-assoc
-    ; unitorˡ-commute-from = ⟺ unitorˡ-commute-to
-    ; unitorˡ-commute-to   = ⟺ unitorˡ-commute-from
-    ; unitorʳ-commute-from = ⟺ unitorʳ-commute-to
-    ; unitorʳ-commute-to   = ⟺ unitorʳ-commute-from
-    ; assoc-commute-from   = ⟺ assoc-commute-to
-    ; assoc-commute-to     = ⟺ assoc-commute-from
-    -- the proof idea of triangle is that the opposite triangle is obtained for free,
-    -- but notice that triangle and the opposite triangle form isomorphism.
-    ; triangle             = λ {X Y} →
-                               Iso-≈ triangle
-                                     (Iso-∘ ([ X +- ]-resp-Iso (Iso-swap (iso ⊥+A≅A)))
-                                            (iso +-assoc))
-                                     ([ -+ Y ]-resp-Iso (Iso-swap (iso A+⊥≅A)))
-    ; pentagon             = λ {X Y Z W} →
-                               Iso-≈ pentagon
-                                     (Iso-∘ ([ X +- ]-resp-Iso (iso +-assoc))
-                                     (Iso-∘ (iso +-assoc)
-                                            ([ -+ W ]-resp-Iso (iso +-assoc))))
-                                     (Iso-∘ (iso +-assoc) (iso +-assoc))
-    }
-    where open op-cartesianMonoidal
-          open _≅_
-
-  open Monoidal +-monoidal public
-
-module CocartesianSymmetricMonoidal (cocartesian : Cocartesian) where
-  open Cocartesian cocartesian
-  open CocartesianMonoidal cocartesian
-  private
-    module op-cartesianSymmetricMonoidal = CSM 𝒞.op Dual.op-cartesian
-
-  +-symmetric : Symmetric +-monoidal
-  +-symmetric = record
-    { braided     = record
-      { braiding = record
-        { F⇒G = record
-          { η           = λ _ → +-swap
-          ; commute     = λ _ → ⟺ +₁∘+-swap
-          ; sym-commute = λ _ → +₁∘+-swap
-          }
-        ; F⇐G = record
-          { η           = λ _ → +-swap
-          ; commute     = λ _ → ⟺ +₁∘+-swap
-          ; sym-commute = λ _ → +₁∘+-swap
-          }
-        ; iso = λ _ → iso +-comm
-        }
-      ; hexagon₁ = hexagon₂
-      ; hexagon₂ = hexagon₁
-      }
-    ; commutative = commutative
-    }
-    where open op-cartesianSymmetricMonoidal
-          open _≅_
-          open Symmetric symmetric using (commutative; hexagon₁; hexagon₂)
-
-  open Symmetric +-symmetric public

--- a/src/Categories/Category/Cocartesian/Monoidal.agda
+++ b/src/Categories/Category/Cocartesian/Monoidal.agda
@@ -1,0 +1,79 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category using (Category)
+
+-- Defines the induced Monoidal structure of a Cocartesian Category
+
+module Categories.Category.Cocartesian.Monoidal {o ℓ e} {𝒞 : Category o ℓ e} where
+
+open Category 𝒞
+open HomReasoning
+
+open import Categories.Category.Cocartesian 𝒞
+open import Categories.Category.Cartesian.Monoidal using (module CartesianMonoidal)
+open import Categories.Category.Monoidal using (Monoidal)
+open import Categories.Morphism 𝒞
+open import Categories.Morphism.Properties 𝒞
+open import Categories.Morphism.Duality 𝒞
+open import Categories.NaturalTransformation.NaturalIsomorphism using (NaturalIsomorphism)
+
+open import Categories.Functor renaming (id to idF)
+open import Categories.Functor.Properties
+
+private
+  variable
+    A : Obj
+
+-- The cocartesian structure induces a monoidal one: 𝒞 is cocartesian monoidal.
+
+module CocartesianMonoidal (cocartesian : Cocartesian) where
+  open Cocartesian cocartesian
+  private module op-cartesianMonoidal = CartesianMonoidal Dual.op-cartesian
+
+  ⊥+A≅A : ⊥ + A ≅ A
+  ⊥+A≅A = op-≅⇒≅ (op-cartesianMonoidal.⊤×A≅A)
+
+  A+⊥≅A : A + ⊥ ≅ A
+  A+⊥≅A = op-≅⇒≅ (op-cartesianMonoidal.A×⊤≅A)
+
+  open op-cartesianMonoidal using (monoidal; ⊤×--id; -×⊤-id)
+  open NaturalIsomorphism using (op′)
+
+  ⊥+--id : NaturalIsomorphism (⊥ +-) idF
+  ⊥+--id = op′ ⊤×--id
+
+  -+⊥-id : NaturalIsomorphism (-+ ⊥) idF
+  -+⊥-id = op′ -×⊤-id
+
+  open Monoidal monoidal using (unit; unitorˡ-commute-to; unitorˡ-commute-from; unitorʳ-commute-to;
+    unitorʳ-commute-from; assoc-commute-to; assoc-commute-from; triangle; pentagon)
+
+  +-monoidal : Monoidal 𝒞
+  +-monoidal = record
+    { ⊗                    = -+-
+    ; unit                 = unit
+    ; unitorˡ              = ⊥+A≅A
+    ; unitorʳ              = A+⊥≅A
+    ; associator           = ≅.sym +-assoc
+    ; unitorˡ-commute-from = ⟺ unitorˡ-commute-to
+    ; unitorˡ-commute-to   = ⟺ unitorˡ-commute-from
+    ; unitorʳ-commute-from = ⟺ unitorʳ-commute-to
+    ; unitorʳ-commute-to   = ⟺ unitorʳ-commute-from
+    ; assoc-commute-from   = ⟺ assoc-commute-to
+    ; assoc-commute-to     = ⟺ assoc-commute-from
+    -- the proof idea of triangle is that the opposite triangle is obtained for free,
+    -- but notice that triangle and the opposite triangle form isomorphism.
+    ; triangle             = λ {X Y} →
+                               Iso-≈ triangle
+                                     (Iso-∘ ([ X +- ]-resp-Iso (Iso-swap (iso ⊥+A≅A)))
+                                            (iso +-assoc))
+                                     ([ -+ Y ]-resp-Iso (Iso-swap (iso A+⊥≅A)))
+    ; pentagon             = λ {X Y Z W} →
+                               Iso-≈ pentagon
+                                     (Iso-∘ ([ X +- ]-resp-Iso (iso +-assoc))
+                                     (Iso-∘ (iso +-assoc)
+                                            ([ -+ W ]-resp-Iso (iso +-assoc))))
+                                     (Iso-∘ (iso +-assoc) (iso +-assoc))
+    }
+    where open op-cartesianMonoidal
+          open _≅_

--- a/src/Categories/Category/Cocartesian/Monoidal.agda
+++ b/src/Categories/Category/Cocartesian/Monoidal.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --without-K --safe #-}
 
-open import Categories.Category using (Category)
+open import Categories.Category.Core using (Category)
 
 -- Defines the induced Monoidal structure of a Cocartesian Category
 
@@ -27,7 +27,7 @@ private
 -- The cocartesian structure induces a monoidal one: 𝒞 is cocartesian monoidal.
 
 module CocartesianMonoidal (cocartesian : Cocartesian) where
-  open Cocartesian cocartesian
+  open Cocartesian cocartesian using (⊥; _+_; _+-; -+_; -+-; +-assoc; module Dual)
   private module op-cartesianMonoidal = CartesianMonoidal Dual.op-cartesian
 
   ⊥+A≅A : ⊥ + A ≅ A
@@ -63,17 +63,20 @@ module CocartesianMonoidal (cocartesian : Cocartesian) where
     ; assoc-commute-to     = ⟺ assoc-commute-from
     -- the proof idea of triangle is that the opposite triangle is obtained for free,
     -- but notice that triangle and the opposite triangle form isomorphism.
-    ; triangle             = λ {X Y} →
-                               Iso-≈ triangle
-                                     (Iso-∘ ([ X +- ]-resp-Iso (Iso-swap (iso ⊥+A≅A)))
-                                            (iso +-assoc))
-                                     ([ -+ Y ]-resp-Iso (Iso-swap (iso A+⊥≅A)))
-    ; pentagon             = λ {X Y Z W} →
-                               Iso-≈ pentagon
-                                     (Iso-∘ ([ X +- ]-resp-Iso (iso +-assoc))
-                                     (Iso-∘ (iso +-assoc)
-                                            ([ -+ W ]-resp-Iso (iso +-assoc))))
-                                     (Iso-∘ (iso +-assoc) (iso +-assoc))
+    ; triangle             = triangle'
+    ; pentagon             = λ {X Y Z W} → pentagon' {X} {Y} {Z} {W}
     }
-    where open op-cartesianMonoidal
-          open _≅_
+    where 
+    open op-cartesianMonoidal
+    open _≅_
+    triangle' = λ {X Y} →
+                          Iso-≈ triangle
+                                (Iso-∘ ([ X +- ]-resp-Iso (Iso-swap (iso ⊥+A≅A)))
+                                      (iso +-assoc))
+                                ([ -+ Y ]-resp-Iso (Iso-swap (iso A+⊥≅A)))
+    pentagon' = λ {X Y Z W} →
+                          Iso-≈ pentagon
+                                (Iso-∘ ([ X +- ]-resp-Iso (iso +-assoc))
+                                (Iso-∘ (iso +-assoc)
+                                      ([ -+ W ]-resp-Iso (iso +-assoc))))
+                                (Iso-∘ (iso +-assoc) (iso +-assoc))

--- a/src/Categories/Category/Cocartesian/SymmetricMonoidal.agda
+++ b/src/Categories/Category/Cocartesian/SymmetricMonoidal.agda
@@ -1,0 +1,54 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core using (Category)
+
+-- Defines the following properties of a Category:
+-- Cocartesian.SymmetricMonoidal
+--    a Cocartesian category is Symmetric Monoidal
+
+module Categories.Category.Cocartesian.SymmetricMonoidal {o ℓ e} (𝒞 : Category o ℓ e) where
+
+open Category 𝒞
+open HomReasoning
+
+private
+  module 𝒞 = Category 𝒞
+
+open import Categories.Category.Cocartesian 𝒞
+open import Categories.Category.Cocartesian.Monoidal
+import Categories.Category.Cartesian.SymmetricMonoidal as CSM
+open import Categories.Category.Monoidal.Symmetric
+open import Categories.Morphism 𝒞
+
+module CocartesianSymmetricMonoidal (cocartesian : Cocartesian) where
+  open Cocartesian cocartesian
+  open CocartesianMonoidal cocartesian
+  private
+    module op-cartesianSymmetricMonoidal = CSM 𝒞.op Dual.op-cartesian
+
+  +-symmetric : Symmetric +-monoidal
+  +-symmetric = record
+    { braided     = record
+      { braiding = record
+        { F⇒G = record
+          { η           = λ _ → +-swap
+          ; commute     = λ _ → ⟺ +₁∘+-swap
+          ; sym-commute = λ _ → +₁∘+-swap
+          }
+        ; F⇐G = record
+          { η           = λ _ → +-swap
+          ; commute     = λ _ → ⟺ +₁∘+-swap
+          ; sym-commute = λ _ → +₁∘+-swap
+          }
+        ; iso = λ _ → iso +-comm
+        }
+      ; hexagon₁ = hexagon₂
+      ; hexagon₂ = hexagon₁
+      }
+    ; commutative = commutative
+    }
+    where open op-cartesianSymmetricMonoidal
+          open _≅_
+          open Symmetric symmetric using (commutative; hexagon₁; hexagon₂)
+
+  open Symmetric +-symmetric public

--- a/src/Categories/Category/Construction/Groups.agda
+++ b/src/Categories/Category/Construction/Groups.agda
@@ -16,7 +16,7 @@ open import Categories.Object.Product.Morphisms 𝒞
 
 open Category 𝒞
 open Cartesian C
-open BinaryProducts products
+
 open Equiv
 open HomReasoning
 open Group using (μ)

--- a/src/Categories/Category/Construction/Properties/Presheaves/FromCartesianCCC.agda
+++ b/src/Categories/Category/Construction/Properties/Presheaves/FromCartesianCCC.agda
@@ -36,7 +36,7 @@ module FromCartesian o′ ℓ′ {o ℓ e} {C : Category o ℓ e} (Car : Cartesi
     S = Setoids o′ ℓ′
     open Prod C using (id×id)
     open Cartesian Car
-    open BinaryProducts products
+    
 
   Pres-exp : (F : Presheaf C S) (X : C.Obj) → Presheaf C S
   Pres-exp F X = record

--- a/src/Categories/Category/Distributive.agda
+++ b/src/Categories/Category/Distributive.agda
@@ -23,8 +23,7 @@ record Distributive : Set (levelOfTerm 𝒞) where
     cartesian : Cartesian 𝒞
     cocartesian : Cocartesian 𝒞
 
-  open Cartesian cartesian using (products)
-  open BinaryProducts products
+  open Cartesian cartesian
   open Cocartesian cocartesian
 
   distributeˡ : ∀ {A B C : Obj} → A × B + A × C ⇒ A × (B + C)

--- a/src/Categories/Category/Distributive/Properties.agda
+++ b/src/Categories/Category/Distributive/Properties.agda
@@ -19,8 +19,7 @@ open HomReasoning
 open Equiv
 
 open Distributive distributive
-open Cartesian cartesian using (products)
-open BinaryProducts products
+open Cartesian cartesian
 open Cocartesian cocartesian
 
 -- distribution and injection

--- a/src/Categories/Category/Extensive/Properties.agda
+++ b/src/Categories/Category/Extensive/Properties.agda
@@ -32,9 +32,9 @@ module _ (extensive : Extensive 𝒞) where
       gf≈hf = sym CP.inject₁ ○ CP.inject₂
 
   to-⊥-is-iso : ∀ {A} (f : A ⇒ ⊥) → IsIso f
-  to-⊥-is-iso f .M.IsIso.inv = CC.initial.!
+  to-⊥-is-iso f .M.IsIso.inv = ¡
   to-⊥-is-iso f .M.IsIso.iso .M.Iso.isoʳ = ¡-unique₂ _ _
-  to-⊥-is-iso f .M.IsIso.iso .M.Iso.isoˡ = equal-inj id (pullback-of-cp-is-cp' pb₁ pb₂) (initial.! ∘ f) id
+  to-⊥-is-iso f .M.IsIso.iso .M.Iso.isoˡ = equal-inj id (pullback-of-cp-is-cp' pb₁ pb₂) (¡ ∘ f) id
     where
       pb₁ : Pullback (i₁ ∘ f) i₁
       pb₁ = record
@@ -69,7 +69,7 @@ module _ (extensive : Extensive 𝒞) where
     where
       open Pullback using (p₁; p₂; commute)
 
-      clash : ∀ {Q} {h₁ : Q ⇒ B} {h₂ : Q ⇒ A + C} → i₁ ∘ h₁ ≈ (f +₁ g) ∘ h₂ → Pullback.P (pullback₂ h₂) ⇒ initial.⊥
+      clash : ∀ {Q} {h₁ : Q ⇒ B} {h₂ : Q ⇒ A + C} → i₁ ∘ h₁ ≈ (f +₁ g) ∘ h₂ → Pullback.P (pullback₂ h₂) ⇒ ⊥
       clash {_}{h₁}{h₂} eq = IsPullback.universal disjoint
         (begin
             i₁ ∘ h₁ ∘ p₁ (pullback₂ h₂)                     ≈⟨ extendʳ eq ⟩
@@ -130,9 +130,9 @@ module _ (extensive : Extensive 𝒞) where
    where
      jm : JointMono₂ (f +₁ g) CC.+-swap
      jm h₁ h₂ h = begin
-       h₁                                      ≈⟨ introˡ CC.+-swap∘swap  ⟩ 
+       h₁                                      ≈⟨ introˡ CC.+-swap∘+-swap  ⟩ 
        (CC.+-swap ∘ CC.+-swap) ∘  h₁           ≈⟨ pullʳ (h (nzero zero)) ⟩ 
-       CC.+-swap ∘ CC.+-swap ∘ h₂              ≈⟨ cancelˡ CC.+-swap∘swap  ⟩
+       CC.+-swap ∘ CC.+-swap ∘ h₂              ≈⟨ cancelˡ CC.+-swap∘+-swap  ⟩
        h₂                                      ∎ 
 
      other-pb : IsPullback g (CC.+-swap ∘ i₂) (CC.+-swap ∘ i₂) (g +₁ f)

--- a/src/Categories/Category/Instance/Properties/Cats.agda
+++ b/src/Categories/Category/Instance/Properties/Cats.agda
@@ -33,7 +33,7 @@ module CanonicallyCartesianClosed {l} where
     module Cats = Category (Cats l l l)
     module Cart = Cartesian (Product.Cats-is {l} {l} {l})
   open Cats using (_⇒_) renaming (Obj to Cat)
-  open Cart hiding (η)
+  open Cart using (_×_; π₁; π₂; unique; ⟨_,_⟩; _⁂_; project₁; project₂; !; !-unique)
 
   infixr 9 _^_
 

--- a/src/Categories/Category/Instance/Properties/Cats.agda
+++ b/src/Categories/Category/Instance/Properties/Cats.agda
@@ -33,9 +33,7 @@ module CanonicallyCartesianClosed {l} where
     module Cats = Category (Cats l l l)
     module Cart = Cartesian (Product.Cats-is {l} {l} {l})
   open Cats using (_⇒_) renaming (Obj to Cat)
-  open Cart using (products; terminal)
-  open Terminal terminal
-  open BinaryProducts products using (_×_; _⁂_; π₁; π₂; ⟨_,_⟩; project₁; project₂; unique)
+  open Cart hiding (η)
 
   infixr 9 _^_
 

--- a/src/Categories/Category/Instance/Properties/Setoids/CCC.agda
+++ b/src/Categories/Category/Instance/Properties/Setoids/CCC.agda
@@ -52,8 +52,7 @@ module _ ℓ where
     }
     where
       open Setoids-Cartesian
-      open BinaryProducts products using (_×_; π₁; π₂; ⟨_,_⟩; project₁; project₂; unique)
-      open Terminal terminal using (⊤; !; !-unique)
+       using (_×_; π₁; π₂; ⟨_,_⟩; project₁; project₂; unique; ⊤; !; !-unique)
 
   Setoids-CCC : CartesianClosed S
   Setoids-CCC = Equivalence.fromCanonical S Setoids-Canonical

--- a/src/Categories/Category/Monoidal/Construction/Kleisli/CounitalCopy.agda
+++ b/src/Categories/Category/Monoidal/Construction/Kleisli/CounitalCopy.agda
@@ -38,9 +38,7 @@ module _ {𝒞 : Category o ℓ e} (cartesian : Cartesian 𝒞) (ELM : Equationa
   open MR 𝒞
   open HomReasoning
   open Equiv
-  open Cartesian cartesian
-  open Terminal terminal
-  open BinaryProducts products renaming (η to prod-η)
+  open Cartesian cartesian renaming (η to prod-η)
 
   open EquationalLiftingMonad ELM hiding (identityˡ)
   open Monad M using (μ)

--- a/src/Categories/Category/Monoidal/Instance/Sets.agda
+++ b/src/Categories/Category/Monoidal/Instance/Sets.agda
@@ -16,6 +16,8 @@ open import Categories.Category.BinaryProducts using (BinaryProducts)
 import Categories.Category.Cartesian as Cartesian
 open import Categories.Category.Cartesian.Monoidal using (module CartesianMonoidal)
 import Categories.Category.Cocartesian as Cocartesian
+import Categories.Category.BinaryCoproducts as BinaryCoproducts
+import Categories.Category.Cocartesian.Monoidal as CM
 open import Categories.Category.Instance.EmptySet
 open import Categories.Category.Instance.Sets
 open import Categories.Category.Instance.SingletonSet
@@ -52,6 +54,7 @@ module Coproduct {o : Level} where
   private
     S = Sets o
     open Cocartesian S
+    open BinaryCoproducts S
 
   Sets-has-all : BinaryCoproducts
   Sets-has-all = record { coproduct = λ {A} {B} → record
@@ -68,4 +71,4 @@ module Coproduct {o : Level} where
   Sets-is = record { initial = EmptySet-⊥ ; coproducts = Sets-has-all }
 
   Sets-Monoidal : Monoidal S
-  Sets-Monoidal = Cocartesian.CocartesianMonoidal.+-monoidal S Sets-is
+  Sets-Monoidal = CM.CocartesianMonoidal.+-monoidal Sets-is

--- a/src/Categories/Diagram/Pullback/Properties.agda
+++ b/src/Categories/Diagram/Pullback/Properties.agda
@@ -104,7 +104,7 @@ module _ (p : Pullback id f) where
 module _ (pullbacks : ∀ {X Y Z} (f : X ⇒ Z) (g : Y ⇒ Z) → Pullback f g)
          (cartesian : Cartesian) where
   open Cartesian cartesian
-  open BinaryProducts products using (⟨_,_⟩; π₁; π₂; ⟨⟩-cong₂; ⟨⟩∘; project₁; project₂)
+   using (⟨_,_⟩; π₁; π₂; ⟨⟩-cong₂; ⟨⟩∘; project₁; project₂)
 
   pullback×cartesian⇒equalizer : Equalizer f g
   pullback×cartesian⇒equalizer {f = f} {g = g} = record

--- a/src/Categories/Functor/Cartesian/Properties.agda
+++ b/src/Categories/Functor/Cartesian/Properties.agda
@@ -27,7 +27,7 @@ private
 
 module _ (C : CartesianCategory o ℓ e) where
   open CartesianCategory C using (terminal; U; products)
-  open BinaryProducts products using (product)
+   using (product)
   open ⊤.Terminal terminal
   open P U
 

--- a/src/Categories/Functor/Monoidal/Properties.agda
+++ b/src/Categories/Functor/Monoidal/Properties.agda
@@ -235,11 +235,9 @@ module _ {A : MonoidalCategory o ℓ e} {B : MonoidalCategory o′ ℓ′ e′} 
 private
 
   module WithCartesianShorthands (C : CartesianCategory o ℓ e) where
-    open CartesianCategory C public
-    open BinaryProducts products public renaming (_⁂_ to infixr 10 _×₁_)
+    open CartesianCategory C public renaming (_⁂_ to infixr 10 _×₁_)
     open CartesianMonoidal cartesian using (monoidal)
     open ⊗-Reasoning monoidal public
-    open ⊤.Terminal terminal public
 
 module _ (C : CartesianCategory o ℓ e) (D : CartesianCategory o′ ℓ′ e′) where
 

--- a/src/Categories/Monad/EquationalLifting.agda
+++ b/src/Categories/Monad/EquationalLifting.agda
@@ -19,8 +19,7 @@ import Categories.Morphism.Reasoning as MR
 
 module Categories.Monad.EquationalLifting {o ℓ e} {C : Category o ℓ e} (cartesian : Cartesian C) where
   open Category C
-  open Cartesian cartesian using (products)
-  open BinaryProducts products hiding (η)
+  open Cartesian cartesian hiding (η)
 
   open CartesianMonoidal cartesian using (monoidal)
   open Symmetric (symmetric C cartesian) using (braided)

--- a/src/Categories/Object/Group.agda
+++ b/src/Categories/Object/Group.agda
@@ -16,10 +16,7 @@ open import Categories.Object.Monoid (CartesianMonoidal.monoidal C)
 open import Categories.Object.Terminal 𝒞
 
 open Category 𝒞
-open Cartesian C
-module Π = BinaryProducts products
-open BinaryProducts products using (_×_; _⁂_; ⟨_,_⟩)
-open Terminal terminal
+open Cartesian C using (_×_; _⁂_; ⟨_,_⟩; !)
 
 record IsGroup (G : Obj) : Set (ℓ ⊔ e) where
   -- any group object is also a monoid object

--- a/src/Categories/Object/NaturalNumbers/Parametrized.agda
+++ b/src/Categories/Object/NaturalNumbers/Parametrized.agda
@@ -11,7 +11,7 @@ module Categories.Object.NaturalNumbers.Parametrized {o ℓ e} (𝒞 : Category 
 
 open import Level
 open Category 𝒞
-open Cartesian 𝒞-Cartesian hiding (η; unique)
+open Cartesian 𝒞-Cartesian using (_×_; π₂; ⟨_,_⟩; ⟨⟩∘; ⟨⟩-cong₂; _⁂_; ⁂∘⟨⟩; project₂; terminal; ⊤; !; !-unique₂)
 open HomReasoning
 open Equiv
 open import Categories.Object.NaturalNumbers 𝒞 terminal using (IsNNO; NNO) renaming (up-to-iso to nno-up-to-iso)

--- a/src/Categories/Object/NaturalNumbers/Parametrized.agda
+++ b/src/Categories/Object/NaturalNumbers/Parametrized.agda
@@ -11,13 +11,10 @@ module Categories.Object.NaturalNumbers.Parametrized {o ℓ e} (𝒞 : Category 
 
 open import Level
 open Category 𝒞
-open Cartesian 𝒞-Cartesian
+open Cartesian 𝒞-Cartesian hiding (η; unique)
 open HomReasoning
 open Equiv
-
-open BinaryProducts products hiding (η; unique)
 open import Categories.Object.NaturalNumbers 𝒞 terminal using (IsNNO; NNO) renaming (up-to-iso to nno-up-to-iso)
-open Terminal terminal using (⊤; !; !-unique₂)
 
 open import Categories.Morphism 𝒞 using (_≅_)
 open import Categories.Morphism.Reasoning 𝒞

--- a/src/Categories/Object/NaturalNumbers/Parametrized/Properties/F-Algebras.agda
+++ b/src/Categories/Object/NaturalNumbers/Parametrized/Properties/F-Algebras.agda
@@ -3,7 +3,7 @@
 open import Level
 open import Categories.Category.Core
 open import Categories.Object.Terminal using (Terminal)
-open import Categories.Category.Cocartesian using (BinaryCoproducts)
+open import Categories.Category.BinaryCoproducts using (BinaryCoproducts)
 open import Categories.Category.Cartesian using (Cartesian)
 
 -- A parametrized NNO corresponds to existence of a (⊤ + (-)) algebra and initiality of the PNNO algebra
@@ -24,8 +24,6 @@ open Cartesian 𝒞-Cartesian
 open HomReasoning
 open Equiv
 open MR 𝒞
-open BinaryProducts products
-open Terminal terminal
 
 open import Categories.Object.NaturalNumbers.Parametrized 𝒞 𝒞-Cartesian
 open import Categories.Object.NaturalNumbers.Properties.F-Algebras 𝒞 terminal 𝒞-Coproducts

--- a/src/Categories/Object/NaturalNumbers/Properties/F-Algebras.agda
+++ b/src/Categories/Object/NaturalNumbers/Properties/F-Algebras.agda
@@ -3,7 +3,7 @@
 open import Level
 open import Categories.Category.Core
 open import Categories.Object.Terminal using (Terminal)
-open import Categories.Category.Cocartesian using (BinaryCoproducts)
+open import Categories.Category.BinaryCoproducts using (BinaryCoproducts)
 
 -- A NNO is an inital algebra for the 'X ↦ ⊤ + X' endofunctor.
 module Categories.Object.NaturalNumbers.Properties.F-Algebras {o ℓ e} (𝒞 : Category o ℓ e) (𝒞-Terminal : Terminal 𝒞) (𝒞-Coproducts : BinaryCoproducts 𝒞) where

--- a/src/Categories/Object/NaturalNumbers/Properties/Parametrized.agda
+++ b/src/Categories/Object/NaturalNumbers/Properties/Parametrized.agda
@@ -5,7 +5,7 @@ open import Categories.Category.Core
 open import Categories.Object.Terminal using (Terminal)
 open import Categories.Category.Cartesian using (Cartesian)
 open import Categories.Category.BinaryProducts using (BinaryProducts)
-open import Categories.Category.Cocartesian using (BinaryCoproducts)
+open import Categories.Category.BinaryCoproducts using (BinaryCoproducts)
 open import Categories.Category.CartesianClosed using (CartesianClosed)
 
 -- In CCCs every NNO is a PNNO
@@ -14,9 +14,7 @@ module Categories.Object.NaturalNumbers.Properties.Parametrized {o ℓ e} (𝒞 
 
 open Category 𝒞
 open CartesianClosed 𝒞-CartesianClosed using (cartesian; λg; eval′; β′; λ-inj; λ-cong; η-exp′; λ-unique′; subst)
-open Cartesian cartesian using (terminal; products)
-open BinaryProducts products renaming (unique′ to bp-unique′)
-open Terminal terminal
+open Cartesian cartesian renaming (unique′ to bp-unique′)
 
 open import Categories.Object.NaturalNumbers 𝒞 terminal using (NNO)
 open import Categories.Object.NaturalNumbers.Parametrized 𝒞 cartesian using (ParametrizedNNO)


### PR DESCRIPTION
Now, as a more manageable version of #518, implementing the suggestions in #509 and adjusting the structure of `Cocartesian` in such a way that `Cartesian` and `Cocartesian` mirror each other.

This includes:
- Changing the way coproducts are defined to prevent Agda from solving holes with qualifiers (like `coproduct.[_,_]`.
- Splitting up `Category.Cocartesian`
- Introducing `Category.BinaryCoproducts`, just like `Category.BinaryProducts` (the module existed before, but not in its own file.
- Publicly opening `BinaryProducts` and `Terminal` in `Cartesian`, just like we already do in `Cocartesian` and adjusting all files that used the old structure.