### PR TITLE
Extend generic monoidal constructions and reasoning

### DIFF
--- a/src/Categories/Category/Monoidal/Braided/Properties.agda
+++ b/src/Categories/Category/Monoidal/Braided/Properties.agda
@@ -7,11 +7,13 @@ open import Categories.Category.Monoidal.Braided using (Braided)
 module Categories.Category.Monoidal.Braided.Properties
   {o ℓ e} {C : Category o ℓ e} {M : Monoidal C} (BM : Braided M) where
 
+open import Algebra.Bundles using (CommutativeMonoid; Monoid)
 open import Data.Product using (_,_)
 
 import Categories.Category.Construction.Core C as Core
 open import Categories.Category.Monoidal.Properties M
 open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Category.Monoidal.Scalars M using (Scalar; _·ʳ_; _·ˡ_)
 import Categories.Category.Monoidal.Utilities M as MonoidalUtilities
 open import Categories.Functor using (Functor)
 open import Categories.Morphism.Reasoning C hiding (push-eq)
@@ -22,7 +24,8 @@ open import Categories.NaturalTransformation.NaturalIsomorphism.Properties
 open Category C
 open Commutation C
 open Braided BM
-open MonoidalUtilities using (_⊗ᵢ_; unitorʳ-naturalIsomorphism)
+open MonoidalUtilities using
+  (_⊗ᵢ_; Obj-⊗-Monoid; unitorˡ-naturalIsomorphism; unitorʳ-naturalIsomorphism)
 open MonoidalUtilities.Shorthands
 open Core.Shorthands
 open Commutationᵢ
@@ -40,6 +43,14 @@ module Shorthands where
 
   σ⇐ : ∀ {X Y} → Y ⊗₀ X ⇒ X ⊗₀ Y
   σ⇐ {X} {Y} = braiding.⇐.η (X , Y)
+
+  σ⇒-comm : ∀ {X Y Z W} {f : X ⇒ Y} {g : Z ⇒ W} →
+            σ⇒ ∘ (f ⊗₁ g) ≈ (g ⊗₁ f) ∘ σ⇒
+  σ⇒-comm {f = f} {g} = braiding.⇒.commute (f , g)
+
+  σ⇐-comm : ∀ {X Y Z W} {f : X ⇒ Y} {g : Z ⇒ W} →
+            σ⇐ ∘ (g ⊗₁ f) ≈ (f ⊗₁ g) ∘ σ⇐
+  σ⇐-comm {f = f} {g} = braiding.⇐.commute (f , g)
 
   σ = braiding.FX≅GX
 
@@ -92,6 +103,26 @@ private
     (σ⇒ ∘ id ⊗₁ λ⇒) ∘ α⇒                ≈⟨ pullʳ triangle ⟩
     σ⇒ ∘ ρ⇒ ⊗₁ id                       ∎)
 
+  ρ⇒-α⇐ : id {X} ⊗₁ ρ⇒ {Y} ≈ ρ⇒ ∘ α⇐
+  ρ⇒-α⇐ = switch-fromtoʳ associator coherence₂
+
+  λ⇒-α⇐ : id {X} ⊗₁ λ⇒ {Y} ≈ ρ⇒ ⊗₁ id ∘ α⇐
+  λ⇒-α⇐ = switch-fromtoʳ associator triangle
+
+  braiding-coherence⊗unit′ : [ unit ⊗₀ (unit ⊗₀ X) ⇒ unit ⊗₀ X ]⟨
+                               id ⊗₁ σ⇒            ⇒⟨ unit ⊗₀ (X ⊗₀ unit) ⟩
+                               id ⊗₁ ρ⇒
+                             ≈ id ⊗₁ λ⇒
+                             ⟩
+  braiding-coherence⊗unit′ = cancel-fromˡ braiding.FX≅GX (begin
+    σ⇒ ∘ id ⊗₁ ρ⇒ ∘ id ⊗₁ σ⇒         ≈⟨ pullˡ (⟺ (glue◽◃ unitorʳ-commute-from (⟺ ρ⇒-α⇐))) ⟩
+    (ρ⇒ ∘ σ⇒ ⊗₁ id ∘ α⇐) ∘ id ⊗₁ σ⇒  ≈⟨ pullʳ hexagon₂ ⟩
+    ρ⇒ ∘ (α⇐ ∘ σ⇒) ∘ α⇐              ≈⟨ refl⟩∘⟨ assoc ⟩
+    ρ⇒ ∘ α⇐ ∘ σ⇒ ∘ α⇐                ≈⟨ pullˡ (⟺ ρ⇒-α⇐) ⟩
+    id ⊗₁ ρ⇒ ∘ σ⇒ ∘ α⇐               ≈˘⟨ pushˡ σ⇒-comm ⟩
+    (σ⇒ ∘ ρ⇒ ⊗₁ id) ∘ α⇐             ≈⟨ pullʳ (⟺ λ⇒-α⇐) ⟩
+    σ⇒ ∘ id ⊗₁ λ⇒                    ∎)
+
 -- The desired theorem follows from |braiding-coherence⊗unit| by
 -- translating it along the right unitor (which is a natural iso).
 
@@ -105,6 +136,20 @@ braiding-coherence = push-eq unitorʳ-naturalIsomorphism (begin
   (λ⇒ ⊗₁ id) ∘ (σ⇒ ⊗₁ id)   ≈⟨ braiding-coherence⊗unit ⟩
   ρ⇒  ⊗₁ id                 ∎)
   where open Functor (-⊗ unit)
+
+-- The unit is transparent to the braiding on the left as well.  Same translation,
+-- along the left unitor this time.
+
+braiding-coherence′ : [ unit ⊗₀ X ⇒ X ]⟨
+                        σ⇒              ⇒⟨ X ⊗₀ unit ⟩
+                        ρ⇒
+                      ≈ λ⇒
+                      ⟩
+braiding-coherence′ = push-eq unitorˡ-naturalIsomorphism (begin
+  id ⊗₁ (ρ⇒ ∘ σ⇒)           ≈⟨ homomorphism ⟩
+  (id ⊗₁ ρ⇒) ∘ (id ⊗₁ σ⇒)   ≈⟨ braiding-coherence⊗unit′ ⟩
+  id ⊗₁ λ⇒                  ∎)
+  where open Functor (unit ⊗-)
 
 -- Variants of the hexagon identities defined on isos.
 
@@ -129,8 +174,22 @@ hexagon₂-inv = to-≈ hexagon₂-iso
 braiding-coherence-iso : unitorˡ ∘ᵢ σ ≈ᵢ unitorʳ {X}
 braiding-coherence-iso = ⌞ braiding-coherence ⌟
 
+braiding-coherence-iso′ : unitorʳ ∘ᵢ σ ≈ᵢ unitorˡ {X}
+braiding-coherence-iso′ = ⌞ braiding-coherence′ ⌟
+
 braiding-coherence-inv : σ⇐ ∘ λ⇐ ≈ ρ⇐ {X}
 braiding-coherence-inv = to-≈ braiding-coherence-iso
+
+braiding-coherence-inv′ : σ⇐ ∘ ρ⇐ ≈ λ⇐ {X}
+braiding-coherence-inv′ = to-≈ braiding-coherence-iso′
+
+-- ... and the same two, solved for the braiding itself.
+
+braiding-coherence-σ : σ⇒ {X} {unit} ≈ λ⇐ ∘ ρ⇒
+braiding-coherence-σ = switch-fromtoˡ unitorˡ braiding-coherence
+
+braiding-coherence-σ′ : σ⇒ {unit} {X} ≈ ρ⇐ ∘ λ⇒
+braiding-coherence-σ′ = switch-fromtoˡ unitorʳ braiding-coherence′
 
 -- The inverse of the braiding is also a braiding on M.
 
@@ -181,9 +240,35 @@ assoc-reverse : [ X ⊗₀ (Y ⊗₀ Z) ⇒ (X ⊗₀ Y) ⊗₀ Z ]⟨
 assoc-reverse = begin
   σ⇐ ∘ id ⊗₁ σ⇐ ∘ α⇒ ∘ σ⇒ ∘ id ⊗₁ σ⇒    ≈⟨ refl⟩∘⟨ assoc²εβ ⟩
   σ⇐ ∘ (id ⊗₁ σ⇐ ∘ α⇒ ∘ σ⇒) ∘ id ⊗₁ σ⇒  ≈⟨ refl⟩∘⟨ pushˡ hex₁' ⟩
-  σ⇐ ∘ (α⇒ ∘ σ⇒ ⊗₁ id) ∘ α⇐ ∘ id ⊗₁ σ⇒  ≈⟨ refl⟩∘⟨ pullʳ (sym-assoc ○ hexagon₂) ⟩
+  σ⇐ ∘ (α⇒ ∘ σ⇒ ⊗₁ id) ∘ α⇐ ∘ id ⊗₁ σ⇒  ≈⟨ refl⟩∘⟨ pullʳ hex₂' ⟩
   σ⇐ ∘ α⇒ ∘ (α⇐ ∘ σ⇒) ∘ α⇐              ≈⟨ refl⟩∘⟨ pullˡ (cancelˡ associator.isoʳ) ⟩
   σ⇐ ∘ σ⇒ ∘ α⇐                          ≈⟨ cancelˡ (braiding.iso.isoˡ _) ⟩
   α⇐                                    ∎
   where
     hex₁' = conjugate-from associator (idᵢ ⊗ᵢ σ) (⟺ (hexagon₁ ○ sym-assoc))
+    hex₂' = sym-assoc ○ hexagon₂
+
+-- Scalars are central: the left and right actions of a scalar on any morphism agree in a
+-- braided monoidal category. Conjugating |f ⊗₁ s| by the braiding swaps the two tensor factors,
+-- and |braiding-coherence| identifies the two unitor sandwiches |ρ …| and |λ …|.
+
+scalar-central : {f : X ⇒ Y} {s : Scalar} → f ·ʳ s ≈ s ·ˡ f
+scalar-central {f = f} {s = s} = begin
+  ρ⇒ ∘ (f ⊗₁ s) ∘ ρ⇐                ≈˘⟨ braiding-coherence ⟩∘⟨ refl⟩∘⟨ braiding-coherence-inv ⟩
+  (λ⇒ ∘ σ⇒) ∘ (f ⊗₁ s) ∘ (σ⇐ ∘ λ⇐)  ≈⟨ pullʳ (pullˡ σ⇒-comm) ⟩
+  λ⇒ ∘ ((s ⊗₁ f) ∘ σ⇒) ∘ (σ⇐ ∘ λ⇐)  ≈⟨ refl⟩∘⟨ cancelInner (braiding.iso.isoʳ _) ⟩
+  λ⇒ ∘ (s ⊗₁ f) ∘ λ⇐                ∎
+
+-- The monoid of objects is commutative up to the braiding isomorphism.
+
+Obj-⊗-Comm-Monoid : CommutativeMonoid _ _
+Obj-⊗-Comm-Monoid = record
+  { Carrier = Obj
+  ; _≈_ = _≅_
+  ; _∙_ = _⊗₀_
+  ; ε   = unit
+  ; isCommutativeMonoid = record
+    { isMonoid = Monoid.isMonoid Obj-⊗-Monoid
+    ; comm     = λ X Y → σ {X , Y}
+    }
+  }

--- a/src/Categories/Category/Monoidal/Construction/Reverse.agda
+++ b/src/Categories/Category/Monoidal/Construction/Reverse.agda
@@ -12,7 +12,9 @@ open import Level using (_⊔_)
 open import Data.Product using (_,_; swap)
 import Function
 
+import Categories.Category.Construction.Core as Core
 open import Categories.Category using (Category)
+open import Categories.Category.Product using (_⁂_)
 open import Categories.Category.Monoidal
 open import Categories.Category.Monoidal.Braided using (Braided)
 import Categories.Category.Monoidal.Braided.Properties as BraidedProperties
@@ -21,8 +23,13 @@ open import Categories.Category.Monoidal.Symmetric using (Symmetric)
 import Categories.Category.Monoidal.Utilities as MonoidalUtils
 import Categories.Morphism as Morphism
 import Categories.Morphism.Reasoning as MorphismReasoning
+open import Categories.Functor using (_∘F_) renaming (id to idF)
 open import Categories.Functor.Bifunctor using (Bifunctor)
-open import Categories.NaturalTransformation.NaturalIsomorphism using (niHelper)
+open import Categories.Functor.Monoidal.Symmetric using (module Strong)
+open import Categories.Functor.Monoidal.Symmetric.Properties
+  using (∘-StrongSymmetricMonoidal)
+open import Categories.NaturalTransformation.NaturalIsomorphism
+  using (_≃_; NaturalIsomorphism; niHelper)
 
 open Category using (Obj)
 
@@ -124,3 +131,80 @@ Reverse-SymmetricMonoidalCategory C = record
   ; symmetric = Reverse-Symmetric symmetric
   }
   where open SymmetricMonoidalCategory C
+
+-- The identity functor from the reverse of a symmetric monoidal category
+-- is strong symmetric monoidal.
+
+module _ {o ℓ e} (C : SymmetricMonoidalCategory o ℓ e) where
+  open SymmetricMonoidalCategory C
+  open HomReasoning
+  private module BraidProps = BraidedProperties braided
+  private module MonoidalProps = MonoidalUtils monoidal
+  open BraidProps using
+    (assoc-reverse; braiding-coherence; braiding-coherence′)
+  open BraidProps.Shorthands
+  open Core.Shorthands U using (idᵢ)
+  open MonoidalProps using (_⊗ᵢ_)
+  open MonoidalProps.Shorthands
+  open Morphism U using (module ≅)
+  open MorphismReasoning U
+
+  private module Reverse = SymmetricMonoidalCategory (Reverse-SymmetricMonoidalCategory C)
+
+  private
+    ⊗-homo :
+      SymmetricMonoidalCategory.⊗ C ∘F (idF ⁂ idF)
+      ≃ idF ∘F Reverse.⊗
+    ⊗-homo = niHelper record
+      { η       = λ _ → σ⇒
+      ; η⁻¹     = λ _ → σ⇐
+      ; commute = λ _ → braiding.⇒.commute _
+      ; iso     = braiding.iso
+      }
+
+    module φ = NaturalIsomorphism ⊗-homo
+
+    associativity : ∀ {X Y Z} →
+      Reverse.associator.from ∘ φ.⇒.η (X Reverse.⊗₀ Y , Z) ∘ (φ.⇒.η (X , Y) ⊗₁ id)
+      ≈ φ.⇒.η (X , Y Reverse.⊗₀ Z) ∘ (id ⊗₁ φ.⇒.η (Y , Z)) ∘ α⇒
+    associativity {X} {Y} {Z} = begin
+      α⇐ ∘ σ⇒ ∘ (σ⇒ ⊗₁ id)                      ≈⟨ refl⟩∘⟨ σ⇒-comm ⟩
+      α⇐ ∘ (id ⊗₁ σ⇒) ∘ σ⇒                      ≈⟨ introʳ associator.isoˡ ⟩
+      (α⇐ ∘ (id ⊗₁ σ⇒) ∘ σ⇒) ∘ α⇐ ∘ α⇒          ≈⟨ sym-assoc ⟩
+      ((α⇐ ∘ (id ⊗₁ σ⇒) ∘ σ⇒) ∘ α⇐) ∘ α⇒        ≈⟨ assoc²βε ⟩∘⟨refl ⟩
+      (α⇐ ∘ (id ⊗₁ σ⇒) ∘ σ⇒ ∘ α⇐) ∘ α⇒          ≈⟨ reverse-assoc ⟩∘⟨refl ⟩
+      (σ⇒ ∘ (id ⊗₁ σ⇒)) ∘ α⇒                    ≈⟨ assoc ⟩
+      σ⇒ ∘ (id ⊗₁ σ⇒) ∘ α⇒                      ∎
+      where
+        reverse-assoc :
+          α⇐ ∘ (id ⊗₁ σ⇒) ∘ σ⇒ ∘ α⇐ ≈ σ⇒ ∘ (id ⊗₁ σ⇒)
+        reverse-assoc = ⟺ (switch-fromtoˡ associator
+          (switch-tofromˡ (idᵢ ⊗ᵢ σ) (switch-tofromˡ σ assoc-reverse)))
+
+  reverse-idF-StrongSymmetricMonoidal :
+    Strong.SymmetricMonoidalFunctor (Reverse-SymmetricMonoidalCategory C) C
+  reverse-idF-StrongSymmetricMonoidal = record
+    { F = idF
+    ; isBraidedMonoidal = record
+      { isStrongMonoidal = record
+        { ε             = ≅.refl
+        ; ⊗-homo        = ⊗-homo
+        ; associativity = associativity
+        ; unitaryˡ      = begin
+          ρ⇒ ∘ σ⇒ ∘ id ⊗₁ id      ≈⟨ refl⟩∘⟨ elimʳ ⊗.identity ⟩
+          ρ⇒ ∘ σ⇒                 ≈⟨ braiding-coherence′ ⟩
+          λ⇒                      ∎
+        ; unitaryʳ      = begin
+          λ⇒ ∘ σ⇒ ∘ id ⊗₁ id      ≈⟨ refl⟩∘⟨ elimʳ ⊗.identity ⟩
+          λ⇒ ∘ σ⇒                 ≈⟨ braiding-coherence ⟩
+          ρ⇒                      ∎
+        }
+      ; braiding-compat = braiding.iso.isoˡ _ ○ ⟺ commutative
+      }
+    }
+
+unreverse-StrongSymmetricMonoidal : ∀ {o ℓ e} {A C : SymmetricMonoidalCategory o ℓ e} →
+  Strong.SymmetricMonoidalFunctor A (Reverse-SymmetricMonoidalCategory C) →
+  Strong.SymmetricMonoidalFunctor A C
+unreverse-StrongSymmetricMonoidal {C = C} H =
+  ∘-StrongSymmetricMonoidal (reverse-idF-StrongSymmetricMonoidal C) H

--- a/src/Categories/Category/Monoidal/CupCap.agda
+++ b/src/Categories/Category/Monoidal/CupCap.agda
@@ -1,0 +1,418 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+
+-- Cup and cap calculus in a monoidal category.
+-- A cup is a morphism `unit ⇒ X`, drawn as creating `X` from no input wires.
+-- A cap is a morphism `X ⇒ unit`, drawn as consuming `X`.
+
+-- In the delooping view (https://ncatlab.org/nlab/show/delooping+hypothesis),
+-- which views a monoidal category as a bicategory on one object, caps and cups are
+-- 2-cells that create or consume the 1-cell `X` from the "identity" 1-cell `unit`.
+
+module Categories.Category.Monoidal.CupCap
+  {o ℓ e} {𝒞 : Category o ℓ e} (M : Monoidal 𝒞) where
+
+open Category 𝒞
+  using (Obj; _⇒_; _≈_; id; _∘_; assoc; sym-assoc; identity²)
+open Monoidal M
+
+open import Categories.Category.Monoidal.Properties M
+open import Categories.Category.Monoidal.Utilities M
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Category.Monoidal.Reassociation M
+open import Categories.Morphism.Reasoning 𝒞
+
+open Shorthands
+
+private
+  variable
+    A B C X Y Z : Obj
+
+-- Opening a cup beside a spectator wire, and closing a cap beside one.  A cup
+-- `unit ⇒ X` is introduced against the spectator `A` by an inverse unitor, and a
+-- cap `X ⇒ unit` is absorbed into it by a unitor; the ˡ/ʳ says which side of `A`
+-- the cup or cap sits on.  Every cup and cap in sight is built from these.
+-- Diagrams read bottom-to-top.
+--
+--       cup-openˡ cup          cup-openʳ cup
+--
+--       X       A              A       X
+--     ┌─┴─┐     │              │     ┌─┴─┐
+--     │cup│     │              │     │cup│
+--     └───┘     │              │     └───┘
+--               A              A
+--
+--       cap-closeˡ cap         cap-closeʳ cap
+--
+--              A                     A
+--              │                     │
+--       X      A               A     X
+--     ┌─┴─┐    │               │   ┌─┴─┐
+--     │cap│    │               │   │cap│
+--     └───┘    │               │   └───┘
+
+module Operations where
+  cup-openˡ : unit ⇒ X → A ⇒ X ⊗₀ A
+  cup-openˡ cup = (cup ⊗₁ id) ∘ λ⇐
+
+  cup-openʳ : unit ⇒ X → A ⇒ A ⊗₀ X
+  cup-openʳ cup = (id ⊗₁ cup) ∘ ρ⇐
+
+  cap-closeˡ : X ⇒ unit → X ⊗₀ A ⇒ A
+  cap-closeˡ cap = λ⇒ ∘ (cap ⊗₁ id)
+
+  cap-closeʳ : X ⇒ unit → A ⊗₀ X ⇒ A
+  cap-closeʳ cap = ρ⇒ ∘ (id ⊗₁ cap)
+
+  cup-bendˡ : unit ⇒ X ⊗₀ Y → A ⇒ X ⊗₀ (Y ⊗₀ A)
+  cup-bendˡ cup = α⇒ ∘ cup-openˡ cup
+
+  cup-bendʳ : unit ⇒ X ⊗₀ Y → A ⇒ (A ⊗₀ X) ⊗₀ Y
+  cup-bendʳ cup = α⇐ ∘ cup-openʳ cup
+
+  -- A cap on a *pair* has to reassociate first to reach its two wires.  Bending
+  -- `cap : X ⊗₀ Y ⇒ unit` around a spectator `A` on the right is `cap-bendˡ`;
+  -- the corresponding right-handed bend is `cap-bendʳ`, and `cap-reassoc`
+  -- below says the two agree.
+
+  cap-bendˡ : X ⊗₀ Y ⇒ unit → X ⊗₀ (Y ⊗₀ A) ⇒ A
+  cap-bendˡ cap = cap-closeˡ cap ∘ α⇐
+
+  cap-bendʳ : X ⊗₀ Y ⇒ unit → (A ⊗₀ X) ⊗₀ Y ⇒ A
+  cap-bendʳ cap = cap-closeʳ cap ∘ α⇒
+
+  cup-nest :
+    unit ⇒ A ⊗₀ B → unit ⇒ X ⊗₀ Y →
+    unit ⇒ (A ⊗₀ X) ⊗₀ (Y ⊗₀ B)
+  cup-nest cup cup′ = α⇐ ∘ (id ⊗₁ cup-bendˡ cup′) ∘ cup
+
+  -- `cup′` is planted inside `cup`; hence the output order `A`, `X`, `Y`, `B`.
+  --
+  --       A       X       Y       B
+  --       │     ┌─┴───────┴─┐     │
+  --       │     │   cup′    │     │
+  --       │     └───────────┘     │
+  --     ┌─┴───────────────────────┴──┐
+  --     │            cup             │
+  --     └────────────────────────────┘
+
+  -- Conjugate a morphism by a unitor and the associator.  `unit-conjˡ f` feeds
+  -- `f` a unit on the left (via `λ⇐`) and reassociates its output to the right;
+  -- `unit-conjʳ` mirrors it on the right (via `ρ⇐`).  A cup bent into place is
+  -- exactly one of these applied to a whiskered cup: `unit-conjˡ (cup ⊗₁ id)` is
+  -- `α⇒ ∘ cup-openˡ cup`, and `unit-conjʳ (id ⊗₁ cup)` is `α⇐ ∘ cup-openʳ cup`.
+
+  unit-conjˡ : (unit ⊗₀ X ⇒ (A ⊗₀ B) ⊗₀ Y) → (X ⇒ A ⊗₀ (B ⊗₀ Y))
+  unit-conjˡ f = α⇒ ∘ f ∘ λ⇐
+
+  unit-conjʳ : (X ⊗₀ unit ⇒ A ⊗₀ (B ⊗₀ Y)) → (X ⇒ (A ⊗₀ B) ⊗₀ Y)
+  unit-conjʳ f = α⇐ ∘ f ∘ ρ⇐
+
+open Operations public
+
+module Congruence where
+  cup-openˡ-resp : {cup cup′ : unit ⇒ Z} →
+    cup ≈ cup′ → cup-openˡ {A = A} cup ≈ cup-openˡ cup′
+  cup-openˡ-resp cup≈cup′ = ((cup≈cup′ ⟩⊗⟨refl) ⟩∘⟨refl)
+
+  cup-openʳ-resp : {cup cup′ : unit ⇒ Z} →
+    cup ≈ cup′ → cup-openʳ {A = A} cup ≈ cup-openʳ cup′
+  cup-openʳ-resp cup≈cup′ = ((refl⟩⊗⟨ cup≈cup′) ⟩∘⟨refl)
+
+  cap-closeˡ-resp : {cap cap′ : Z ⇒ unit} →
+    cap ≈ cap′ → cap-closeˡ {A = A} cap ≈ cap-closeˡ cap′
+  cap-closeˡ-resp cap≈cap′ = refl⟩∘⟨ (cap≈cap′ ⟩⊗⟨refl)
+
+  cap-closeʳ-resp : {cap cap′ : Z ⇒ unit} →
+    cap ≈ cap′ → cap-closeʳ {A = A} cap ≈ cap-closeʳ cap′
+  cap-closeʳ-resp cap≈cap′ = refl⟩∘⟨ (refl⟩⊗⟨ cap≈cap′)
+
+  cup-bendˡ-resp : {cup cup′ : unit ⇒ X ⊗₀ Y} →
+    cup ≈ cup′ → cup-bendˡ {A = A} cup ≈ cup-bendˡ cup′
+  cup-bendˡ-resp cup≈cup′ = refl⟩∘⟨ cup-openˡ-resp cup≈cup′
+
+  cup-bendʳ-resp : {cup cup′ : unit ⇒ X ⊗₀ Y} →
+    cup ≈ cup′ → cup-bendʳ {A = A} cup ≈ cup-bendʳ cup′
+  cup-bendʳ-resp cup≈cup′ = refl⟩∘⟨ cup-openʳ-resp cup≈cup′
+
+  cap-bendˡ-resp : {cap cap′ : X ⊗₀ Y ⇒ unit} →
+    cap ≈ cap′ → cap-bendˡ {A = A} cap ≈ cap-bendˡ cap′
+  cap-bendˡ-resp cap≈cap′ = cap-closeˡ-resp cap≈cap′ ⟩∘⟨refl
+
+  cap-bendʳ-resp : {cap cap′ : X ⊗₀ Y ⇒ unit} →
+    cap ≈ cap′ → cap-bendʳ {A = A} cap ≈ cap-bendʳ cap′
+  cap-bendʳ-resp cap≈cap′ = cap-closeʳ-resp cap≈cap′ ⟩∘⟨refl
+
+open Congruence public
+
+-- A morphism on the spectator wire commutes through a cup or cap.
+module Cup (cup : unit ⇒ Z) where
+  cup-openˡ-∘ : {f : Z ⇒ Y} →
+    (f ⊗₁ id {A}) ∘ cup-openˡ cup ≈ cup-openˡ (f ∘ cup)
+  cup-openˡ-∘ = pullˡ merge₁ˡ
+
+  cup-openʳ-∘ : {f : Z ⇒ Y} →
+    (id {A} ⊗₁ f) ∘ cup-openʳ cup ≈ cup-openʳ (f ∘ cup)
+  cup-openʳ-∘ = pullˡ merge₂ˡ
+
+  cup-openˡ-commute : {f : A ⇒ B} →
+    (id ⊗₁ f) ∘ cup-openˡ cup ≈ cup-openˡ {A = B} cup ∘ f
+  cup-openˡ-commute = pullˡ (⟺ whisker-comm) ○ extendˡ (⟺ unitorˡ-commute-to)
+
+  cup-openʳ-commute : {f : A ⇒ B} →
+    (f ⊗₁ id) ∘ cup-openʳ cup ≈ cup-openʳ {A = B} cup ∘ f
+  cup-openʳ-commute = pullˡ whisker-comm ○ extendˡ (⟺ unitorʳ-commute-to)
+
+open Cup public
+
+module Cap (cap : Z ⇒ unit) where
+  cap-closeˡ-∘ : {f : Y ⇒ Z} →
+    cap-closeˡ cap ∘ (f ⊗₁ id {A}) ≈ cap-closeˡ (cap ∘ f)
+  cap-closeˡ-∘ = pullʳ merge₁ˡ
+
+  cap-closeʳ-∘ : {f : Y ⇒ Z} →
+    cap-closeʳ cap ∘ (id {A} ⊗₁ f) ≈ cap-closeʳ (cap ∘ f)
+  cap-closeʳ-∘ = pullʳ merge₂ˡ
+
+  cap-closeˡ-commute : {f : A ⇒ B} →
+    cap-closeˡ cap ∘ (id ⊗₁ f) ≈ f ∘ cap-closeˡ {A = A} cap
+  cap-closeˡ-commute = pullʳ whisker-comm ○ extendʳ unitorˡ-commute-from
+
+  cap-closeʳ-commute : {f : A ⇒ B} →
+    cap-closeʳ cap ∘ (f ⊗₁ id) ≈ f ∘ cap-closeʳ cap
+  cap-closeʳ-commute = pullʳ (⟺ whisker-comm) ○ extendʳ unitorʳ-commute-from
+
+open Cap public
+
+module BentCup (cup : unit ⇒ X ⊗₀ Y) where
+  cup-bendˡ-commute : {f : A ⇒ B} →
+    (id ⊗₁ (id ⊗₁ f)) ∘ cup-bendˡ cup ≈ cup-bendˡ {A = B} cup ∘ f
+  cup-bendˡ-commute = pullˡ (⟺ α⇒-id⊗-commute) ○ extendˡ (cup-openˡ-commute cup)
+
+  cup-bendʳ-commute : {f : A ⇒ B} →
+    ((f ⊗₁ id {X}) ⊗₁ id {Y}) ∘ cup-bendʳ cup ≈ cup-bendʳ {A = B} cup ∘ f
+  cup-bendʳ-commute = pullˡ (⟺ α⇐-⊗id-commute) ○ extendˡ (cup-openʳ-commute cup)
+
+  cup-bendˡ-⊗ : {f : X ⇒ Z} {g : Y ⇒ B} →
+    (f ⊗₁ (g ⊗₁ id {A})) ∘ cup-bendˡ cup ≈ cup-bendˡ ((f ⊗₁ g) ∘ cup)
+  cup-bendˡ-⊗ = pullˡ (⟺ assoc-commute-from) ○ pullʳ (cup-openˡ-∘ cup)
+
+  cup-bendʳ-⊗ : {f : X ⇒ Z} {g : Y ⇒ B} →
+    ((id {A} ⊗₁ f) ⊗₁ g) ∘ cup-bendʳ cup ≈ cup-bendʳ ((f ⊗₁ g) ∘ cup)
+  cup-bendʳ-⊗ = pullˡ (⟺ assoc-commute-to) ○ pullʳ (cup-openʳ-∘ cup)
+
+open BentCup public
+
+module BentCap (cap : X ⊗₀ Y ⇒ unit) where
+  cap-bendˡ-commute : {f : A ⇒ B} →
+    cap-bendˡ cap ∘ (id ⊗₁ (id ⊗₁ f)) ≈ f ∘ cap-bendˡ {A = A} cap
+  cap-bendˡ-commute = pullʳ (⟺ α⇐-id⊗-commute) ○ extendʳ (cap-closeˡ-commute cap)
+
+  cap-bendʳ-commute : {f : A ⇒ B} →
+    cap-bendʳ cap ∘ ((f ⊗₁ id {X}) ⊗₁ id {Y}) ≈ f ∘ cap-bendʳ cap
+  cap-bendʳ-commute = pullʳ α⇒-⊗id-commute ○ extendʳ (cap-closeʳ-commute cap)
+
+  cap-bendˡ-⊗ : {f : Z ⇒ X} {g : B ⇒ Y} →
+    cap-bendˡ cap ∘ (f ⊗₁ (g ⊗₁ id {A})) ≈ cap-bendˡ (cap ∘ (f ⊗₁ g))
+  cap-bendˡ-⊗ = pullʳ assoc-commute-to ○ pullˡ (cap-closeˡ-∘ cap)
+
+  cap-bendʳ-⊗ : {f : Z ⇒ X} {g : B ⇒ Y} →
+    cap-bendʳ cap ∘ ((id {A} ⊗₁ f) ⊗₁ g) ≈ cap-bendʳ (cap ∘ (f ⊗₁ g))
+  cap-bendʳ-⊗ = pullʳ assoc-commute-from ○ pullˡ (cap-closeʳ-∘ cap)
+
+open BentCap public
+
+module Coherence where
+  -- Opening a cup beside `A ⊗₀ B` can be done beside one factor at a time.
+  cup-openˡ-natural : {cup : unit ⇒ Z} →
+    α⇒ ∘ (cup-openˡ {A = A} cup ⊗₁ id {B}) ≈ cup-openˡ cup
+  cup-openˡ-natural {cup = cup} = begin
+    α⇒ ∘ (((cup ⊗₁ id) ∘ λ⇐) ⊗₁ id)        ≈⟨ refl⟩∘⟨ split₁ˡ ⟩
+    α⇒ ∘ ((cup ⊗₁ id) ⊗₁ id) ∘ (λ⇐ ⊗₁ id)  ≈⟨ extendʳ α⇒-⊗id-commute ⟩
+    (cup ⊗₁ id) ∘ α⇒ ∘ (λ⇐ ⊗₁ id)          ≈⟨ refl⟩∘⟨ λ⇐-assoc ⟩
+    cup-openˡ cup                           ∎
+
+  cup-openʳ-natural : {cup : unit ⇒ Z} →
+    α⇒ {A} {B} {Z} ∘ cup-openʳ cup ≈ id ⊗₁ cup-openʳ cup
+  cup-openʳ-natural {cup = cup} = begin
+    α⇒ ∘ (id ⊗₁ cup) ∘ ρ⇐             ≈⟨ extendʳ α⇒-id⊗-commute ⟩
+    (id ⊗₁ (id ⊗₁ cup)) ∘ α⇒ ∘ ρ⇐     ≈˘⟨ refl⟩∘⟨ ρ⇐-assoc ⟩
+    (id ⊗₁ (id ⊗₁ cup)) ∘ (id ⊗₁ ρ⇐)  ≈⟨ merge₂ˡ ⟩
+    id ⊗₁ cup-openʳ cup               ∎
+
+  cap-closeˡ-natural : {cap : Z ⇒ unit} →
+    cap-closeˡ cap ∘ α⇒ {Z} {A} {B} ≈ cap-closeˡ cap ⊗₁ id
+  cap-closeˡ-natural {cap = cap} = begin
+    cap-closeˡ cap ∘ α⇒                       ≈⟨ assoc ⟩
+    λ⇒ ∘ (cap ⊗₁ id) ∘ α⇒                     ≈˘⟨ refl⟩∘⟨ α⇒-⊗id-commute ⟩
+    λ⇒ ∘ α⇒ ∘ ((cap ⊗₁ id) ⊗₁ id)             ≈⟨ pullˡ coherence₁ ⟩
+    (λ⇒ ⊗₁ id) ∘ ((cap ⊗₁ id) ⊗₁ id)          ≈⟨ merge₁ˡ ⟩
+    cap-closeˡ cap ⊗₁ id                      ∎
+
+  cap-closeʳ-natural : {cap : Z ⇒ unit} →
+    cap-closeʳ {A = A ⊗₀ B} cap ∘ α⇐ {A} {B} {Z} ≈ id ⊗₁ cap-closeʳ cap
+  cap-closeʳ-natural {cap = cap} = begin
+    cap-closeʳ cap ∘ α⇐               ≈⟨ pullʳ α⇐-id⊗-commute ⟩
+    ρ⇒ ∘ α⇐ ∘ (id ⊗₁ (id ⊗₁ cap))     ≈⟨ pullˡ ρ⇒-assoc ⟩
+    (id ⊗₁ ρ⇒) ∘ (id ⊗₁ (id ⊗₁ cap))  ≈⟨ merge₂ˡ ⟩
+    id ⊗₁ cap-closeʳ cap              ∎
+
+  -- The same fact, with the associator moved to the other side.
+  cap-closeʳ-assoc : {cap : Z ⇒ unit} →
+    cap-closeʳ {A = A ⊗₀ B} cap ≈ (id ⊗₁ cap-closeʳ cap) ∘ α⇒ {A} {B} {Z}
+  cap-closeʳ-assoc = switch-tofromʳ associator cap-closeʳ-natural
+
+  -- Whiskering a right-opened cup by `B` and reassociating drops it onto the `B`
+  -- wire, where it is a left-opened cup.  `A` is a spectator on both sides.
+  cup-openʳ-whisker : {cup : unit ⇒ Z} →
+    α⇒ ∘ (cup-openʳ {A = A} cup ⊗₁ id {B}) ≈ id ⊗₁ cup-openˡ cup
+  cup-openʳ-whisker {cup = cup} = begin
+    α⇒ ∘ (((id ⊗₁ cup) ∘ ρ⇐) ⊗₁ id)          ≈⟨ refl⟩∘⟨ split₁ˡ ⟩
+    α⇒ ∘ ((id ⊗₁ cup) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id)    ≈⟨ extendʳ assoc-commute-from ⟩
+    (id ⊗₁ (cup ⊗₁ id)) ∘ α⇒ ∘ (ρ⇐ ⊗₁ id)    ≈⟨ refl⟩∘⟨ triangle-inv′ ⟩
+    (id ⊗₁ (cup ⊗₁ id)) ∘ (id ⊗₁ λ⇐)         ≈⟨ merge₂ˡ ⟩
+    id ⊗₁ cup-openˡ cup                      ∎
+
+  -- Two cups planted side by side commute: the one already in place can be
+  -- pushed under the one being planted, which then opens on its own unit.
+  --
+  --       X       Y       A       B
+  --       │       │     ┌─┴───────┴─┐
+  --       │       │     │   cup′    │
+  --     ┌─┴───────┴─┐   └───────────┘
+  --     │    cup    │
+  --     └───────────┘
+  --                       ≈
+  --       X       Y       A       B
+  --     ┌─┴───────┴─┐     │       │
+  --     │    cup    │     │       │
+  --     └───────────┘   ┌─┴───────┴─┐
+  --                     │   cup′    │
+  --                     └───────────┘
+
+  parallel-cups-commute : {cup : unit ⇒ X ⊗₀ Y} {cup′ : unit ⇒ A ⊗₀ B} →
+    (id ⊗₁ cup-openʳ cup′) ∘ cup ≈ α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐ ∘ cup′
+  parallel-cups-commute {cup = cup} {cup′} = begin
+    (id ⊗₁ cup-openʳ cup′) ∘ cup        ≈˘⟨ cup-openʳ-natural ⟩∘⟨refl ⟩
+    (α⇒ ∘ cup-openʳ cup′) ∘ cup          ≈⟨ pullʳ (⟺ (cup-openʳ-commute cup′)) ⟩
+    α⇒ ∘ (cup ⊗₁ id) ∘ cup-openʳ cup′    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ open-unit ⟩
+    α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐ ∘ cup′        ∎
+    where
+      open-unit : cup-openʳ {A = unit} cup′ ≈ λ⇐ ∘ cup′
+      open-unit = begin
+        (id ⊗₁ cup′) ∘ ρ⇐  ≈⟨ refl⟩∘⟨ ⟺ coherence-inv₃ ⟩
+        (id ⊗₁ cup′) ∘ λ⇐  ≈˘⟨ unitorˡ-commute-to ⟩
+        λ⇐ ∘ cup′          ∎
+
+  -- The pentagon, in cap vocabulary: a cap on `C ⊗₀ X` closed against `A ⊗₀ B`,
+  -- once the two associators in front of it are unwound, is that cap closed
+  -- against `B` alone.  Again `A` only watches.
+  cap-closeʳ-pentagon : {cap : C ⊗₀ X ⇒ unit} →
+    cap-closeʳ {A = A ⊗₀ B} cap ∘ α⇒ ∘ (α⇐ ⊗₁ id {X})
+    ≈ (id ⊗₁ cap-bendʳ cap) ∘ α⇒
+  cap-closeʳ-pentagon {cap = cap} = begin
+    cap-closeʳ cap ∘ α⇒ ∘ (α⇐ ⊗₁ id)                 ≈⟨ pushˡ cap-closeʳ-assoc ⟩
+    (id ⊗₁ cap-closeʳ cap) ∘ α⇒ ∘ α⇒ ∘ (α⇐ ⊗₁ id)    ≈⟨ refl⟩∘⟨ sym-assoc ⟩
+    (id ⊗₁ cap-closeʳ cap) ∘ (α⇒ ∘ α⇒) ∘ (α⇐ ⊗₁ id)  ≈⟨ refl⟩∘⟨ pentagon-collapse ⟩
+    (id ⊗₁ cap-closeʳ cap) ∘ (id ⊗₁ α⇒) ∘ α⇒         ≈⟨ pullˡ merge₂ˡ ⟩
+    (id ⊗₁ cap-bendʳ cap) ∘ α⇒                       ∎
+
+  cup-bendˡ-assoc : (cup : unit ⇒ X ⊗₀ Y) →
+    (id ⊗₁ α⇒) ∘ α⇒ ∘ (cup-bendˡ {A = A} cup ⊗₁ id {B})
+    ≈ cup-bendˡ cup
+  cup-bendˡ-assoc cup = begin
+    (id ⊗₁ α⇒) ∘ α⇒ ∘ (cup-bendˡ cup ⊗₁ id)         ≈⟨ refl⟩∘⟨ refl⟩∘⟨ split₁ˡ ⟩
+    (id ⊗₁ α⇒) ∘ α⇒ ∘ (α⇒ ⊗₁ id) ∘
+      (cup-openˡ cup ⊗₁ id)                         ≈⟨ assoc²εβ ⟩
+    ((id ⊗₁ α⇒) ∘ α⇒ ∘ (α⇒ ⊗₁ id)) ∘
+      (cup-openˡ cup ⊗₁ id)                         ≈⟨ pentagon ⟩∘⟨refl ⟩
+    (α⇒ ∘ α⇒) ∘ (cup-openˡ cup ⊗₁ id)               ≈⟨ pullʳ cup-openˡ-natural ⟩
+    cup-bendˡ cup                                   ∎
+
+  cap-bendˡ-assoc : (cap : X ⊗₀ Y ⇒ unit) →
+    (cap-bendˡ {A = A} cap ⊗₁ id {B}) ∘ α⇐ ∘ (id ⊗₁ α⇐)
+    ≈ cap-bendˡ cap
+  cap-bendˡ-assoc cap = begin
+    ((cap-closeˡ cap ∘ α⇐) ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐)  ≈⟨ pushˡ split₁ˡ ⟩
+    (cap-closeˡ cap ⊗₁ id) ∘ (α⇐ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐)
+      ≈⟨ pushˡ (⟺ cap-closeˡ-natural) ⟩
+    cap-closeˡ cap ∘ α⇒ ∘ (α⇐ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐)
+      ≈⟨ refl⟩∘⟨ assoc²εβ ⟩
+    cap-closeˡ cap ∘ (α⇒ ∘ (α⇐ ⊗₁ id) ∘ α⇐) ∘ (id ⊗₁ α⇐)
+      ≈⟨ refl⟩∘⟨ pentagon-assoc ⟩∘⟨refl ⟩
+    cap-closeˡ cap ∘ (α⇐ ∘ (id ⊗₁ α⇒)) ∘ (id ⊗₁ α⇐)
+      ≈⟨ refl⟩∘⟨ cancelʳ (⊗-cancel identity² associator.isoʳ) ⟩
+    cap-bendˡ cap                                           ∎
+
+  -- Closing `cap` on the left of the inner pair, with `λ⇒`, is the same as
+  -- reassociating first and closing it on the right, with `ρ⇒`.  This is the
+  -- triangle, whiskered on both sides by `A` and `X`.
+  cap-reassoc : {cap : B ⊗₀ C ⇒ unit} →
+    (id {A} ⊗₁ cap-bendˡ {A = X} cap) ∘ α⇒ ≈ (cap-bendʳ cap ⊗₁ id) ∘ α⇐
+  cap-reassoc {cap = cap} = begin
+    (id ⊗₁ ((λ⇒ ∘ (cap ⊗₁ id)) ∘ α⇐)) ∘ α⇒                   ≈⟨ (refl⟩⊗⟨ assoc) ⟩∘⟨refl ⟩
+    (id ⊗₁ (λ⇒ ∘ (cap ⊗₁ id) ∘ α⇐)) ∘ α⇒                     ≈⟨ split₂³ ⟩∘⟨refl ⟩
+    ((id ⊗₁ λ⇒) ∘ (id ⊗₁ (cap ⊗₁ id)) ∘ (id ⊗₁ α⇐)) ∘ α⇒     ≈⟨ assoc²βε ⟩
+    (id ⊗₁ λ⇒) ∘ (id ⊗₁ (cap ⊗₁ id)) ∘ (id ⊗₁ α⇐) ∘ α⇒       ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc-to-coherence ⟩
+    (id ⊗₁ λ⇒) ∘ (id ⊗₁ (cap ⊗₁ id)) ∘ α⇒ ∘ (α⇒ ⊗₁ id) ∘ α⇐  ≈⟨ refl⟩∘⟨ extendʳ (⟺ assoc-commute-from) ⟩
+    (id ⊗₁ λ⇒) ∘ α⇒ ∘ ((id ⊗₁ cap) ⊗₁ id) ∘ (α⇒ ⊗₁ id) ∘ α⇐  ≈⟨ pullˡ triangle ⟩
+    (ρ⇒ ⊗₁ id) ∘ ((id ⊗₁ cap) ⊗₁ id) ∘ (α⇒ ⊗₁ id) ∘ α⇐       ≈⟨ assoc²εβ ⟩
+    ((ρ⇒ ⊗₁ id) ∘ ((id ⊗₁ cap) ⊗₁ id) ∘ (α⇒ ⊗₁ id)) ∘ α⇐     ≈⟨ merge₁³ ⟩∘⟨refl ⟩
+    ((ρ⇒ ∘ (id ⊗₁ cap) ∘ α⇒) ⊗₁ id) ∘ α⇐                     ≈⟨ (sym-assoc ⟩⊗⟨refl) ⟩∘⟨refl ⟩
+    (cap-bendʳ cap ⊗₁ id) ∘ α⇐                               ∎
+
+  -- Pentagon slide: given a unit-map `u` and a map `f` whose target splits as
+  -- `X ⊗₀ Y`, pull the "cup" built by `u` then `f` leftward through the associators.
+  cup-slideˡ : {u : unit ⇒ A ⊗₀ B} {f : B ⇒ X ⊗₀ Y} →
+    unit-conjˡ ((α⇐ ⊗₁ id {C}) ∘ ((id ⊗₁ f) ⊗₁ id) ∘ (u ⊗₁ id))
+    ≈ ((α⇐ ∘ (id ⊗₁ (α⇒ ∘ (f ⊗₁ id)))) ∘ (α⇒ ∘ (u ⊗₁ id))) ∘ λ⇐
+  cup-slideˡ {A = A} {C = C} {u = u} {f = f} = pullˡ slide
+    where
+      -- The slide itself, with the trailing `λ⇐` peeled off.
+      slide : α⇒ ∘ (α⇐ ⊗₁ id {C}) ∘ ((id {A} ⊗₁ f) ⊗₁ id) ∘ (u ⊗₁ id)
+           ≈ (α⇐ ∘ (id ⊗₁ (α⇒ ∘ (f ⊗₁ id)))) ∘ (α⇒ ∘ (u ⊗₁ id))
+      slide = begin
+        α⇒ ∘ (α⇐ ⊗₁ id) ∘ ((id ⊗₁ f) ⊗₁ id) ∘ (u ⊗₁ id)           ≈⟨ pullˡ assoc-from-coherence ⟩
+        (α⇐ ∘ (id ⊗₁ α⇒) ∘ α⇒) ∘ ((id ⊗₁ f) ⊗₁ id) ∘ (u ⊗₁ id)    ≈⟨ sym-assoc ⟩∘⟨refl ⟩
+        ((α⇐ ∘ (id ⊗₁ α⇒)) ∘ α⇒) ∘ ((id ⊗₁ f) ⊗₁ id) ∘ (u ⊗₁ id)  ≈⟨ center assoc-commute-from ⟩
+        (α⇐ ∘ (id ⊗₁ α⇒)) ∘ ((id ⊗₁ (f ⊗₁ id)) ∘ α⇒) ∘ (u ⊗₁ id)  ≈⟨ refl⟩∘⟨ assoc ⟩
+        (α⇐ ∘ (id ⊗₁ α⇒)) ∘ (id ⊗₁ (f ⊗₁ id)) ∘ α⇒ ∘ (u ⊗₁ id)    ≈⟨ center merge₂ˡ ⟩
+        α⇐ ∘ (id ⊗₁ (α⇒ ∘ (f ⊗₁ id))) ∘ α⇒ ∘ (u ⊗₁ id)            ≈⟨ sym-assoc ⟩
+        (α⇐ ∘ (id ⊗₁ (α⇒ ∘ (f ⊗₁ id)))) ∘ (α⇒ ∘ (u ⊗₁ id))        ∎
+
+  -- Slide a cap `g` sitting in left-tensor position rightward through the
+  -- associators.  Pure associator gymnastics — `g` is treated opaquely.
+  cap-slideʳ : {g : B ⊗₀ (C ⊗₀ X) ⇒ Y} →
+    (((id {A} ⊗₁ g) ∘ α⇒) ⊗₁ id {Z}) ∘ α⇐ ∘ (id ⊗₁ α⇐)
+    ≈ α⇐ ∘ (id ⊗₁ ((g ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐))) ∘ α⇒
+  cap-slideʳ {C = C} {X = X} {Z = Z} {g = g} = begin
+    (((id ⊗₁ g) ∘ α⇒) ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐)              ≈⟨ split₁ʳ ⟩∘⟨refl ⟩
+    (((id ⊗₁ g) ⊗₁ id) ∘ (α⇒ ⊗₁ id)) ∘ α⇐ ∘ (id ⊗₁ α⇐)      ≈⟨ switch-fromtoˡ associator slide ⟩
+    α⇐ ∘ (id ⊗₁ ((g ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐))) ∘ α⇒         ∎
+    where
+      reassociate :
+        α⇒ ∘ (α⇒ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐ {C} {X} {Z})
+        ≈ (id ⊗₁ α⇐) ∘ (id ⊗₁ (id ⊗₁ α⇐)) ∘ α⇒
+      reassociate = begin
+        α⇒ ∘ (α⇒ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐)                ≈⟨ assoc²εβ ⟩
+        (α⇒ ∘ (α⇒ ⊗₁ id) ∘ α⇐) ∘ (id ⊗₁ α⇐)              ≈˘⟨ assoc-to-coherence ⟩∘⟨refl ⟩
+        ((id ⊗₁ α⇐) ∘ α⇒) ∘ (id ⊗₁ α⇐)                   ≈⟨ pullʳ α⇒-id⊗-commute ⟩
+        (id ⊗₁ α⇐) ∘ (id ⊗₁ (id ⊗₁ α⇐)) ∘ α⇒             ∎
+
+      merge :
+        (id ⊗₁ (g ⊗₁ id)) ∘ (id ⊗₁ α⇐) ∘ (id ⊗₁ (id ⊗₁ α⇐)) ∘ α⇒
+        ≈ (id ⊗₁ ((g ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐))) ∘ α⇒
+      merge = ⟺ assoc²βε ○ (merge₂³ ⟩∘⟨refl)
+
+      slide : α⇒ ∘ (((id ⊗₁ g) ⊗₁ id) ∘ (α⇒ ⊗₁ id)) ∘ α⇐ ∘ (id ⊗₁ α⇐ {C} {X} {Z})
+            ≈ (id ⊗₁ ((g ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐))) ∘ α⇒
+      slide = begin
+        α⇒ ∘ (((id ⊗₁ g) ⊗₁ id) ∘ (α⇒ ⊗₁ id)) ∘ α⇐ ∘ (id ⊗₁ α⇐)   ≈⟨ refl⟩∘⟨ assoc ⟩
+        α⇒ ∘ ((id ⊗₁ g) ⊗₁ id) ∘ (α⇒ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐)     ≈⟨ extendʳ assoc-commute-from ⟩
+        (id ⊗₁ (g ⊗₁ id)) ∘ α⇒ ∘ (α⇒ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐)     ≈⟨ refl⟩∘⟨ reassociate ⟩
+        (id ⊗₁ (g ⊗₁ id)) ∘ (id ⊗₁ α⇐) ∘ (id ⊗₁ (id ⊗₁ α⇐)) ∘ α⇒  ≈⟨ merge ⟩
+        (id ⊗₁ ((g ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐))) ∘ α⇒                ∎
+
+open Coherence public

--- a/src/Categories/Category/Monoidal/Reasoning.agda
+++ b/src/Categories/Category/Monoidal/Reasoning.agda
@@ -121,6 +121,10 @@ split₁ˡ {f = f} {g} {h} = begin
   (f ∘ g) ⊗₁ (id ∘ h)   ≈⟨ ⊗-distrib-over-∘ ⟩
   f ⊗₁ id ∘ g ⊗₁ h      ∎
 
+split₁³ : ∀ {W X Y Z A} {f : Y ⇒ Z} {g : X ⇒ Y} {h : W ⇒ X} →
+          (f ∘ g ∘ h) ⊗₁ id {A} ≈ (f ⊗₁ id) ∘ (g ⊗₁ id) ∘ (h ⊗₁ id)
+split₁³ = split₁ˡ ○ (refl⟩∘⟨ split₁ˡ)
+
 -- Split a composite in the second component
 --
 --   |   |        |   |       |   |
@@ -143,6 +147,10 @@ split₂ˡ {f = f} {g} {h} = begin
   (id ∘ f) ⊗₁ (g ∘ h)   ≈⟨ ⊗-distrib-over-∘ ⟩
   id ⊗₁ g ∘ f ⊗₁ h      ∎
 
+split₂³ : ∀ {W X Y Z A} {f : Y ⇒ Z} {g : X ⇒ Y} {h : W ⇒ X} →
+          id {A} ⊗₁ (f ∘ g ∘ h) ≈ (id ⊗₁ f) ∘ (id ⊗₁ g) ∘ (id ⊗₁ h)
+split₂³ = split₂ˡ ○ (refl⟩∘⟨ split₂ˡ)
+
 -- The opposite, i.e. merge
 merge₁ʳ : ∀ {X₁ Y₁ Z₁ X₂ Y₂} {f : Y₁ ⇒ Z₁} {g : X₁ ⇒ Y₁} {h : X₂ ⇒ Y₂} →
           f ⊗₁ h ∘ g ⊗₁ id ≈ (f ∘ g) ⊗₁ h
@@ -159,6 +167,14 @@ merge₂ʳ = Equiv.sym split₂ʳ
 merge₂ˡ : ∀ {X₁ Y₁ X₂ Y₂ Z₂} {f : X₁ ⇒ Y₁} {g : Y₂ ⇒ Z₂} {h : X₂ ⇒ Y₂} →
           id ⊗₁ g ∘ f ⊗₁ h ≈ f ⊗₁ (g ∘ h)
 merge₂ˡ = Equiv.sym split₂ˡ
+
+merge₁³ : ∀ {W X Y Z A} {f : Y ⇒ Z} {g : X ⇒ Y} {h : W ⇒ X} →
+          (f ⊗₁ id) ∘ (g ⊗₁ id) ∘ (h ⊗₁ id {A}) ≈ (f ∘ g ∘ h) ⊗₁ id
+merge₁³ = Equiv.sym split₁³
+
+merge₂³ : ∀ {W X Y Z A} {f : Y ⇒ Z} {g : X ⇒ Y} {h : W ⇒ X} →
+          (id ⊗₁ f) ∘ (id ⊗₁ g) ∘ (id {A} ⊗₁ h) ≈ id ⊗₁ (f ∘ g ∘ h)
+merge₂³ = Equiv.sym split₂³
 
 -- Combined splitting and re-association.
 

--- a/src/Categories/Category/Monoidal/Reassociation.agda
+++ b/src/Categories/Category/Monoidal/Reassociation.agda
@@ -23,32 +23,137 @@ open MR 𝒞
 
 private
   variable
-    A B C D : Obj
+    A B C D X Y Z : Obj
 
-pentagon-assoc
-  : α⇒ {A ⊗₀ B} {C} {D} ∘ (α⇐ {A} {B} {C} ⊗₁ id) ∘ α⇐ {A} {B ⊗₀ C} {D}
-    ≈ α⇐ {A} {B} {C ⊗₀ D} ∘ (id ⊗₁ α⇒ {B} {C} {D})
-pentagon-assoc = begin
-  α⇒ ∘ (α⇐ ⊗₁ id) ∘ α⇐                                 ≈⟨ refl⟩∘⟨ insertʳ (⊗-cancel identity² associator.isoˡ) ⟩
-  α⇒ ∘ (((α⇐ ⊗₁ id) ∘ α⇐) ∘ (id ⊗₁ α⇐)) ∘ (id ⊗₁ α⇒)   ≈⟨ refl⟩∘⟨ pentagon-inv ⟩∘⟨refl ⟩
-  α⇒ ∘ (α⇐ ∘ α⇐) ∘ (id ⊗₁ α⇒)                          ≈⟨ refl⟩∘⟨ assoc ⟩
-  α⇒ ∘ α⇐ ∘ α⇐ ∘ (id ⊗₁ α⇒)                            ≈⟨ cancelˡ associator.isoʳ ⟩
-  α⇐ ∘ (id ⊗₁ α⇒)                                      ∎
+------------------------------------------------------------------------
+-- Unitors against the associator.
 
-λ⇒-assoc : (λ⇒ {A} ⊗₁ id {B}) ∘ α⇐ {unit} {A} {B} ≈ λ⇒
+λ⇒-assoc : (λ⇒ {A} ⊗₁ id {B}) ∘ α⇐ ≈ λ⇒
 λ⇒-assoc = ⟺ (switch-fromtoʳ associator coherence₁)
 
 λ⇐-assoc : α⇒ ∘ (λ⇐ {A} ⊗₁ id {B}) ≈ λ⇐
 λ⇐-assoc = begin
-  α⇒ ∘ (λ⇐ ⊗₁ id)   ≈⟨ refl⟩∘⟨ ⟺ coherence-inv₁ ⟩
+  α⇒ ∘ (λ⇐ ⊗₁ id)   ≈˘⟨ refl⟩∘⟨ coherence-inv₁ ⟩
   α⇒ ∘ (α⇐ ∘ λ⇐)    ≈⟨ cancelˡ associator.isoʳ ⟩
   λ⇐                ∎
 
-ρ⇒-assoc : ρ⇒ ∘ α⇐ {A} {B} {unit} ≈ id {A} ⊗₁ ρ⇒
+ρ⇒-assoc : ρ⇒ ∘ α⇐ {X} {Y} {unit} ≈ id ⊗₁ ρ⇒
 ρ⇒-assoc = ⟺ (switch-fromtoʳ associator coherence₂)
 
-ρ⇐-assoc : id {A} ⊗₁ ρ⇐ {B} ≈ α⇒ ∘ ρ⇐ {A ⊗₀ B}
+ρ⇐-assoc : id {A} ⊗₁ ρ⇐ {B} ≈ α⇒ ∘ ρ⇐
 ρ⇐-assoc = begin
   id ⊗₁ ρ⇐                 ≈˘⟨ cancelˡ associator.isoʳ ⟩
   α⇒ ∘ (α⇐ ∘ (id ⊗₁ ρ⇐))   ≈⟨ refl⟩∘⟨ coherence-inv₂ ⟩
   α⇒ ∘ ρ⇐                  ∎
+
+-- Commute the left unitor past a right counit through the associator: the
+-- |coherence₁| triangle, then the right unitor's square.
+λ⇒-ρ⇐-comm : λ⇒ ∘ α⇒ ∘ ρ⇐ ≈ ρ⇐ {X} ∘ λ⇒
+λ⇒-ρ⇐-comm = pullˡ coherence₁ ○ ⟺ unitorʳ-commute-to
+
+------------------------------------------------------------------------
+-- Whiskered maps against the associator.  Each is `assoc-commute-from/to`
+-- with one leg's `id ⊗₁ id` folded away.
+
+α⇒-id⊗-commute : {k : X ⇒ Y} →
+  α⇒ {A} {B} {Y} ∘ (id ⊗₁ k) ≈ (id ⊗₁ (id ⊗₁ k)) ∘ α⇒
+α⇒-id⊗-commute {k = k} = begin
+  α⇒ ∘ (id ⊗₁ k)            ≈˘⟨ refl⟩∘⟨ (⊗.identity ⟩⊗⟨refl) ⟩
+  α⇒ ∘ ((id ⊗₁ id) ⊗₁ k)    ≈⟨ assoc-commute-from ⟩
+  (id ⊗₁ (id ⊗₁ k)) ∘ α⇒    ∎
+
+α⇐-id⊗-commute : {k : X ⇒ Y} →
+  (id {A ⊗₀ B} ⊗₁ k) ∘ α⇐ ≈ α⇐ ∘ (id ⊗₁ (id ⊗₁ k))
+α⇐-id⊗-commute {k = k} = begin
+  (id ⊗₁ k) ∘ α⇐            ≈˘⟨ (⊗.identity ⟩⊗⟨refl) ⟩∘⟨refl ⟩
+  ((id ⊗₁ id) ⊗₁ k) ∘ α⇐    ≈˘⟨ assoc-commute-to ⟩
+  α⇐ ∘ (id ⊗₁ (id ⊗₁ k))    ∎
+
+α⇐-⊗id-commute : {k : X ⇒ Y} →
+  α⇐ {Y} {A} {B} ∘ (k ⊗₁ id) ≈ ((k ⊗₁ id) ⊗₁ id) ∘ α⇐
+α⇐-⊗id-commute {k = k} = begin
+  α⇐ ∘ (k ⊗₁ id)          ≈˘⟨ refl⟩∘⟨ (refl⟩⊗⟨ ⊗.identity) ⟩
+  α⇐ ∘ (k ⊗₁ (id ⊗₁ id))  ≈⟨ assoc-commute-to ⟩
+  ((k ⊗₁ id) ⊗₁ id) ∘ α⇐  ∎
+
+α⇒-⊗id-commute : {k : X ⇒ Y} →
+  α⇒ {Y} {A} {B} ∘ ((k ⊗₁ id) ⊗₁ id) ≈ (k ⊗₁ id) ∘ α⇒
+α⇒-⊗id-commute {k = k} = begin
+  α⇒ ∘ ((k ⊗₁ id) ⊗₁ id)  ≈⟨ assoc-commute-from ⟩
+  (k ⊗₁ (id ⊗₁ id)) ∘ α⇒  ≈⟨ (refl⟩⊗⟨ ⊗.identity) ⟩∘⟨refl ⟩
+  (k ⊗₁ id) ∘ α⇒          ∎
+
+-- Maps whiskered into *different* factors commute past each other: both sides are
+-- `f ⊗₁ g`, serialized the two ways round.
+whisker-comm : {f : A ⇒ B} {g : X ⇒ Y} →
+  (f ⊗₁ id {Y}) ∘ (id {A} ⊗₁ g) ≈ (id ⊗₁ g) ∘ (f ⊗₁ id {X})
+whisker-comm = ⟺ serialize₁₂ ○ serialize₂₁
+
+-- Rebracketing commutes with a map tensored on either side.
+rebracket-tightenˡ : {f : B ⇒ C} {h : A ⊗₀ (X ⊗₀ Y) ⇒ B ⊗₀ (X ⊗₀ Y)} →
+  α⇐ ∘ ((f ⊗₁ id) ∘ h) ∘ α⇒ ≈ ((f ⊗₁ id) ⊗₁ id) ∘ (α⇐ ∘ h ∘ α⇒)
+rebracket-tightenˡ {f = f} {h = h} = begin
+  α⇐ ∘ ((f ⊗₁ id) ∘ h) ∘ α⇒   ≈⟨ refl⟩∘⟨ assoc ⟩
+  α⇐ ∘ (f ⊗₁ id) ∘ h ∘ α⇒     ≈⟨ extendʳ α⇐-⊗id-commute ⟩
+  ((f ⊗₁ id) ⊗₁ id) ∘ α⇐ ∘ h ∘ α⇒ ∎
+
+rebracket-tightenʳ : {h : B ⊗₀ (X ⊗₀ Y) ⇒ C ⊗₀ (X ⊗₀ Y)} {g : A ⇒ B} →
+  α⇐ ∘ (h ∘ (g ⊗₁ id)) ∘ α⇒ ≈ (α⇐ ∘ h ∘ α⇒) ∘ ((g ⊗₁ id) ⊗₁ id)
+rebracket-tightenʳ {h = h} {g = g} = begin
+  α⇐ ∘ (h ∘ (g ⊗₁ id)) ∘ α⇒        ≈⟨ refl⟩∘⟨ assoc ⟩
+  α⇐ ∘ h ∘ (g ⊗₁ id) ∘ α⇒          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ α⇒-⊗id-commute ⟩
+  α⇐ ∘ h ∘ α⇒ ∘ ((g ⊗₁ id) ⊗₁ id)  ≈⟨ assoc²εβ ⟩
+  (α⇐ ∘ h ∘ α⇒) ∘ ((g ⊗₁ id) ⊗₁ id) ∎
+
+------------------------------------------------------------------------
+-- Pentagon corollaries.
+
+pentagon-assoc : α⇒ {A ⊗₀ B} {C} {D} ∘ (α⇐ ⊗₁ id) ∘ α⇐ ≈ α⇐ ∘ (id ⊗₁ α⇒)
+pentagon-assoc = conjugate-from (idᵢ ⊗ᵢ (associator ⁻¹)) (associator ⁻¹) pentagon-inv
+
+assoc-to-coherence :
+  (id {A} ⊗₁ α⇐ {B} {C} {D}) ∘ α⇒ ≈ α⇒ ∘ (α⇒ ⊗₁ id) ∘ α⇐
+assoc-to-coherence = begin
+  (id ⊗₁ α⇐) ∘ α⇒         ≈⟨ conjugate-from associator (idᵢ ⊗ᵢ associator) (⟺ pentagon) ⟩
+  (α⇒ ∘ (α⇒ ⊗₁ id)) ∘ α⇐  ≈⟨ assoc ⟩
+  α⇒ ∘ (α⇒ ⊗₁ id) ∘ α⇐    ∎
+
+assoc-from-coherence :
+  α⇒ {A ⊗₀ B} {C} {D} ∘ (α⇐ ⊗₁ id) ≈ α⇐ ∘ (id ⊗₁ α⇒) ∘ α⇒
+assoc-from-coherence =
+  switch-tofromʳ associator (assoc ○ pentagon-assoc) ○ assoc
+
+-- Two associators followed by `α⇐ ⊗₁ id` drop a level.
+pentagon-collapse :
+  (α⇒ {A} {B} {C ⊗₀ D} ∘ α⇒) ∘ (α⇐ ⊗₁ id) ≈ (id ⊗₁ α⇒) ∘ α⇒
+pentagon-collapse = pullʳ assoc-from-coherence ○ cancelˡ associator.isoʳ
+
+pentagon-collapse-inv :
+  (α⇒ {A} {B} {C} ⊗₁ id {D}) ∘ α⇐ ∘ α⇐ ≈ α⇐ ∘ (id ⊗₁ α⇐)
+pentagon-collapse-inv = begin
+  (α⇒ ⊗₁ id) ∘ α⇐ ∘ α⇐
+    ≈˘⟨ refl⟩∘⟨ pentagon-inv ⟩
+  (α⇒ ⊗₁ id) ∘ ((α⇐ ⊗₁ id) ∘ α⇐) ∘ (id ⊗₁ α⇐)
+    ≈⟨ refl⟩∘⟨ assoc ⟩
+  (α⇒ ⊗₁ id) ∘ (α⇐ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐)
+    ≈⟨ cancelˡ (⊗-cancel associator.isoʳ identity²) ⟩
+  α⇐ ∘ (id ⊗₁ α⇐)  ∎
+
+-- Associator-conjugation slide.  Conjugating an `id ⊗₁ f` block by `α⇐ ∘ _ ∘ α⇒`
+-- on the left, whiskered by `id` and wrapped in a further pair of associators,
+-- equals the same `f` conjugated by `α⇒ ∘ _ ∘ α⇐` on the right, under one `α⇒`.
+-- `f` is opaque — this is pure pentagon/associator gymnastics.
+α-conj-slide : {f : A ⊗₀ X ⇒ B ⊗₀ X} →
+  α⇒ ∘ α⇒ ∘ ((α⇐ ∘ (id {Y} ⊗₁ f) ∘ α⇒) ⊗₁ id {Z}) ∘ α⇐
+  ≈ (id ⊗₁ (α⇒ ∘ (f ⊗₁ id) ∘ α⇐)) ∘ α⇒
+α-conj-slide {f = f} = begin
+  α⇒ ∘ α⇒ ∘ ((α⇐ ∘ (id ⊗₁ f) ∘ α⇒) ⊗₁ id) ∘ α⇐                    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ split₁³ ⟩∘⟨refl ⟩
+  α⇒ ∘ α⇒ ∘ ((α⇐ ⊗₁ id) ∘ ((id ⊗₁ f) ⊗₁ id) ∘ (α⇒ ⊗₁ id)) ∘ α⇐    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ assoc²βε ⟩
+  α⇒ ∘ α⇒ ∘ (α⇐ ⊗₁ id) ∘ ((id ⊗₁ f) ⊗₁ id) ∘ (α⇒ ⊗₁ id) ∘ α⇐      ≈⟨ assoc²εα ⟩
+  ((α⇒ ∘ α⇒) ∘ (α⇐ ⊗₁ id)) ∘ ((id ⊗₁ f) ⊗₁ id) ∘ (α⇒ ⊗₁ id) ∘ α⇐  ≈⟨ pentagon-collapse ⟩∘⟨refl ⟩
+  ((id ⊗₁ α⇒) ∘ α⇒) ∘ ((id ⊗₁ f) ⊗₁ id) ∘ (α⇒ ⊗₁ id) ∘ α⇐         ≈⟨ assoc ⟩
+  (id ⊗₁ α⇒) ∘ α⇒ ∘ ((id ⊗₁ f) ⊗₁ id) ∘ (α⇒ ⊗₁ id) ∘ α⇐           ≈⟨ refl⟩∘⟨ extendʳ assoc-commute-from ⟩
+  (id ⊗₁ α⇒) ∘ (id ⊗₁ (f ⊗₁ id)) ∘ α⇒ ∘ (α⇒ ⊗₁ id) ∘ α⇐           ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ assoc-to-coherence ⟩
+  (id ⊗₁ α⇒) ∘ (id ⊗₁ (f ⊗₁ id)) ∘ (id ⊗₁ α⇐) ∘ α⇒                ≈˘⟨ assoc²βε ⟩
+  ((id ⊗₁ α⇒) ∘ (id ⊗₁ (f ⊗₁ id)) ∘ (id ⊗₁ α⇐)) ∘ α⇒              ≈⟨ merge₂³ ⟩∘⟨refl ⟩
+  (id ⊗₁ (α⇒ ∘ (f ⊗₁ id) ∘ α⇐)) ∘ α⇒                              ∎

--- a/src/Categories/Category/Monoidal/Symmetric/Properties.agda
+++ b/src/Categories/Category/Monoidal/Symmetric/Properties.agda
@@ -8,8 +8,11 @@ module Categories.Category.Monoidal.Symmetric.Properties
   {o ℓ e} {C : Category o ℓ e} {M : Monoidal C} (SM : Symmetric M) where
 
 import Categories.Category.Monoidal.Braided.Properties as BraidedProperties
+import Categories.Category.Construction.Core C as Core
+import Categories.Category.Monoidal.Utilities M as MonUtil
 
 open import Categories.Category.Monoidal.Properties M using (monoidal-Op)
+open import Categories.Morphism C using (_≅_)
 open import Categories.Morphism.Reasoning C
 open import Data.Product using (_,_)
 
@@ -20,6 +23,11 @@ open Symmetric SM
 -- Shorthands for the braiding
 
 open BraidedProperties braided public using (module Shorthands)
+open BraidedProperties braided using (braiding-coherence-inv)
+open Shorthands
+open Core.Shorthands using (idᵢ)
+open MonUtil using (_⊗ᵢ_)
+open MonUtil.Shorthands
 
 -- Extra properties of the braiding in a symmetric monoidal category
 
@@ -28,6 +36,36 @@ braiding-selfInverse = introʳ commutative ○ cancelˡ (braiding.iso.isoˡ _)
 
 inv-commutative : ∀ {X Y} → braiding.⇐.η (X , Y) ∘ braiding.⇐.η (Y , X) ≈ id
 inv-commutative = ∘-resp-≈ braiding-selfInverse braiding-selfInverse ○ commutative
+
+mirrorˡ : ∀ {X Y Z} → (id {X} ⊗₁ σ⇒ {Z} {Y}) ∘ σ⇐ {X} {Z ⊗₀ Y} ≈ σ⇒ ∘ (σ⇒ ⊗₁ id)
+mirrorˡ = begin
+  id ⊗₁ σ⇒ ∘ σ⇐         ≈⟨ refl⟩∘⟨ braiding-selfInverse ⟩
+  id ⊗₁ σ⇒ ∘ σ⇒         ≈˘⟨ σ⇒-comm ⟩
+  σ⇒ ∘ σ⇒ ⊗₁ id         ∎
+
+mirrorʳ : ∀ {X Y Z} → (σ⇒ {Z} {Y} ⊗₁ id {X}) ∘ σ⇐ {Z ⊗₀ Y} {X} ≈ σ⇒ ∘ (id ⊗₁ σ⇒)
+mirrorʳ = begin
+  σ⇒ ⊗₁ id ∘ σ⇐         ≈⟨ refl⟩∘⟨ braiding-selfInverse ⟩
+  σ⇒ ⊗₁ id ∘ σ⇒         ≈˘⟨ σ⇒-comm ⟩
+  σ⇒ ∘ id ⊗₁ σ⇒         ∎
+
+cup-swap : ∀ {A X} {cup : unit ⇒ X} →
+  (id {A} ⊗₁ cup) ∘ ρ⇐ ≈ σ⇐ ∘ (cup ⊗₁ id) ∘ λ⇐
+cup-swap {cup = cup} = begin
+  id ⊗₁ cup ∘ ρ⇐       ≈⟨ refl⟩∘⟨ ⟺ braiding-coherence-inv ⟩
+  id ⊗₁ cup ∘ σ⇐ ∘ λ⇐  ≈⟨ extendʳ (⟺ σ⇐-comm) ⟩
+  σ⇐ ∘ cup ⊗₁ id ∘ λ⇐  ∎
+
+middle-braid : ∀ {Y A Z} →
+  (α⇒ {Y} {A} {Z} ∘ (σ⇒ ⊗₁ id) ∘ α⇐) ∘ σ⇐
+  ≈ (id ⊗₁ σ⇒) ∘ α⇒
+middle-braid = begin
+  (α⇒ ∘ (σ⇒ ⊗₁ id) ∘ α⇐) ∘ σ⇐                             ≈⟨ introˡ (_≅_.isoˡ (idᵢ ⊗ᵢ braided-iso)) ⟩
+  ((id ⊗₁ σ⇒) ∘ (id ⊗₁ σ⇒)) ∘ (α⇒ ∘ σ⇒ ⊗₁ id ∘ α⇐) ∘ σ⇐   ≈⟨ refl⟩∘⟨ assoc²βγ ⟩
+  ((id ⊗₁ σ⇒) ∘ (id ⊗₁ σ⇒)) ∘ (α⇒ ∘ σ⇒ ⊗₁ id) ∘ α⇐ ∘ σ⇐   ≈⟨ extend² hexagon₁ ⟩
+  ((id ⊗₁ σ⇒) ∘ α⇒) ∘ (σ⇒ ∘ α⇒) ∘ (α⇐ ∘ σ⇐)               ≈⟨ refl⟩∘⟨ cancelInner associator.isoʳ ⟩
+  ((id ⊗₁ σ⇒) ∘ α⇒) ∘ σ⇒ ∘ σ⇐                             ≈⟨ elimʳ (braiding.iso.isoʳ _) ⟩
+  (id ⊗₁ σ⇒) ∘ α⇒                                         ∎
 
 -- The opposite monoidal category is symmetric
 

--- a/src/Categories/Category/Monoidal/Traced/Properties.agda
+++ b/src/Categories/Category/Monoidal/Traced/Properties.agda
@@ -1,0 +1,133 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Consequences of the trace in a traced monoidal category:
+--   * the trace commutes with the left and right scalar actions, and those two
+--     actions agree on it (scalars are central);
+--   * the trace of an endomorphism `f : X ⇒ X`, closed up with the unitors, is a
+--     scalar, and the trace of `id {X}` is the dimension of `X`;
+--   * the trace transports to the opposite monoidal category.
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Category.Monoidal.Traced using (Traced)
+
+module Categories.Category.Monoidal.Traced.Properties
+    {o ℓ e} {C : Category o ℓ e} {M : Monoidal C} (T : Traced M) where
+
+open Category C
+  using (Obj; _⇒_; _≈_; id; _∘_; assoc; identityˡ; identityʳ)
+open Traced T
+
+open import Categories.Category.Monoidal.Scalars M
+  using ( Scalar; _·ₛ_; idₛ; _·ˡ_; _·ʳ_; ·ˡ-resp-≈; ·ˡ-∘
+        ; id-·ˡ; id-·ʳ )
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Morphism.Reasoning C
+open import Categories.Category.Monoidal.Reassociation M
+  using (λ⇒-assoc; λ⇐-assoc; α⇐-⊗id-commute)
+open import Categories.Category.Monoidal.Properties M using (monoidal-Op)
+open import Categories.Category.Monoidal.Braided.Properties braided using (scalar-central)
+open import Categories.Category.Monoidal.Symmetric.Properties symmetric
+  using (symmetric-Op; braiding-selfInverse)
+import Categories.Category.Monoidal.Utilities M as MonUtil
+open MonUtil.Shorthands
+
+private
+  variable
+    A B X Y : Obj
+    s : Scalar
+    f : A ⇒ B
+    ff : A ⊗₀ X ⇒ B ⊗₀ X
+
+------------------------------------------------------------------------------
+-- Scalar actions and the trace.
+
+private abstract
+  -- The left action is post-composition by the endomorphism `s ·ˡ id`: it is a
+  -- monoid action, so it splits `s ·ˡ f` as `(s ·ₛ idₛ) ·ˡ (id ∘ f)`.
+  ·ˡ-natural : s ·ˡ f ≈ (s ·ˡ id) ∘ f
+  ·ˡ-natural {s = s} {f = f} = begin
+    s ·ˡ f                   ≈⟨ ·ˡ-resp-≈ (⟺ identityʳ) (⟺ identityˡ) ⟩
+    (s ·ₛ idₛ) ·ˡ (id ∘ f)   ≈⟨ ·ˡ-∘ ⟩
+    (s ·ˡ id) ∘ (idₛ ·ˡ f)   ≈⟨ refl⟩∘⟨ id-·ˡ ⟩
+    (s ·ˡ id) ∘ f            ∎
+
+  -- Conjugating a left whisker by the associator pushes it one factor down.
+  α-conjugate : {g : A ⇒ B} → α⇐ ∘ (g ⊗₁ id {X ⊗₀ Y}) ∘ α⇒ ≈ (g ⊗₁ id) ⊗₁ id
+  α-conjugate = pullˡ α⇐-⊗id-commute ○ cancelʳ associator.isoˡ
+
+  -- The left action on `id` over a tensor only touches the left factor: split
+  -- both unitors off the associator, conjugate the scalar's whisker down onto
+  -- the left factor, then merge the whiskers back together.
+  ·ˡ-id⊗ : s ·ˡ id {A ⊗₀ X} ≈ (s ·ˡ id) ⊗₁ id
+  ·ˡ-id⊗ {s = s} = begin
+    λ⇒ ∘ (s ⊗₁ id) ∘ λ⇐                              ≈˘⟨ λ⇒-assoc ⟩∘⟨ refl⟩∘⟨ λ⇐-assoc ⟩
+    ((λ⇒ ⊗₁ id) ∘ α⇐) ∘ (s ⊗₁ id) ∘ α⇒ ∘ (λ⇐ ⊗₁ id)  ≈⟨ pullʳ assoc²εβ ⟩
+    (λ⇒ ⊗₁ id) ∘ (α⇐ ∘ (s ⊗₁ id) ∘ α⇒) ∘ (λ⇐ ⊗₁ id)  ≈⟨ refl⟩∘⟨ α-conjugate ⟩∘⟨refl ⟩
+    (λ⇒ ⊗₁ id) ∘ ((s ⊗₁ id) ⊗₁ id) ∘ (λ⇐ ⊗₁ id)      ≈⟨ merge₁³ ⟩
+    (λ⇒ ∘ (s ⊗₁ id) ∘ λ⇐) ⊗₁ id                      ∎
+
+-- Pull a left scalar out of the trace: the scalar rides the free wire.
+trace-resp-scalarˡ : trace (s ·ˡ ff) ≈ s ·ˡ trace ff
+trace-resp-scalarˡ {s = s} {ff = ff} = begin
+  trace (s ·ˡ ff)                ≈⟨ trace⟨ ·ˡ-natural ⟩ ⟩
+  trace ((s ·ˡ id) ∘ ff)         ≈⟨ trace⟨ ·ˡ-id⊗ ⟩∘⟨refl ⟩ ⟩
+  trace (((s ·ˡ id) ⊗₁ id) ∘ ff) ≈⟨ tightenₗ ⟩
+  (s ·ˡ id) ∘ trace ff           ≈˘⟨ ·ˡ-natural ⟩
+  s ·ˡ trace ff                  ∎
+
+trace-scalar-idˡ : trace (idₛ ·ˡ ff) ≈ trace ff
+trace-scalar-idˡ = trace-resp-≈ id-·ˡ
+
+-- Pull a right scalar out of the trace, by reducing to the left case.
+-- (`scalar-central : f ·ʳ s ≈ s ·ˡ f`, that the two actions agree, comes from
+-- `Braided.Properties`.)
+trace-resp-scalarʳ : trace (ff ·ʳ s) ≈ trace ff ·ʳ s
+trace-resp-scalarʳ {ff = ff} {s = s} = begin
+  trace (ff ·ʳ s)  ≈⟨ trace⟨ scalar-central ⟩ ⟩
+  trace (s ·ˡ ff)  ≈⟨ trace-resp-scalarˡ ⟩
+  s ·ˡ trace ff    ≈˘⟨ scalar-central ⟩
+  trace ff ·ʳ s    ∎
+
+trace-scalar-idʳ : trace (ff ·ʳ idₛ) ≈ trace ff
+trace-scalar-idʳ = trace-resp-≈ id-·ʳ
+
+------------------------------------------------------------------------------
+-- The trace of an endomorphism is a scalar: close `f : X ⇒ X` up with the unitors
+-- into `unit ⊗₀ X ⇒ unit ⊗₀ X` and trace out `X`.  No wire enters or leaves the
+-- loop, so what remains is an endomorphism of the unit — a scalar
+--
+--         ╭──── X ────╮
+--         │           │
+--      ┌──┴──┐        │
+--      │  f  │        │
+--      └──┬──┘        │
+--         │           │
+--         ╰──── X ────╯
+
+trace-endo : X ⇒ X → Scalar
+trace-endo f = trace (λ⇐ ∘ f ∘ λ⇒)
+
+-- The (categorical) dimension of an object, also called the Euler characteristic,
+-- is the trace of its identity. See https://ncatlab.org/nlab/show/trace.
+-- If the category is a matrix category over a commutative ring, this coincides with
+-- tr(Iₙ) = n, the usual dimension of a vector space/free module.
+
+trace-dim : Obj → Scalar
+trace-dim X = trace-endo (id {X})
+
+-- The trace transports to the opposite monoidal category.
+
+traced-Op : Traced monoidal-Op
+traced-Op = record
+  { symmetric    = symmetric-Op
+  ; trace        = trace
+  ; trace-resp-≈ = trace-resp-≈
+  ; slide        = ⟺ slide
+  ; tightenₗ     = tightenᵣ
+  ; tightenᵣ     = tightenₗ
+  ; vanishing₁   = vanishing₁
+  ; vanishing₂   = trace⟨ trace⟨ assoc ⟩ ⟩ ○ vanishing₂
+  ; superposing  = trace⟨ assoc ⟩ ○ superposing
+  ; yanking      = trace⟨ braiding-selfInverse ⟩ ○ yanking
+  }

--- a/src/Categories/Category/Monoidal/Utilities.agda
+++ b/src/Categories/Category/Monoidal/Utilities.agda
@@ -131,6 +131,9 @@ triangle-iso = ⌞ triangle ⌟
 triangle-inv : α⇐ ∘ id ⊗₁ λ⇐ ≈ ρ⇐ {X} ⊗₁ id {Y}
 triangle-inv = to-≈ triangle-iso
 
+triangle-inv′ : α⇒ {X} {unit} {Y} ∘ (ρ⇐ ⊗₁ id) ≈ id ⊗₁ λ⇐
+triangle-inv′ = Equiv.sym (switch-tofromˡ associator triangle-inv)
+
 pentagon-iso :
      idᵢ ⊗ᵢ associator ∘ᵢ associator ∘ᵢ associator {X} {Y} {Z} ⊗ᵢ idᵢ {W}
   ≈ᵢ associator ∘ᵢ associator

--- a/src/Categories/Morphism/Reasoning/Core.agda
+++ b/src/Categories/Morphism/Reasoning/Core.agda
@@ -7,6 +7,7 @@ open import Categories.Category
 
   Identity : reasoning about identity
   Assoc4   : associativity combinators for composites of 4 morphisms
+  AssocN   : reassociate the tail of longer composites
   Pulls  : use a ∘ b ≈ c as left-to-right rewrite
   Pushes : use c ≈ a ∘ b as a left-to-right rewrite
   IntroElim : introduce/eliminate an equivalent-to-id arrow
@@ -129,6 +130,22 @@ module Pushes (c≡ab : c ≈ a ∘ b) where
     a ∘ (b ∘ f) ∎
 
 open Pushes public
+
+module AssocN where
+  private
+    variable
+      A B D E U W Z : Obj
+
+  reassoc-tail₅ : {f : Z ⇒ U} {g : E ⇒ Z} {h : D ⇒ E} {i : B ⇒ D} {j : A ⇒ B} →
+    f ∘ g ∘ h ∘ i ∘ j ≈ (f ∘ g ∘ h ∘ i) ∘ j
+  reassoc-tail₅ = pushʳ assoc²εβ
+
+  reassoc-tail₆ : {f : Z ⇒ U} {g : E ⇒ Z} {h : D ⇒ E} {i : W ⇒ D}
+    {j : B ⇒ W} {k : A ⇒ B} →
+    f ∘ g ∘ h ∘ i ∘ j ∘ k ≈ (f ∘ g ∘ h ∘ i ∘ j) ∘ k
+  reassoc-tail₆ = pushʳ reassoc-tail₅
+
+open AssocN public
 
 -- Introduce/Elimilate an equivalent-to-identity
 -- on left, right or 'in the middle' of something existing


### PR DESCRIPTION
## Summary

Extend the generic monoidal infrastructure used by rigid and traced category
developments.

This adds:

- reusable long-composite and three-factor tensor reasoning laws
- a dedicated `Monoidal.CupCap` module for cup/cap opening, closing, bending,
  nesting, naturality, and reassociation
- reverse monoidal, braided, and symmetric constructions
- supporting braided, symmetric, scalar, and traced properties

## Motivation

The dual calculus in #538 needs several constructions that depend only on the
underlying monoidal structure. Keeping them in a prerequisite PR makes those
lemmas independently reusable and leaves the rigid-category PR focused on its
mathematical subject.

In particular, `Monoidal.CupCap` separates cup/cap-specific calculations from
the structural associator, unitor, whiskering, and pentagon laws in
`Monoidal.Reassociation`. The new reasoning combinators provide concise names
for recurring reassociation and tensor-splitting steps, while the reverse and
braiding constructions support dualization into the reversed opposite
category.
