### PR TITLE
Rename universal morphism of initial object

### DIFF
--- a/src/Categories/Adjoint/Properties.agda
+++ b/src/Categories/Adjoint/Properties.agda
@@ -290,10 +290,10 @@ module _ {R : Functor D C} where
     { initial = record
       { ⊥        = record { f = unit.η X }
       ; ⊥-is-initial = record
-        { !        =
+        { ¡        =
           let open C.HomReasoning
           in record { commute = LRadjunct≈id ○ ⟺ C.identityʳ }
-        ; !-unique = λ {A} g →
+        ; ¡-unique = λ {A} g →
           let open D.HomReasoning
           in -, (begin
             Radjunct (f A)            ≈⟨ Radjunct-resp-≈ (C.Equiv.sym (C.Equiv.trans (commute g) (C.identityʳ {f = f A}))) ⟩
@@ -317,7 +317,7 @@ module _ {R : Functor D C} where
       ; commute = λ {X Y} i →
         let open C.HomReasoning
             open MR C using (pullʳ; cancelˡ; cancelʳ)
-        in proj₂ $ umors.!-unique₂ (R.F₀ X)
+        in proj₂ $ umors.¡-unique₂ (R.F₀ X)
            {record { f = R.F₁ i }}
            (record
            { h       = ε Y D.∘ L₁ (R.F₁ i)
@@ -341,7 +341,7 @@ module _ {R : Functor D C} where
       let open C.HomReasoning
           open MR C using (pullʳ; cancelˡ; id-comm-sym)
           α = f (umors.⊥ c)
-      in proj₂ $ umors.!-unique₂ c
+      in proj₂ $ umors.¡-unique₂ c
          {record { f = α }}
          (record
          { h       = ε (L₀ c) D.∘ L₁ α
@@ -366,20 +366,20 @@ module _ {R : Functor D C} where
           commaObj∘g {X} {Y} g = record { f = f (umors.⊥ Y) C.∘ g }
 
           ⊥X⇒⊥Y : ∀ {X Y} (g : X C.⇒ Y) → (X ↙ R) [ umors.⊥ X , commaObj∘g g ]
-          ⊥X⇒⊥Y {X} {Y} g = umors.! X {commaObj∘g g}
+          ⊥X⇒⊥Y {X} {Y} g = umors.¡ X {commaObj∘g g}
 
           L₀ : ∀ X → D.Obj
           L₀ X         = β (umors.⊥ X)
           L₁ : ∀ {X Y} → X C.⇒ Y → β (umors.⊥ X) D.⇒ β (umors.⊥ Y)
           L₁ {X} {Y} g = h (⊥X⇒⊥Y g)
           L-Hom : ∀ {X Y Z} {i : X C.⇒ Y} {j : Y C.⇒ Z} → D [ L₁ (C [ j ∘ i ]) ≈ (D [ L₁ j ∘ L₁ i ]) ]
-          L-Hom {X} {Y} {Z} {i} {j} = proj₂ $ umors.!-unique₂ X (umors.! X) $
+          L-Hom {X} {Y} {Z} {i} {j} = proj₂ $ umors.¡-unique₂ X (umors.¡ X) $
               record { commute = begin
-                R.F₁ (h (umors.! Y) D.∘ h (umors.! X)) C.∘ f (umors.⊥ X)
+                R.F₁ (h (umors.¡ Y) D.∘ h (umors.¡ X)) C.∘ f (umors.⊥ X)
                   ≈⟨ (C.∘-resp-≈ˡ R.homomorphism) ○ C.assoc ⟩
-                R.F₁ (h (umors.! Y)) C.∘ R.F₁ (h (umors.! X)) C.∘ f (umors.⊥ X)
+                R.F₁ (h (umors.¡ Y)) C.∘ R.F₁ (h (umors.¡ X)) C.∘ f (umors.⊥ X)
                   ≈⟨ (C.∘-resp-≈ʳ (commute (⊥X⇒⊥Y i) ○ C.identityʳ)) ○ C.sym-assoc ⟩
-                (R.F₁ (h (umors.! Y)) C.∘ f (umors.⊥ Y)) C.∘ i
+                (R.F₁ (h (umors.¡ Y)) C.∘ f (umors.⊥ Y)) C.∘ i
                   ≈⟨ pushˡ (commute (⊥X⇒⊥Y j) ○ C.identityʳ) ⟩
                 f (umors.⊥ Z) C.∘ j C.∘ i
                   ≈˘⟨ C.identityʳ ⟩
@@ -391,11 +391,11 @@ module _ {R : Functor D C} where
           L            = record
             { F₀           = L₀
             ; F₁           = L₁
-            ; identity     = λ {X} → proj₂ $ umors.!-unique X $
+            ; identity     = λ {X} → proj₂ $ umors.¡-unique X $
               record { commute = elimˡ R.identity ○ ⟺ C.identityʳ ○ ⟺ C.identityʳ }
             ; homomorphism = L-Hom
-            ; F-resp-≈     = λ {X} eq → proj₂ $ umors.!-unique₂ X (umors.! X) $
-              record { commute = commute (umors.! X) ○ C.∘-resp-≈ˡ (C.∘-resp-≈ʳ (⟺ eq)) }
+            ; F-resp-≈     = λ {X} eq → proj₂ $ umors.¡-unique₂ X (umors.¡ X) $
+              record { commute = commute (umors.¡ X) ○ C.∘-resp-≈ˡ (C.∘-resp-≈ʳ (⟺ eq)) }
             }
             where open C.HomReasoning using (_○_; ⟺)
                   open MR C using (elimˡ)
@@ -403,7 +403,7 @@ module _ {R : Functor D C} where
           ⊥Rd    : (d : D.Obj) → CommaObj (const! (R.F₀ d)) R
           ⊥Rd d    = umors.⊥ (R.F₀ d)
           ⊥Rd⇒id : (d : D.Obj) →  (R.F₀ d ↙ R) [ ⊥Rd d , record { f = C.id } ]
-          ⊥Rd⇒id d = umors.! (R.F₀ d) {record { f = C.id }}
+          ⊥Rd⇒id d = umors.¡ (R.F₀ d) {record { f = C.id }}
           ε      : ∀ d → L₀ (R.F₀ d) D.⇒ d
           ε d      = h (⊥Rd⇒id d)
 

--- a/src/Categories/Category/CartesianClosed/Properties.agda
+++ b/src/Categories/Category/CartesianClosed/Properties.agda
@@ -78,14 +78,14 @@ initial→strict-initial i .is-initial = i
 -- proof from https://math.stackexchange.com/a/4877251/606410
 initial→strict-initial {⊥} i .is-strict f = record
   { from = f
-  ; to = !
+  ; to = ¡
   ; iso = record
     { isoˡ = begin
-      ! ∘ f               ≈˘⟨ refl⟩∘⟨ project₁ ⟩
-      ! ∘ π₁ ∘ ⟨ f , id ⟩ ≈⟨ pullˡ (initial-product.!-unique₂ (! ∘ π₁) π₂)  ⟩
+      ¡ ∘ f               ≈˘⟨ refl⟩∘⟨ project₁ ⟩
+      ¡ ∘ π₁ ∘ ⟨ f , id ⟩ ≈⟨ pullˡ (initial-product.¡-unique₂ (¡ ∘ π₁) π₂)  ⟩
       π₂ ∘ ⟨ f , id ⟩     ≈⟨ project₂ ⟩
       id                  ∎
-    ; isoʳ = !-unique₂ (f ∘ !) id
+    ; isoʳ = ¡-unique₂ (f ∘ ¡) id
     }
   }
   where open IsInitial i

--- a/src/Categories/Category/Cocartesian.agda
+++ b/src/Categories/Category/Cocartesian.agda
@@ -30,9 +30,7 @@ record Cocartesian : Set (levelOfTerm 𝒞) where
     initial    : Initial
     coproducts : BinaryCoproducts
 
-  open Initial initial
-    renaming (! to ¡; !-unique to ¡-unique; !-unique₂ to ¡-unique₂)
-    public
+  open Initial initial public
   open BinaryCoproducts coproducts hiding (module Dual) public
 
   times : Obj → ℕ → Obj

--- a/src/Categories/Category/Complete/Properties/SolutionSet.agda
+++ b/src/Categories/Category/Complete/Properties/SolutionSet.agda
@@ -106,7 +106,7 @@ module _ {C : Category o ℓ e} (Com : Complete (o ⊔ ℓ ⊔ o′) (o ⊔ ℓ 
   SolutionSet⇒Initial = record
     { ⊥            = equalizer.obj
     ; ⊥-is-initial = record
-      { !        = ! _
-      ; !-unique = !-unique
+      { ¡        = ! _
+      ; ¡-unique = !-unique
       }
     }

--- a/src/Categories/Category/Construction/F-Algebras.agda
+++ b/src/Categories/Category/Construction/F-Algebras.agda
@@ -79,7 +79,7 @@ module Lambek {𝒞 : Category o ℓ e} {F : Endofunctor 𝒞} (I : Initial (F-A
 
     -- By initiality, we get the following morphism
     f : F-Algebra-Morphism ⊥ F⊥
-    f = !
+    f = ¡
 
     module FAM = F-Algebra-Morphism f
 

--- a/src/Categories/Category/Construction/F-Coalgebras.agda
+++ b/src/Categories/Category/Construction/F-Coalgebras.agda
@@ -72,18 +72,18 @@ private
     IsTerminal (F-Coalgebras F) T →
     IsInitial (F-Algebras (Functor.op F)) (F-Coalgebra⇒coF-Algebra T)
   coIsTerminal⇒Initial {C = C} {F = F} {T = T} isTT = record
-    { ! =
-        F-Coalgebra-Morphism⇒coF-Algebra-Morphism ¡
-    ; !-unique =
+    { ¡ =
+        F-Coalgebra-Morphism⇒coF-Algebra-Morphism !
+    ; ¡-unique =
         λ  γ  → Functor.F-resp-≈ (F-Coalgebras⇒coF-Algebras F)
-        {f = ¡}
+        {f = !}
         {g = coF-Algebra-Morphism⇒F-Coalgebra-Morphism γ}
-        (¡-unique (coF-Algebra-Morphism⇒F-Coalgebra-Morphism γ))
+        (!-unique (coF-Algebra-Morphism⇒F-Coalgebra-Morphism γ))
     }
     where
       open Category (F-Algebras (Functor.op F))
       open MR (F-Algebras (Functor.op F))
-      open IsTerminal isTT renaming (! to ¡; !-unique to ¡-unique)
+      open IsTerminal isTT
       open HomReasoning
       open Equiv
 

--- a/src/Categories/Category/Construction/Thinnings.agda
+++ b/src/Categories/Category/Construction/Thinnings.agda
@@ -112,8 +112,8 @@ Thinnings = record
 
 []-initial : IsInitial Thinnings []
 []-initial = record
-  { ! = Sublist-[]-universal _
-  ; !-unique = λ f → Category.Equiv.reflexive Thinnings (Sublist-[]-irrelevant _ f)
+  { ¡ = Sublist-[]-universal _
+  ; ¡-unique = λ f → Category.Equiv.reflexive Thinnings (Sublist-[]-irrelevant _ f)
   }
 
 initial : Initial Thinnings

--- a/src/Categories/Category/Construction/mu-Bialgebras.agda
+++ b/src/Categories/Category/Construction/mu-Bialgebras.agda
@@ -280,7 +280,7 @@ module _ (μT : Initial (F-Algebras T)) (νF : Terminal (F-Coalgebras F)) where
     id⇒A2C∘C2A : ∀ ( X : Obj ) → X ⇒ ((A2C ∘F C2A) .F₀ X)
     id⇒A2C∘C2A = G∘F≈id.⇐.η
 
-  -- implicit args to `!` supplied here for clarity
+  -- implicit args to `¡` supplied here for clarity
   -- ⦅ A2C₀ ⊤ ⦆ ≈ A2C₁ 〖 C2A₀ ⊥ 〗 ∘ id⇒A2C∘C2A ⊥
-  centralTheorem : μT̂.! {A = A2C .F₀ ⊤} ≈ A2C. F₁ (νF̂.! {A = C2A .F₀ ⊥}) ∘ id⇒A2C∘C2A ⊥
-  centralTheorem = μT̂.!-unique (A2C. F₁ νF̂.! ∘ id⇒A2C∘C2A ⊥)
+  centralTheorem : μT̂.¡ {A = A2C .F₀ ⊤} ≈ A2C. F₁ (νF̂.! {A = C2A .F₀ ⊥}) ∘ id⇒A2C∘C2A ⊥
+  centralTheorem = μT̂.¡-unique (A2C. F₁ νF̂.! ∘ id⇒A2C∘C2A ⊥)

--- a/src/Categories/Category/Equivalence/Preserves.agda
+++ b/src/Categories/Category/Equivalence/Preserves.agda
@@ -39,9 +39,9 @@ module _ (S : StrongEquivalence C D) where
   -- see below the proof for the abbreviations that make the proof readable
   pres-IsInitial : {c : C.Obj} (i : IsInitial C c) → IsInitial D (F.₀ c)
   pres-IsInitial {c} i = record
-    { ! = λ {A} →  F∘G≈id.⇒.η A D.∘ F.₁ (! i)
-    ; !-unique = λ {A} f → begin  {- f : F.₀ c D.⇒ A -}
-      FG⇒ A D.∘ F.₁ (! i)                                            ≈⟨ (refl⟩∘⟨ F.F-resp-≈ (!-unique i _)) ⟩
+    { ¡ = λ {A} →  F∘G≈id.⇒.η A D.∘ F.₁ (¡ i)
+    ; ¡-unique = λ {A} f → begin  {- f : F.₀ c D.⇒ A -}
+      FG⇒ A D.∘ F.₁ (¡ i)                                            ≈⟨ (refl⟩∘⟨ F.F-resp-≈ (¡-unique i _)) ⟩
       FG⇒ A D.∘ F.₁ ((G.₁ f C.∘ GF⇒) C.∘ G.₁ FG⇐′ C.∘ GF⇐)          ≈⟨ (refl⟩∘⟨ F.homomorphism) ⟩
       FG⇒ A D.∘ F.₁ (G.₁ f C.∘ GF⇒) D.∘ F.₁ (G.₁ FG⇐′ C.∘ GF⇐)      ≈⟨ (refl⟩∘⟨ refl⟩∘⟨ (F.homomorphism ○ (D.Equiv.sym (F≃id-comm₂ F∘G≈id) ⟩∘⟨refl))) ⟩
       FG⇒ A D.∘ F.₁ (G.₁ f C.∘ GF⇒) D.∘ FG⇐ D.∘ F.F₁ GF⇐            ≈⟨ (refl⟩∘⟨ F.homomorphism ⟩∘⟨refl) ⟩

--- a/src/Categories/Category/Instance/EmptySet.agda
+++ b/src/Categories/Category/Instance/EmptySet.agda
@@ -19,7 +19,7 @@ module _ {o : Level} where
 
   EmptySet-⊥ : Initial
   EmptySet-⊥ .Initial.⊥ = ⊥
-  EmptySet-⊥ .Initial.⊥-is-initial .IsInitial.! ()
+  EmptySet-⊥ .Initial.⊥-is-initial .IsInitial.¡ ()
 
 module _ {c ℓ : Level} where
   open Init (Setoids c ℓ)
@@ -35,10 +35,10 @@ module _ {c ℓ : Level} where
   EmptySetoid-⊥ = record
     { ⊥            = EmptySetoid
     ; ⊥-is-initial = record
-      { !        = record
+      { ¡        = record
         { to = λ ()
         ; cong  = λ { {()} }
         }
-      ; !-unique = λ { _ {()} }
+      ; ¡-unique = λ { _ {()} }
       }
     }

--- a/src/Categories/Category/Instance/Nat.agda
+++ b/src/Categories/Category/Instance/Nat.agda
@@ -73,8 +73,8 @@ Nat-Cocartesian = record
   { initial = record
     { ⊥ = 0
     ; ⊥-is-initial = record
-      { ! = λ ()
-      ; !-unique = λ _ ()
+      { ¡ = λ ()
+      ; ¡-unique = λ _ ()
       }
     }
   ; coproducts = record { coproduct = λ {m} {n} → Coprod m n }

--- a/src/Categories/Category/Instance/Properties/Setoids/Cocomplete.agda
+++ b/src/Categories/Category/Instance/Properties/Setoids/Cocomplete.agda
@@ -66,7 +66,7 @@ Setoids-Cocomplete o ℓ e c ℓ′ {J} F = record
         }
       }
     ; ⊥-is-initial = record
-      { !        = λ {K} →
+      { ¡        = λ {K} →
         let module K = Cocone K
         in record
         { arr     = record
@@ -75,7 +75,7 @@ Setoids-Cocomplete o ℓ e c ℓ′ {J} F = record
           }
         ; commute = Setoid.refl K.N
         }
-      ; !-unique = λ { {K} f {a , Sa} →
+      ; ¡-unique = λ { {K} f {a , Sa} →
         let module K = Cocone K
             module f = Cocone⇒ f
             open RS K.N

--- a/src/Categories/Category/Instance/Zero/Properties.agda
+++ b/src/Categories/Category/Instance/Zero/Properties.agda
@@ -18,8 +18,8 @@ open Functor
 -- Unlike for ⊤ being Terminal, Agda can't deduce these, need to be explicit
 Zero-⊥ : Initial
 Zero-⊥ .⊥ = Zero
-Zero-⊥ .⊥-is-initial .! .F₀ ()
-Zero-⊥ .⊥-is-initial .!-unique f = niHelper record
+Zero-⊥ .⊥-is-initial .¡ .F₀ ()
+Zero-⊥ .⊥-is-initial .¡-unique f = niHelper record
   { η = λ()
   ; η⁻¹ = λ()
   ; commute = λ{ {()} }

--- a/src/Categories/Category/Monoidal/Instance/Rels.agda
+++ b/src/Categories/Category/Monoidal/Instance/Rels.agda
@@ -62,8 +62,8 @@ module _ {o ℓ} where
     { initial = record
       { ⊥ = ⊥
       ; ⊥-is-initial = record
-        { ! = λ ()
-        ; !-unique = λ _ → (λ { {()} }) , (λ { {()} })
+        { ¡ = λ ()
+        ; ¡-unique = λ _ → (λ { {()} }) , (λ { {()} })
         }
       }
     ; coproducts = record

--- a/src/Categories/Diagram/Coend/Properties.agda
+++ b/src/Categories/Diagram/Coend/Properties.agda
@@ -33,8 +33,8 @@ module _ {o ℓ e o′ ℓ′ e′} {C : Category o ℓ e} {D : Category o′ �
   Coend⇒Initial c = record
     { ⊥ = cowedge
     ; ⊥-is-initial = record
-      { ! = λ {A} → record { u = factor A ; commute = universal }
-      ; !-unique = λ {A} f → unique {A} (Cowedge-Morphism.commute f)
+      { ¡ = λ {A} → record { u = factor A ; commute = universal }
+      ; ¡-unique = λ {A} f → unique {A} (Cowedge-Morphism.commute f)
       }
     }
     where
@@ -43,9 +43,9 @@ module _ {o ℓ e o′ ℓ′ e′} {C : Category o ℓ e} {D : Category o′ �
   Initial⇒Coend : Initial Cowedges → Coend F
   Initial⇒Coend i = record
     { cowedge = ⊥
-    ; factor = λ W → u {W₂ = W} !
-    ; universal = commute !
-    ; unique = λ {_} {g} x → !-unique (record { u = g ; commute = x })
+    ; factor = λ W → u {W₂ = W} ¡
+    ; universal = commute ¡
+    ; unique = λ {_} {g} x → ¡-unique (record { u = g ; commute = x })
     }
     where
     open Initial.Initial i

--- a/src/Categories/Diagram/Colimit.agda
+++ b/src/Categories/Diagram/Colimit.agda
@@ -43,7 +43,7 @@ record Colimit : Set (o ⊔ ℓ ⊔ e ⊔ o′ ⊔ ℓ′ ⊔ e′) where
   open Cocone colimit hiding (coapex) renaming (N to coapex; ψ to proj; commute to colimit-commute) public
 
   rep-cocone : ∀ K → colimit ⇨ K
-  rep-cocone K = initial.! {K}
+  rep-cocone K = initial.¡ {K}
 
   rep : ∀ K → coapex ⇒ Cocone.N K
   rep K = arr
@@ -70,7 +70,7 @@ record Colimit : Set (o ⊔ ℓ ⊔ e ⊔ o′ ⊔ ℓ′ ⊔ e′) where
   unrep-cone f = unrep (_⇨_.arr f)
 
   g-η : ∀ {f : coapex ⇒ X} → rep (unrep f) ≈ f
-  g-η {f = f} = initial.!-unique (coconify f)
+  g-η {f = f} = initial.¡-unique (coconify f)
 
   η-cocone : Cocones [ rep-cocone colimit ≈ Category.id Cocones ]
   η-cocone = initial.⊥-id (rep-cocone colimit)
@@ -79,13 +79,13 @@ record Colimit : Set (o ⊔ ℓ ⊔ e ⊔ o′ ⊔ ℓ′ ⊔ e′) where
   η = η-cocone
 
   rep-cocone∘ : Cocones [ Cocones [ q ∘ rep-cocone K ] ≈ rep-cocone K′ ]
-  rep-cocone∘ {K = K} {q = q} = Equiv.sym (initial.!-unique (Cocones [ q ∘ rep-cocone K ]))
+  rep-cocone∘ {K = K} {q = q} = Equiv.sym (initial.¡-unique (Cocones [ q ∘ rep-cocone K ]))
 
   rep∘ : ∀ {q : K ⇨ K′} → _⇨_.arr q ∘ rep K ≈ rep K′
   rep∘ {q = q} = rep-cocone∘ {q = q}
 
   rep-cone-self-id : Cocones [ rep-cocone colimit ≈  Cocones.id  ]
-  rep-cone-self-id = initial.!-unique ( Cocones.id )
+  rep-cone-self-id = initial.¡-unique ( Cocones.id )
 
   rep-self-id : rep colimit ≈ id
   rep-self-id = rep-cone-self-id

--- a/src/Categories/Diagram/Colimit/Properties.agda
+++ b/src/Categories/Diagram/Colimit/Properties.agda
@@ -65,11 +65,11 @@ module _ {F : Functor J C} {OP : IndexedCoproductOf (Functor.₀ F)} {MP : Index
           }
         }
       ; ⊥-is-initial = record
-        { ! = λ {A} → record
+        { ¡ = λ {A} → record
           { arr = coequalize (bang-lemma A)
           ; commute = ⟺ (pushˡ universal) ○ OP.commute
           }
-        ; !-unique = λ f → Equiv.sym (unique (OP.unique (assoc ○ Cocone⇒.commute f)))
+        ; ¡-unique = λ f → Equiv.sym (unique (OP.unique (assoc ○ Cocone⇒.commute f)))
         }
       }
     }

--- a/src/Categories/Diagram/Duality.agda
+++ b/src/Categories/Diagram/Duality.agda
@@ -163,8 +163,8 @@ module _ {F : Functor J C} where
     { terminal = record
       { ⊤             = Cocone⇒coCone ⊥
       ; ⊤-is-terminal = record
-        { !        = Cocone⇒⇒coCone⇒ !
-        ; !-unique = λ f → !-unique (coCone⇒⇒Cocone⇒ f)
+        { !        = Cocone⇒⇒coCone⇒ ¡
+        ; !-unique = λ f → ¡-unique (coCone⇒⇒Cocone⇒ f)
         }
       }
     }

--- a/src/Categories/Diagram/Pushout/Properties.agda
+++ b/src/Categories/Diagram/Pushout/Properties.agda
@@ -78,10 +78,10 @@ module _ (i : Initial) where
     t : Terminal
     t = ⊥⇒op⊤ i
 
-  pushout-⊥⇒coproduct : Pushout (! {X}) (! {Y}) → Coproduct X Y
+  pushout-⊥⇒coproduct : Pushout (¡ {X}) (¡ {Y}) → Coproduct X Y
   pushout-⊥⇒coproduct p = coProduct⇒Coproduct (pullback-⊤⇒product t (Pushout⇒coPullback p))
 
-  coproduct⇒pushout-⊥ : Coproduct X Y → Pushout (! {X}) (! {Y})
+  coproduct⇒pushout-⊥ : Coproduct X Y → Pushout (¡ {X}) (¡ {Y})
   coproduct⇒pushout-⊥ c = coPullback⇒Pushout (product⇒pullback-⊤ t (Coproduct⇒coProduct c))
 
 pushout-resp-≈ : Pushout f g → f ≈ h → g ≈ i → Pushout h i

--- a/src/Categories/Functor/Construction/LiftAlgebras.agda
+++ b/src/Categories/Functor/Construction/LiftAlgebras.agda
@@ -53,15 +53,15 @@ liftInitial μT = record
     ; α = ⦅ F₀ ⊥ ⦆
     }
   ; ⊥-is-initial = record
-    { ! = λ {A = X} →
+    { ¡ = λ {A = X} →
       let
         a = F-Coalgebra.A X
         c = F-Coalgebra.α X
       in record
       { f = ⦅ a ⦆
-      ; commutes = !-unique₂ (c ∘ ⦅ a ⦆) (F₁ ⦅ a ⦆ ∘ ⦅ F₀ ⊥ ⦆)
+      ; commutes = ¡-unique₂ (c ∘ ⦅ a ⦆) (F₁ ⦅ a ⦆ ∘ ⦅ F₀ ⊥ ⦆)
       }
-    ; !-unique = λ {A = X} g → !-unique (F-Coalgebra-Morphism.f g)
+    ; ¡-unique = λ {A = X} g → ¡-unique (F-Coalgebra-Morphism.f g)
     }
   }
   where
@@ -71,5 +71,5 @@ liftInitial μT = record
     open MR (F-Algebras T)
     open HomReasoning
     open Equiv
-    ⦅_⦆ = λ X → ! {A = X} -- "banana brackets" (Meijer 1991)
+    ⦅_⦆ = λ X → ¡ {A = X} -- "banana brackets" (Meijer 1991)
     open Functor LiftAlgebras

--- a/src/Categories/Functor/Duality.agda
+++ b/src/Categories/Functor/Duality.agda
@@ -37,8 +37,8 @@ module _ (G : Functor C D) {J : Category o ℓ e} where
                                           PreservesLimit G.op L →
                                           PreservesColimit G (coLimit⇒Colimit C L)
   coPreservesLimit⇒PreservesCoLimit L is⊤ = record
-    { !        = λ {K} → coCone⇒⇒Cocone⇒ _ (! {Cocone⇒coCone _ K})
-    ; !-unique = λ f → !-unique (Cocone⇒⇒coCone⇒ _ f)
+    { ¡        = λ {K} → coCone⇒⇒Cocone⇒ _ (! {Cocone⇒coCone _ K})
+    ; ¡-unique = λ f → !-unique (Cocone⇒⇒coCone⇒ _ f)
     }
     where open IsTerminal is⊤
 
@@ -46,8 +46,8 @@ module _ (G : Functor C D) {J : Category o ℓ e} where
                                         PreservesColimit G L →
                                         PreservesLimit G.op (Colimit⇒coLimit C L)
   PreservesColimit⇒coPreservesLimit L is⊥ = record
-    { !        = λ {K} → Cocone⇒⇒coCone⇒ _ (! {coCone⇒Cocone _ K})
-    ; !-unique = λ f → !-unique (coCone⇒⇒Cocone⇒ _ f)
+    { !        = λ {K} → Cocone⇒⇒coCone⇒ _ (¡ {coCone⇒Cocone _ K})
+    ; !-unique = λ f → ¡-unique (coCone⇒⇒Cocone⇒ _ f)
     }
     where open IsInitial is⊥
 

--- a/src/Categories/Object/Duality.agda
+++ b/src/Categories/Object/Duality.agda
@@ -30,8 +30,8 @@ private
 
 IsInitial⇒coIsTerminal : IsInitial X → IsTerminal X
 IsInitial⇒coIsTerminal is⊥ = record
-  { !        = !
-  ; !-unique = !-unique
+  { !        = ¡
+  ; !-unique = ¡-unique
   }
   where open IsInitial is⊥
 
@@ -44,8 +44,8 @@ IsInitial⇒coIsTerminal is⊥ = record
 
 coIsTerminal⇒IsInitial : IsTerminal X → IsInitial X
 coIsTerminal⇒IsInitial is⊤ = record
-  { !        = !
-  ; !-unique = !-unique
+  { ¡        = !
+  ; ¡-unique = !-unique
   }
   where open IsTerminal is⊤
 
@@ -105,7 +105,7 @@ coIndexedProductOf⇒IndexedCoproductOf ΠP = record
 -- Zero objects are autodual
 IsZero⇒coIsZero : IsZero C Z → IsZero op Z
 IsZero⇒coIsZero is-zero = record
-  { isInitial = record { ! = ! ; !-unique = !-unique }
+  { isInitial = record { ¡ = ! ; ¡-unique = !-unique }
   ; isTerminal = record { ! = ¡ ; !-unique = ¡-unique }
   }
   where
@@ -113,7 +113,7 @@ IsZero⇒coIsZero is-zero = record
 
 coIsZero⇒IsZero : IsZero op Z → IsZero C Z
 coIsZero⇒IsZero co-is-zero = record
-  { isInitial = record { ! = ! ; !-unique = !-unique }
+  { isInitial = record { ¡ = ! ; ¡-unique = !-unique }
   ; isTerminal = record { ! = ¡ ; !-unique = ¡-unique }
   }
   where

--- a/src/Categories/Object/Initial.agda
+++ b/src/Categories/Object/Initial.agda
@@ -15,18 +15,18 @@ open HomReasoning
 
 record IsInitial (⊥ : Obj) : Set (o ⊔ ℓ ⊔ e) where
   field
-    ! : {A : Obj} → (⊥ ⇒ A)
-    !-unique : ∀ {A} → (f : ⊥ ⇒ A) → ! ≈ f
+    ¡ : {A : Obj} → (⊥ ⇒ A)
+    ¡-unique : ∀ {A} → (f : ⊥ ⇒ A) → ¡ ≈ f
 
-  !-unique₂ : ∀ {A} → (f g : ⊥ ⇒ A) → f ≈ g
-  !-unique₂ f g = begin
-    f ≈˘⟨ !-unique f ⟩
-    ! ≈⟨ !-unique g ⟩
+  ¡-unique₂ : ∀ {A} → (f g : ⊥ ⇒ A) → f ≈ g
+  ¡-unique₂ f g = begin
+    f ≈˘⟨ ¡-unique f ⟩
+    ¡ ≈⟨ ¡-unique g ⟩
     g ∎
     where open HomReasoning
 
   ⊥-id : (f : ⊥ ⇒ ⊥) → f ≈ id
-  ⊥-id f = !-unique₂ f id
+  ⊥-id f = ¡-unique₂ f id
 
 record Initial : Set (o ⊔ ℓ ⊔ e) where
   field
@@ -38,12 +38,12 @@ record Initial : Set (o ⊔ ℓ ⊔ e) where
 open Initial
 
 to-⊥-is-Epi : ∀ {A : Obj} {i : Initial} → (f : A ⇒ ⊥ i) → Epi f
-to-⊥-is-Epi {_} {i} _ = λ g h _ → !-unique₂ i g h
+to-⊥-is-Epi {_} {i} _ = λ g h _ → ¡-unique₂ i g h
 
 up-to-iso : (i₁ i₂ : Initial) → ⊥ i₁ ≅ ⊥ i₂
 up-to-iso i₁ i₂ = record
-  { from = ! i₁
-  ; to   = ! i₂
+  { from = ¡ i₁
+  ; to   = ¡ i₂
   ; iso  = record { isoˡ = ⊥-id i₁ _; isoʳ = ⊥-id i₂ _ }
   }
 
@@ -51,9 +51,9 @@ transport-by-iso : (i : Initial) → ∀ {X} → ⊥ i ≅ X → Initial
 transport-by-iso i {X} i≅X = record
   { ⊥        = X
   ; ⊥-is-initial = record
-    { !        = ! i ∘ to
-    ; !-unique = λ h →  begin
-      ! i ∘ to        ≈⟨ !-unique i (h ∘ from) ⟩∘⟨refl  ⟩
+    { ¡        = ¡ i ∘ to
+    ; ¡-unique = λ h →  begin
+      ¡ i ∘ to        ≈⟨ ¡-unique i (h ∘ from) ⟩∘⟨refl  ⟩
       (h ∘ from) ∘ to ≈⟨ cancelʳ isoʳ ⟩
       h              ∎
     }
@@ -61,7 +61,7 @@ transport-by-iso i {X} i≅X = record
   where open _≅_ i≅X
 
 up-to-iso-unique : ∀ i i′ → (iso : ⊥ i ≅ ⊥ i′) → up-to-iso i i′ ≃ iso
-up-to-iso-unique i i′ iso = ⌞ !-unique i _ ⌟
+up-to-iso-unique i i′ iso = ⌞ ¡-unique i _ ⌟
 
 up-to-iso-invˡ : ∀ {t X} {i : ⊥ t ≅ X} → up-to-iso t (transport-by-iso t i) ≃ i
 up-to-iso-invˡ {t} {i = i} = up-to-iso-unique t (transport-by-iso t i) i

--- a/src/Categories/Object/Initial/Colimit.agda
+++ b/src/Categories/Object/Initial/Colimit.agda
@@ -18,13 +18,13 @@ module _ {o′ ℓ′ e′} {F : Functor (Zero {o′} {ℓ′} {e′}) C} where
   colimit⇒⊥ L = record
     { ⊥        = coapex
     ; ⊥-is-initial = record
-      { !        = rep record
+      { ¡        = rep record
         { coapex = record
           { ψ       = λ ()
           ; commute = λ { {()} }
           }
         }
-      ; !-unique = λ f → initial.!-unique record
+      ; ¡-unique = λ f → initial.¡-unique record
         { arr     = f
         ; commute = λ { {()} }
         }
@@ -45,15 +45,15 @@ module _ {o′ ℓ′ e′} {F : Functor (Zero {o′} {ℓ′} {e′}) C} where
           }
         }
       ; ⊥-is-initial = record
-        { !        = λ {K} →
+        { ¡        = λ {K} →
           let open Cocone F K
           in record
-          { arr     = !
+          { arr     = ¡
           ; commute = λ { {()} }
           }
-        ; !-unique = λ f →
+        ; ¡-unique = λ f →
           let module f = Cocone⇒ F f
-          in !-unique f.arr
+          in ¡-unique f.arr
         }
       }
     }

--- a/src/Categories/Object/NaturalNumbers/Parametrized/Properties/F-Algebras.agda
+++ b/src/Categories/Object/NaturalNumbers/Parametrized/Properties/F-Algebras.agda
@@ -44,20 +44,20 @@ Initial⇒PNNO algebra isInitial = record
   ; isParametrizedNNO = record
     { z = z
     ; s = s
-    ; universal = λ {A} {X} f g → F-Algebra-Morphism.f (isInitial.! A {A = alg′ f g})
+    ; universal = λ {A} {X} f g → F-Algebra-Morphism.f (isInitial.¡ A {A = alg′ f g})
     ; commute₁ = λ {A} {X} {f} {g} → begin
       f                                                                       ≈˘⟨ inject₁ ⟩
       [ f , g ] ∘ i₁                                                          ≈˘⟨ refl⟩∘⟨ (+₁∘i₁ ○ identityʳ) ⟩
-      [ f , g ] ∘ (id +₁ F-Algebra-Morphism.f (isInitial.! A)) ∘ i₁           ≈˘⟨ extendʳ (F-Algebra-Morphism.commutes (isInitial.! A {A = alg′ f g})) ⟩
-      F-Algebra-Morphism.f (isInitial.! A) ∘ [ ⟨ id , z ∘ ! ⟩ , id ⁂ s ] ∘ i₁ ≈⟨ refl⟩∘⟨ inject₁ ⟩
-      (F-Algebra-Morphism.f (IsInitial.! (isInitial A))) ∘ ⟨ id , z ∘ ! ⟩     ∎
+      [ f , g ] ∘ (id +₁ F-Algebra-Morphism.f (isInitial.¡ A)) ∘ i₁           ≈˘⟨ extendʳ (F-Algebra-Morphism.commutes (isInitial.¡ A {A = alg′ f g})) ⟩
+      F-Algebra-Morphism.f (isInitial.¡ A) ∘ [ ⟨ id , z ∘ ! ⟩ , id ⁂ s ] ∘ i₁ ≈⟨ refl⟩∘⟨ inject₁ ⟩
+      (F-Algebra-Morphism.f (isInitial.¡ A)) ∘ ⟨ id , z ∘ ! ⟩     ∎
     ; commute₂ = λ {A} {X} {f} {g} → begin
-      g ∘ F-Algebra-Morphism.f (IsInitial.! (isInitial A))                      ≈˘⟨ pullˡ inject₂ ⟩
-      [ f , g ] ∘ i₂ ∘ F-Algebra-Morphism.f (IsInitial.! (isInitial A))         ≈˘⟨ refl⟩∘⟨ +₁∘i₂ ⟩
-      [ f , g ] ∘ (id +₁ F-Algebra-Morphism.f (IsInitial.! (isInitial A))) ∘ i₂ ≈˘⟨ extendʳ (F-Algebra-Morphism.commutes (isInitial.! A {A = alg′ f g})) ⟩
-      F-Algebra-Morphism.f (isInitial.! A) ∘ [ ⟨ id , z ∘ ! ⟩ , id ⁂ s ] ∘  i₂  ≈⟨ refl⟩∘⟨ inject₂ ⟩
-      F-Algebra-Morphism.f (IsInitial.! (isInitial A)) ∘ (id ⁂ s)               ∎
-    ; unique = λ {A} {X} {f} {g} {u} eqᶻ eqˢ → ⟺ $ isInitial.!-unique A {A = alg′ f g} (record
+      g ∘ F-Algebra-Morphism.f (isInitial.¡ A)                      ≈˘⟨ pullˡ inject₂ ⟩
+      [ f , g ] ∘ i₂ ∘ F-Algebra-Morphism.f (isInitial.¡ A)         ≈˘⟨ refl⟩∘⟨ +₁∘i₂ ⟩
+      [ f , g ] ∘ (id +₁ F-Algebra-Morphism.f (isInitial.¡ A)) ∘ i₂ ≈˘⟨ extendʳ (F-Algebra-Morphism.commutes (isInitial.¡ A {A = alg′ f g})) ⟩
+      F-Algebra-Morphism.f (isInitial.¡ A) ∘ [ ⟨ id , z ∘ ! ⟩ , id ⁂ s ] ∘  i₂  ≈⟨ refl⟩∘⟨ inject₂ ⟩
+      F-Algebra-Morphism.f (isInitial.¡ A) ∘ (id ⁂ s)               ∎
+    ; unique = λ {A} {X} {f} {g} {u} eqᶻ eqˢ → ⟺ $ isInitial.¡-unique A {A = alg′ f g} (record
       { f = u
       ; commutes = begin
         u ∘ [ ⟨ id , z ∘ ! ⟩ , id ⁂ s ]              ≈˘⟨ +-g-η ⟩
@@ -89,7 +89,7 @@ PNNO⇒Initial₂ : (pnno : ParametrizedNNO)
   → (∀ A → IsInitial (F-Algebras (A +-))
                       (PNNO-Algebra A (ParametrizedNNO.N pnno) (ParametrizedNNO.z pnno) (ParametrizedNNO.s pnno)))
 PNNO⇒Initial₂ pnno A = record
-  { ! = λ {alg} → record
+  { ¡ = λ {alg} → record
     { f = universal (F-Algebra.α alg ∘ i₁) (F-Algebra.α alg ∘ i₂)
     ; commutes = begin
       universal (F-Algebra.α alg ∘ i₁) (F-Algebra.α alg ∘ i₂) ∘ [ ⟨ id , z ∘ ! ⟩ , id ⁂ s ]  ≈⟨ ∘[] ⟩
@@ -99,7 +99,7 @@ PNNO⇒Initial₂ pnno A = record
       , ((F-Algebra.α alg ∘ i₂) ∘ universal (F-Algebra.α alg ∘ i₁) (F-Algebra.α alg ∘ i₂)) ] ≈˘⟨ ∘[] ○ []-cong₂ (∘-resp-≈ʳ identityʳ) sym-assoc ⟩
       F-Algebra.α alg ∘ (id +₁ universal (F-Algebra.α alg ∘ i₁) (F-Algebra.α alg ∘ i₂))      ∎
     }
-  ; !-unique = λ {X} f →
+  ; ¡-unique = λ {X} f →
     let commute₁ = begin
           F-Algebra.α X ∘ i₁                                        ≈˘⟨ refl⟩∘⟨ (+₁∘i₁ ○ identityʳ) ⟩
           F-Algebra.α X ∘ (id +₁ F-Algebra-Morphism.f f) ∘ i₁       ≈˘⟨ extendʳ (F-Algebra-Morphism.commutes f) ⟩

--- a/src/Categories/Object/NaturalNumbers/Properties/F-Algebras.agda
+++ b/src/Categories/Object/NaturalNumbers/Properties/F-Algebras.agda
@@ -32,18 +32,18 @@ Initial⇒NNO initial = record
     { z = ⊥.α ∘ i₁
     ; s = ⊥.α ∘ i₂
     ; universal = λ {A} q f →
-      F-Algebra-Morphism.f (initial.! {A = alg q f})
+      F-Algebra-Morphism.f (initial.¡ {A = alg q f})
     ; z-commute = λ {A} {q} {f} → begin
       q                                                       ≈˘⟨ inject₁ ⟩
       [ q , f ] ∘ i₁                                          ≈˘⟨ refl⟩∘⟨ (+₁∘i₁ ○ identityʳ) ⟩
-      [ q , f ] ∘ (id +₁ F-Algebra-Morphism.f initial.!) ∘ i₁ ≈˘⟨ extendʳ (F-Algebra-Morphism.commutes (initial.! {A = alg q f})) ⟩
-      F-Algebra-Morphism.f initial.! ∘ ⊥.α ∘ i₁               ∎
+      [ q , f ] ∘ (id +₁ F-Algebra-Morphism.f initial.¡) ∘ i₁ ≈˘⟨ extendʳ (F-Algebra-Morphism.commutes (initial.¡ {A = alg q f})) ⟩
+      F-Algebra-Morphism.f initial.¡ ∘ ⊥.α ∘ i₁               ∎
     ; s-commute = λ {A} {q} {f} → begin
-      f ∘ F-Algebra-Morphism.f initial.!                      ≈˘⟨ pullˡ inject₂ ⟩
-      [ q , f ] ∘ i₂ ∘ F-Algebra-Morphism.f initial.!         ≈˘⟨ refl⟩∘⟨ +₁∘i₂ ⟩
-      [ q , f ] ∘ (id +₁ F-Algebra-Morphism.f initial.!) ∘ i₂ ≈˘⟨ extendʳ $ F-Algebra-Morphism.commutes (initial.! {A = alg q f}) ⟩
-      F-Algebra-Morphism.f initial.! ∘ ⊥.α ∘ i₂               ∎
-    ; unique = λ {A} {f} {q} {u} eqᶻ eqˢ → ⟺ $ initial.!-unique $ record
+      f ∘ F-Algebra-Morphism.f initial.¡                      ≈˘⟨ pullˡ inject₂ ⟩
+      [ q , f ] ∘ i₂ ∘ F-Algebra-Morphism.f initial.¡         ≈˘⟨ refl⟩∘⟨ +₁∘i₂ ⟩
+      [ q , f ] ∘ (id +₁ F-Algebra-Morphism.f initial.¡) ∘ i₂ ≈˘⟨ extendʳ $ F-Algebra-Morphism.commutes (initial.¡ {A = alg q f}) ⟩
+      F-Algebra-Morphism.f initial.¡ ∘ ⊥.α ∘ i₂               ∎
+    ; unique = λ {A} {f} {q} {u} eqᶻ eqˢ → ⟺ $ initial.¡-unique $ record
       { f = u
       ; commutes = begin
         u ∘ ⊥.α                             ≈˘⟨ +-g-η ⟩
@@ -70,7 +70,7 @@ NNO⇒Initial nno = record
     ; α = [ z , s ]
     }
   ; ⊥-is-initial = record
-    { ! = λ {alg} → record
+    { ¡ = λ {alg} → record
       { f = universal (F-Algebra.α alg ∘ i₁) (F-Algebra.α alg ∘ i₂)
       ; commutes = begin
         universal (F-Algebra.α alg ∘ i₁) (F-Algebra.α alg ∘ i₂) ∘ [ z , s ]                                         ≈⟨ ∘[] ⟩
@@ -79,7 +79,7 @@ NNO⇒Initial nno = record
         [ F-Algebra.α alg ∘ i₁ , F-Algebra.α alg ∘ (i₂ ∘ universal (F-Algebra.α alg ∘ i₁) (F-Algebra.α alg ∘ i₂)) ] ≈˘⟨ ∘[] ○ []-cong₂ (∘-resp-≈ʳ identityʳ) refl ⟩
         F-Algebra.α alg ∘ (id +₁ universal (F-Algebra.α alg ∘ i₁) (F-Algebra.α alg ∘ i₂))                           ∎
       }
-    ; !-unique = λ {A} f →
+    ; ¡-unique = λ {A} f →
       let z-commutes = begin
             F-Algebra.α A ∘ i₁                                  ≈˘⟨ refl⟩∘⟨ (+₁∘i₁ ○ identityʳ) ⟩
             F-Algebra.α A ∘ (id +₁ F-Algebra-Morphism.f f) ∘ i₁ ≈˘⟨ extendʳ (F-Algebra-Morphism.commutes f) ⟩

--- a/src/Categories/Object/Zero.agda
+++ b/src/Categories/Object/Zero.agda
@@ -22,11 +22,6 @@ record IsZero (Z : Obj) : Set (o ⊔ ℓ ⊔ e) where
     isTerminal : IsTerminal Z
 
   open IsInitial isInitial public
-    renaming
-    ( ! to ¡
-    ; !-unique to ¡-unique
-    ; !-unique₂ to ¡-unique₂
-    )
   open IsTerminal isTerminal public
 
   zero⇒ : ∀ {A B : Obj} → A ⇒ B


### PR DESCRIPTION
As a successor to #521 I have renamed `!` in `IsInitial` to `¡`, since this is how it gets imported most of the time anyway.
This is part of a bigger effort started in #518 to make usage of products and coproducts more streamlined.