### PR TITLE
Package monoidal dualization and compact closure

### DIFF
--- a/src/Categories/Category/Monoidal/CompactClosed.agda
+++ b/src/Categories/Category/Monoidal/CompactClosed.agda
@@ -12,6 +12,7 @@ open import Level
 open import Categories.Functor.Bifunctor
 open import Categories.NaturalTransformation.NaturalIsomorphism
 open import Categories.Category.Monoidal.Rigid
+import Categories.Category.Monoidal.Rigid.Symmetry as RigidSymmetry
 
 open Category C
 open Commutation C
@@ -20,3 +21,12 @@ record CompactClosed : Set (levelOfTerm M) where
   field
     symmetric : Symmetric M
     rigid     : LeftRigid M ⊎ RightRigid M
+
+  -- Either handedness of rigidity gives the other, since the braiding turns a
+  -- left dual into a right one and vice versa.
+
+  leftRigid : LeftRigid M
+  leftRigid = [ (λ L → L) , RigidSymmetry.right⇒left M symmetric ]′ rigid
+
+  rightRigid : RightRigid M
+  rightRigid = [ RigidSymmetry.left⇒right M symmetric , (λ R → R) ]′ rigid

--- a/src/Categories/Category/Monoidal/CompactClosed/Properties.agda
+++ b/src/Categories/Category/Monoidal/CompactClosed/Properties.agda
@@ -1,0 +1,50 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+-- --lossy-unification makes this typecheck in ~3s instead of ~25s
+
+-- Compact closure transfers to the opposite monoidal category, and dualization
+-- gives a strong symmetric monoidal equivalence with the opposite category.
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Equivalence using (StrongEquivalence)
+open import Categories.Category.Monoidal.Bundle using (SymmetricMonoidalCategory)
+open import Categories.Category.Monoidal.CompactClosed using (CompactClosed)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+import Categories.Category.Monoidal.Rigid.Functor.Symmetric as RigidFunctor
+import Categories.Functor.Monoidal.Symmetric as SymmetricFunctor
+
+module Categories.Category.Monoidal.CompactClosed.Properties
+    {o ℓ e} {C : Category o ℓ e} {M : Monoidal C} (K : CompactClosed M) where
+
+open import Data.Sum using (inj₁)
+
+open import Categories.Category.Monoidal.Properties M using (monoidal-Op)
+open import Categories.Category.Monoidal.Rigid.Properties M using (rigidʳ-Op)
+open import Categories.Category.Monoidal.Symmetric.Properties using (symmetric-Op)
+import Categories.Category.Monoidal.CompactClosed monoidal-Op as OpCompactClosed
+
+open CompactClosed K using (symmetric; leftRigid; rightRigid; rigid)
+open import Categories.Category.Monoidal.Rigid.Dual M leftRigid using (dualFunctor)
+open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
+open import Categories.NaturalTransformation.NaturalIsomorphism using (_≃_)
+
+symmetricMonoidalCategory : SymmetricMonoidalCategory o ℓ e
+symmetricMonoidalCategory = record { symmetric = symmetric }
+
+compactClosed-Op : OpCompactClosed.CompactClosed
+compactClosed-Op = record
+  { symmetric = symmetric-Op symmetric
+  ; rigid     = inj₁ (rigidʳ-Op rightRigid)
+  }
+
+dual²≃id : Functor.op dualFunctor ∘F dualFunctor ≃ idF
+dual²≃id = RigidFunctor.DoubleDualˡ.double-dual≃id M symmetric leftRigid
+
+dual-equivalence : StrongEquivalence C (Category.op C)
+dual-equivalence = RigidFunctor.dual-equivalence M symmetric rigid
+
+dual-StrongSymmetricMonoidalFunctor :
+  SymmetricFunctor.Strong.SymmetricMonoidalFunctor
+    symmetricMonoidalCategory
+    (SymmetricMonoidalCategory.op symmetricMonoidalCategory)
+dual-StrongSymmetricMonoidalFunctor =
+  RigidFunctor.dual-StrongSymmetricMonoidalFunctor M symmetric rigid

--- a/src/Categories/Category/Monoidal/Rigid.agda
+++ b/src/Categories/Category/Monoidal/Rigid.agda
@@ -15,7 +15,7 @@ open Commutation C
 
 private
   variable
-    X : Obj
+    X Y : Obj
 
 -- left rigid monoidal category
 record LeftRigid : Set (levelOfTerm M) where
@@ -43,6 +43,11 @@ record LeftRigid : Set (levelOfTerm M) where
              ≈ id
              ⟩
 
+  -- The dual of a morphism: f : X ⇒ Y bent around into its mate Y ⁻¹ ⇒ X ⁻¹.
+  dual₁ : X ⇒ Y → Y ⁻¹ ⇒ X ⁻¹
+  dual₁ f = unitorˡ.from ∘ (ε ⊗₁ id) ∘ associator.to
+              ∘ (id ⊗₁ ((f ⊗₁ id) ∘ η)) ∘ unitorʳ.to
+
 -- right rigid monoidal category
 record RightRigid : Set (levelOfTerm M) where
   open Monoidal M public
@@ -68,3 +73,8 @@ record RightRigid : Set (levelOfTerm M) where
                unitorʳ.from
              ≈ id
              ⟩
+
+  -- The dual of a morphism: f : X ⇒ Y bent around into its mate Y ⁻¹ ⇒ X ⁻¹.
+  dual₁ : X ⇒ Y → Y ⁻¹ ⇒ X ⁻¹
+  dual₁ f = unitorʳ.from ∘ (id ⊗₁ ε) ∘ (id ⊗₁ (f ⊗₁ id))
+              ∘ associator.from ∘ (η ⊗₁ id) ∘ unitorˡ.to

--- a/src/Categories/Category/Monoidal/Rigid/Dual.agda
+++ b/src/Categories/Category/Monoidal/Rigid/Dual.agda
@@ -1,0 +1,413 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Transpose (mate) operations for a left rigid monoidal category:
+-- turning cups `unit ⇒ X ⊗₀ Z` and caps `W ⊗₀ X ⇒ unit` into maps out of / into
+-- the dual `X ⁻¹` (`cupᵀ`, `capᵀ`, `dual₁`), with their snake and cancellation laws.
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Category.Monoidal.Rigid using (LeftRigid)
+open import Categories.Functor using (Functor)
+
+module Categories.Category.Monoidal.Rigid.Dual
+    {o ℓ e} {C : Category o ℓ e}
+    (M : Monoidal C) (L : LeftRigid M) where
+
+open Category C
+  using (Obj; _⇒_; _≈_; id; _∘_; assoc; sym-assoc; identityˡ; identityʳ)
+open LeftRigid L
+
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Morphism.Reasoning C
+open import Categories.Morphism C using (_≅_)
+open import Categories.Category.Monoidal.Utilities M
+  using (module Shorthands; triangle-inv′)
+open import Categories.Category.Monoidal.Properties M
+  using (coherence₁; coherence-inv₁; coherence₃)
+open import Categories.Category.Monoidal.Reassociation M
+  using (α⇐-⊗id-commute; assoc-from-coherence; whisker-comm)
+open import Categories.Category.Monoidal.CupCap M
+
+open Shorthands
+
+private
+  variable
+    W X Y Z : Obj
+    f : X ⇒ Y
+
+-- Diagrams read bottom-to-top.  Duality bends a wire: `η` grows a `Y`/`Y ⁻¹` pair
+-- out of nothing, `ε` swallows an `X ⁻¹`/`X` pair back into it.  `cupˡ` and `capˡ`
+-- are those two bends with a spectator wire alongside.
+--
+--                cupˡ                                capˡ
+--
+--     Y       Y ⁻¹      X                                        Y
+--     │         │       │                                        │
+--     │         │       │                 ╭───────────╮          │
+--     ╰─────────╯       │      ← η        │           │          │      ← ε
+--                       │                 │           │          │
+--                       X               X ⁻¹          X          Y
+
+cupˡ : X ⇒ Y ⊗₀ (Y ⁻¹ ⊗₀ X)
+cupˡ = cup-bendˡ η
+
+capˡ : X ⁻¹ ⊗₀ (X ⊗₀ Y) ⇒ Y
+capˡ = cap-bendˡ ε
+
+private
+  transposeˡ : Z ⊗₀ X ⇒ unit → unit ⇒ X ⊗₀ W → Z ⇒ W
+  transposeˡ cap cup = cap-bendˡ cap ∘ cup-openʳ cup
+
+  snake-whiskered : {cup : unit ⇒ X ⊗₀ Z} {cap : Z ⊗₀ X ⇒ unit} →
+    ρ⇒ ∘ (id ⊗₁ cap) ∘ α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐ ≈ id →
+    (cap-bendʳ cap ⊗₁ id {W}) ∘ α⇐ ∘ cup-openˡ cup ≈ id
+  snake-whiskered {cup = cup} {cap} snake = begin
+    snakeᵗ ∘ α⇐ ∘ cup-openˡ cup                         ≈⟨ refl⟩∘⟨ pullˡ α⇐-⊗id-commute ⟩
+    snakeᵗ ∘ ((((cup ⊗₁ id) ⊗₁ id) ∘ α⇐) ∘ λ⇐)          ≈⟨ refl⟩∘⟨ pullʳ coherence-inv₁ ⟩
+    snakeᵗ ∘ (((cup ⊗₁ id) ⊗₁ id) ∘ (λ⇐ ⊗₁ id))         ≈⟨ refl⟩∘⟨ merge₁ˡ ⟩
+    snakeᵗ ∘ (cup-openˡ cup ⊗₁ id)                      ≈⟨ merge₁ˡ ⟩
+    (cap-bendʳ cap ∘ cup-openˡ cup) ⊗₁ id               ≈⟨ assoc²αε ⟩⊗⟨refl ⟩
+    (ρ⇒ ∘ (id ⊗₁ cap) ∘ α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐) ⊗₁ id    ≈⟨ snake ⟩⊗⟨refl ⟩
+    id ⊗₁ id                                            ≈⟨ ⊗.identity ⟩
+    id                                                  ∎
+    where snakeᵗ = cap-bendʳ cap ⊗₁ id
+
+  transposeˡ-cup-cancel : {cup : unit ⇒ X ⊗₀ Z} {cap : Z ⊗₀ X ⇒ unit} {cup′ : unit ⇒ X ⊗₀ W} →
+    ρ⇒ ∘ (id ⊗₁ cap) ∘ α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐ ≈ id →
+    (id ⊗₁ transposeˡ cap cup′) ∘ cup ≈ cup′
+  transposeˡ-cup-cancel {cup = cup} {cap} {cup′} snake = begin
+    (id ⊗₁ transposeˡ cap cup′) ∘ cup                       ≈⟨ pushˡ split₂ˡ ⟩
+    (id ⊗₁ cap-bendˡ cap) ∘ ((id ⊗₁ cup-openʳ cup′) ∘ cup)  ≈⟨ refl⟩∘⟨ parallel-cups-commute ⟩
+    (id ⊗₁ cap-bendˡ cap) ∘ (α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐ ∘ cup′)  ≈⟨ pullˡ cap-reassoc ⟩
+    (snakeᵗ ∘ α⇐) ∘ ((cup ⊗₁ id) ∘ λ⇐ ∘ cup′)               ≈⟨ assoc ⟩
+    snakeᵗ ∘ α⇐ ∘ (cup ⊗₁ id) ∘ λ⇐ ∘ cup′                   ≈⟨ reassoc-tail₅ ⟩
+    (snakeᵗ ∘ α⇐ ∘ cup-openˡ cup) ∘ cup′                    ≈⟨ elimˡ (snake-whiskered snake) ⟩
+    cup′                                                    ∎
+    where snakeᵗ = cap-bendʳ cap ⊗₁ id
+
+  -- The left unitor's square against `ε`, with the |coherence₁| triangle glued on.
+  ε-λ : ε {X} ∘ (λ⇒ ⊗₁ id) ≈ λ⇒ ∘ (id ⊗₁ ε) ∘ α⇒
+  ε-λ = ⟺ (glue◽◃ unitorˡ-commute-from coherence₁)
+
+  ε-mergeʳ : {cap : W ⊗₀ X ⇒ unit} → (id ⊗₁ ε {X}) ∘ (cap ⊗₁ (id ⊗₁ id)) ≈ cap ⊗₁ ε
+  ε-mergeʳ {cap = cap} = begin
+    (id ⊗₁ ε) ∘ (cap ⊗₁ (id ⊗₁ id))   ≈˘⟨ ⊗-distrib-over-∘ ⟩
+    (id ∘ cap) ⊗₁ (ε ∘ (id ⊗₁ id))    ≈⟨ identityˡ ⟩⊗⟨ elimʳ ⊗.identity ⟩
+    cap ⊗₁ ε                          ∎
+
+  -- `cap` and `ε` land side by side in `unit ⊗₀ unit`; `cap` is the outer one, so
+  -- the unitor lets it out in front and leaves `ε` closing against its own wire.
+  λ-cap-ε : {cap : W ⊗₀ X ⇒ unit} → λ⇒ ∘ (cap ⊗₁ ε {X}) ≈ cap ∘ cap-closeʳ ε
+  λ-cap-ε {cap = cap} = begin
+    λ⇒ ∘ (cap ⊗₁ ε)                 ≈⟨ pushʳ serialize₁₂ ⟩
+    (λ⇒ ∘ (cap ⊗₁ id)) ∘ (id ⊗₁ ε)  ≈⟨ (coherence₃ ⟩∘⟨refl) ⟩∘⟨refl ⟩
+    (ρ⇒ ∘ (cap ⊗₁ id)) ∘ (id ⊗₁ ε)  ≈⟨ unitorʳ-commute-from ⟩∘⟨refl ⟩
+    (cap ∘ ρ⇒) ∘ (id ⊗₁ ε)          ≈⟨ assoc ⟩
+    cap ∘ cap-closeʳ ε              ∎
+
+  -- `transposeˡ cap η` splits at `α⇐` into a head, `λ⇒ ∘ (cap ⊗₁ id) ∘ α⇐`, and a
+  -- tail, `cup-openʳ η`.  Whisker the head by `X` and close it with `ε`: the counit
+  -- walks left past the associators to meet the cup the tail will plant, and `cap`
+  -- drops out in front.  What is left behind it is the snake's cap-half, with `W`
+  -- watching.
+  ε-against-bendˡ : {cap : W ⊗₀ X ⇒ unit} →
+    ε ∘ (cap-bendˡ cap ⊗₁ id)
+    ≈ cap ∘ (id ⊗₁ cap-bendʳ ε) ∘ α⇒
+  ε-against-bendˡ {cap = cap} = begin
+    ε ∘ (((λ⇒ ∘ (cap ⊗₁ id)) ∘ α⇐) ⊗₁ id)                     ≈⟨ refl⟩∘⟨ (assoc ⟩⊗⟨refl) ⟩
+    ε ∘ ((λ⇒ ∘ (cap ⊗₁ id) ∘ α⇐) ⊗₁ id)                       ≈⟨ refl⟩∘⟨ split₁³ ⟩
+    ε ∘ (λ⇒ ⊗₁ id) ∘ ((cap ⊗₁ id) ⊗₁ id) ∘ (α⇐ ⊗₁ id)         ≈⟨ pullˡ ε-λ ⟩
+    (λ⇒ ∘ (id ⊗₁ ε) ∘ α⇒) ∘ ((cap ⊗₁ id) ⊗₁ id) ∘ (α⇐ ⊗₁ id)  ≈⟨ assoc²βε ⟩
+    λ⇒ ∘ (id ⊗₁ ε) ∘ α⇒ ∘ ((cap ⊗₁ id) ⊗₁ id) ∘ (α⇐ ⊗₁ id)
+      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ extendʳ assoc-commute-from ⟩
+    λ⇒ ∘ (id ⊗₁ ε) ∘ (cap ⊗₁ (id ⊗₁ id)) ∘ α⇒ ∘ (α⇐ ⊗₁ id)    ≈⟨ refl⟩∘⟨ pullˡ ε-mergeʳ ⟩
+    λ⇒ ∘ (cap ⊗₁ ε) ∘ α⇒ ∘ (α⇐ ⊗₁ id)                         ≈⟨ pullˡ λ-cap-ε ⟩
+    (cap ∘ cap-closeʳ ε) ∘ α⇒ ∘ (α⇐ ⊗₁ id)                    ≈⟨ pullʳ cap-closeʳ-pentagon ⟩
+    cap ∘ (id ⊗₁ cap-bendʳ ε) ∘ α⇒                            ∎
+
+  -- Head and tail, glued: the associator hands the tail's cup to the head's cap
+  -- (`cup-openʳ-whisker`), the two halves merge under the `W`-whisker, and the
+  -- snake straightens them out, leaving `cap` alone.
+  transposeˡ-cap-cancel : {cap : W ⊗₀ X ⇒ unit} → ε ∘ (transposeˡ cap η ⊗₁ id) ≈ cap
+  transposeˡ-cap-cancel {cap = cap} = begin
+    ε ∘ (transposeˡ cap η ⊗₁ id)                          ≈⟨ refl⟩∘⟨ split₁ˡ ⟩
+    ε ∘ (cap-bendˡ cap ⊗₁ id) ∘ (cup-openʳ η ⊗₁ id)       ≈⟨ pullˡ ε-against-bendˡ ⟩
+    (cap ∘ (id ⊗₁ snake-cap) ∘ α⇒) ∘ (cup-openʳ η ⊗₁ id)  ≈⟨ assoc²βε ⟩
+    cap ∘ (id ⊗₁ snake-cap) ∘ α⇒ ∘ (cup-openʳ η ⊗₁ id)    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cup-openʳ-whisker ⟩
+    cap ∘ (id ⊗₁ snake-cap) ∘ (id ⊗₁ cup-openˡ η)         ≈⟨ refl⟩∘⟨ merge₂ˡ ⟩
+    cap ∘ (id ⊗₁ (snake-cap ∘ cup-openˡ η))               ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ snake ⟩
+    cap ∘ (id ⊗₁ id)                                      ≈⟨ elimʳ ⊗.identity ⟩
+    cap                                                   ∎
+    where
+      snake-cap = cap-bendʳ ε
+      snake = assoc²αε ○ snake₁
+
+  dual₁-as-cup-transpose : dual₁ f ≈ transposeˡ ε ((f ⊗₁ id) ∘ η)
+  dual₁-as-cup-transpose = assoc²εα
+
+  dual₁-as-cap-transpose : dual₁ f ≈ transposeˡ (ε ∘ (id ⊗₁ f)) η
+  dual₁-as-cap-transpose {f = f} = begin
+    dual₁ f                                             ≈⟨ dual₁-as-cup-transpose ⟩
+    transposeˡ ε ((f ⊗₁ id) ∘ η)                       ≈˘⟨ refl⟩∘⟨ cup-openʳ-∘ η ⟩
+    cap-bendˡ ε ∘ (id ⊗₁ (f ⊗₁ id)) ∘ cup-openʳ η      ≈⟨ pullˡ (cap-bendˡ-⊗ ε) ⟩
+    transposeˡ (ε ∘ (id ⊗₁ f)) η                       ∎
+
+-- `dual₁ f : Y ⁻¹ ⇒ X ⁻¹` is `f` bent around: grow an `X`/`X ⁻¹` pair, run `f` on
+-- the `X` leg, and close the resulting `Y` against the incoming `Y ⁻¹`.  Reading
+-- the two laws below off the picture: sliding `dual₁ f` along the cup (`dual₁-cup`)
+-- or the cap (`dual₁-cap`) is the same as sliding `f` the other way.
+--
+--                              X ⁻¹
+--                               │
+--         ╭───────────────╮     │
+--         │               │     │        ← ε closes Y ⁻¹ against Y
+--         │            ┌──┴──┐  │
+--         │            │  f  │  │
+--         │            └──┬──┘  │
+--         │               │     │
+--         │               ╰─────╯        ← η grows X / X ⁻¹
+--         │
+--        Y ⁻¹
+
+dual₁-cup : (id ⊗₁ dual₁ f) ∘ η ≈ (f ⊗₁ id) ∘ η
+dual₁-cup {f = f} = begin
+  (id ⊗₁ dual₁ f) ∘ η                         ≈⟨ refl⟩⊗⟨ dual₁-as-cup-transpose ⟩∘⟨refl ⟩
+  (id ⊗₁ transposeˡ ε ((f ⊗₁ id) ∘ η)) ∘ η    ≈⟨ transposeˡ-cup-cancel snake₁ ⟩
+  (f ⊗₁ id) ∘ η                               ∎
+
+dual₁-cap : ε ∘ (dual₁ f ⊗₁ id) ≈ ε ∘ (id ⊗₁ f)
+dual₁-cap {f = f} = begin
+  ε ∘ (dual₁ f ⊗₁ id)                       ≈⟨ refl⟩∘⟨ dual₁-as-cap-transpose ⟩⊗⟨refl ⟩
+  ε ∘ (transposeˡ (ε ∘ (id ⊗₁ f)) η ⊗₁ id)  ≈⟨ transposeˡ-cap-cancel ⟩
+  ε ∘ (id ⊗₁ f)                             ∎
+
+cupᵀ : unit ⇒ X ⊗₀ Z → X ⁻¹ ⇒ Z
+cupᵀ cup = transposeˡ ε cup
+
+-- Both snake identities survive whiskering by a spectator wire `W`: running the
+-- `X`- (resp. `X ⁻¹`-) loop alongside an untouched `W` is still the identity.
+-- The snake is the zig-zag pulled straight — bend the wire out with `η`, back in
+-- with `ε`, and nothing has happened.
+--
+--         X                                          X
+--         │                                          │
+--         │      ╭──────────────╮                    │
+--         │      │              │   ← ε              │
+--         ╰──────╯              │           =        │
+--            ↑ η                │                    │
+--                               │                    │
+--                               X                    X
+--
+--     ρ⇒ ∘ (id ⊗₁ ε) ∘ α⇒ ∘ (η ⊗₁ id) ∘ λ⇐   ≈   id          (`snake₁`)
+
+private
+  snake₂-whiskered : ((λ⇒ ⊗₁ id {W}) ∘ ((ε {X} ⊗₁ id) ⊗₁ id))
+      ∘ (α⇐ ⊗₁ id) ∘ ((id ⊗₁ η) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id) ≈ id
+  snake₂-whiskered = begin
+    ((λ⇒ ⊗₁ id) ∘ ((ε ⊗₁ id) ⊗₁ id)) ∘ (α⇐ ⊗₁ id) ∘ ((id ⊗₁ η) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id)
+      ≈˘⟨ split₁ˡ ⟩∘⟨ split₁³ ⟩
+    ((λ⇒ ∘ (ε ⊗₁ id)) ⊗₁ id) ∘ ((α⇐ ∘ (id ⊗₁ η) ∘ ρ⇐) ⊗₁ id)  ≈⟨ merge₁ˡ ⟩
+    ((λ⇒ ∘ (ε ⊗₁ id)) ∘ α⇐ ∘ (id ⊗₁ η) ∘ ρ⇐) ⊗₁ id            ≈⟨ assoc ⟩⊗⟨refl ⟩
+    (λ⇒ ∘ (ε ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ η) ∘ ρ⇐) ⊗₁ id              ≈⟨ snake₂ ⟩⊗⟨refl ⟩
+    id ⊗₁ id                                                  ≈⟨ ⊗.identity ⟩
+    id                                                        ∎
+
+cupˡ-expand : α⇐ {W} {X} {X ⁻¹ ⊗₀ Y} ∘ (id ⊗₁ cupˡ)
+              ≈ α⇒ ∘ (α⇐ ⊗₁ id) ∘ ((id ⊗₁ η) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id)
+cupˡ-expand = begin
+  α⇐ ∘ (id ⊗₁ cupˡ)                                     ≈⟨ refl⟩∘⟨ split₂³ ⟩
+  α⇐ ∘ (id ⊗₁ α⇒) ∘ (id ⊗₁ (η ⊗₁ id)) ∘ (id ⊗₁ λ⇐)      ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ triangle-inv′ ⟩
+  α⇐ ∘ (id ⊗₁ α⇒) ∘ (id ⊗₁ (η ⊗₁ id)) ∘ α⇒ ∘ (ρ⇐ ⊗₁ id)
+    ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ extendʳ assoc-commute-from ⟩
+  α⇐ ∘ (id ⊗₁ α⇒) ∘ α⇒ ∘ ((id ⊗₁ η) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id)   ≈⟨ assoc²εβ ⟩
+  (α⇐ ∘ (id ⊗₁ α⇒) ∘ α⇒) ∘ ((id ⊗₁ η) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id) ≈˘⟨ assoc-from-coherence ⟩∘⟨refl ⟩
+  (α⇒ ∘ (α⇐ ⊗₁ id)) ∘ ((id ⊗₁ η) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id)      ≈⟨ assoc ⟩
+  α⇒ ∘ (α⇐ ⊗₁ id) ∘ ((id ⊗₁ η) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id)        ∎
+
+private
+  -- `capˡ`'s head, rewhiskered: the counit and its unitor drop onto the left factor.
+  capˡ-head : λ⇒ ∘ (ε {X} ⊗₁ id {X ⁻¹ ⊗₀ W}) ∘ α⇒ ≈ (λ⇒ ⊗₁ id) ∘ ((ε ⊗₁ id) ⊗₁ id)
+  capˡ-head = begin
+    λ⇒ ∘ (ε ⊗₁ id) ∘ α⇒               ≈˘⟨ refl⟩∘⟨ (refl⟩⊗⟨ ⊗.identity) ⟩∘⟨refl ⟩
+    λ⇒ ∘ (ε ⊗₁ (id ⊗₁ id)) ∘ α⇒       ≈˘⟨ refl⟩∘⟨ assoc-commute-from ⟩
+    λ⇒ ∘ α⇒ ∘ ((ε ⊗₁ id) ⊗₁ id)       ≈⟨ pullˡ coherence₁ ⟩
+    (λ⇒ ⊗₁ id) ∘ ((ε ⊗₁ id) ⊗₁ id)    ∎
+
+-- `snake₁`/`snake₂` in `cupˡ`/`capˡ` vocabulary: bending a wire out with `cupˡ`
+-- and back in with `capˡ` straightens it, spectator wire and all. `snakeˡ-wire`
+-- straightens the wire `X` (with `Y` watching), `snakeˡ-dual` the dual wire `X ⁻¹`
+-- (with `W` watching) — the same zig-zag, entered from the other end.
+--
+--            snakeˡ-wire                          snakeˡ-dual
+--
+--      X               Y                   X ⁻¹              W
+--      │               │                     │               │
+--      │   ╭───────╮   │                     │   ╭───────╮   │
+--      │   │       │   │   ← capˡ (ε)        │   │       │   │   ← capˡ (ε)
+--      ╰───╯       │   │   ← cupˡ (η)        ╰───╯       │   │   ← cupˡ (η)
+--                  │   │                                 │   │
+--                  X   Y                              X ⁻¹   W
+--
+-- Read bottom-to-top: the incoming wire climbs the cap's right leg, the cap bends it
+-- into its partner, the cup bends it back, and it leaves on the left — a straight
+-- wire, drawn crooked.  The spectator never meets either bend.
+
+snakeˡ-wire : (id ⊗₁ capˡ {X} {Y}) ∘ cupˡ ≈ id
+snakeˡ-wire = begin
+  (id ⊗₁ capˡ) ∘ cupˡ                               ≈⟨ pullˡ cap-reassoc ⟩
+  ((cap-bendʳ ε ⊗₁ id) ∘ α⇐) ∘ cup-openˡ η          ≈⟨ assoc ⟩
+  (cap-bendʳ ε ⊗₁ id) ∘ α⇐ ∘ cup-openˡ η            ≈⟨ snake-whiskered snake₁ ⟩
+  id                                                ∎
+
+snakeˡ-dual : capˡ {X} {X ⁻¹ ⊗₀ W} ∘ (id ⊗₁ cupˡ) ≈ id
+snakeˡ-dual = begin
+  capˡ ∘ (id ⊗₁ cupˡ)                             ≈⟨ assoc²αε ⟩
+  λ⇒ ∘ (ε ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ cupˡ)              ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cupˡ-expand ⟩
+  λ⇒ ∘ (ε ⊗₁ id) ∘ α⇒ ∘ (α⇐ ⊗₁ id) ∘ ((id ⊗₁ η) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id)
+    ≈⟨ assoc²εβ ⟩
+  (λ⇒ ∘ (ε ⊗₁ id) ∘ α⇒) ∘ (α⇐ ⊗₁ id) ∘ ((id ⊗₁ η) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id)
+    ≈⟨ capˡ-head ⟩∘⟨refl ⟩
+  ((λ⇒ ⊗₁ id) ∘ ((ε ⊗₁ id) ⊗₁ id)) ∘ (α⇐ ⊗₁ id) ∘ ((id ⊗₁ η) ⊗₁ id) ∘ (ρ⇐ ⊗₁ id)
+    ≈⟨ snake₂-whiskered ⟩
+  id                                              ∎
+
+cupᵀ-η : (cup : unit ⇒ X ⊗₀ Z) → (id {X} ⊗₁ cupᵀ cup) ∘ η ≈ cup
+cupᵀ-η cup = transposeˡ-cup-cancel snake₁
+
+cupᵀ-resp-≈ : {cup cup′ : unit ⇒ X ⊗₀ Z} → cup ≈ cup′ → cupᵀ cup ≈ cupᵀ cup′
+cupᵀ-resp-≈ cup≈cup′ = refl⟩∘⟨ refl⟩⊗⟨ cup≈cup′ ⟩∘⟨refl
+
+cupᵀ-unbend : {f : X ⁻¹ ⇒ Z} → cupᵀ ((id ⊗₁ f) ∘ η) ≈ f
+cupᵀ-unbend {f = f} = begin
+  capˡ ∘ cup-openʳ ((id ⊗₁ f) ∘ η)        ≈˘⟨ refl⟩∘⟨ cup-openʳ-∘ η ⟩
+  capˡ ∘ (id ⊗₁ (id ⊗₁ f)) ∘ cup-openʳ η  ≈⟨ pullˡ (cap-bendˡ-commute ε) ⟩
+  (f ∘ capˡ) ∘ cup-openʳ η                 ≈⟨ pullʳ snake ⟩
+  f ∘ id                                  ≈⟨ identityʳ ⟩
+  f                                       ∎
+  where
+    snake : capˡ ∘ cup-openʳ η ≈ id
+    snake = assoc²αε ○ snake₂
+
+cupᵀ-unique : {f g : X ⁻¹ ⇒ Z} → (id ⊗₁ f) ∘ η ≈ (id ⊗₁ g) ∘ η → f ≈ g
+cupᵀ-unique f≈g = ⟺ cupᵀ-unbend ○ cupᵀ-resp-≈ f≈g ○ cupᵀ-unbend
+
+dual₁-identity : dual₁ (id {X}) ≈ id
+dual₁-identity = dual₁-as-cup-transpose ○ cupᵀ-unbend
+
+dual₁-resp-≈ : {f g : X ⇒ Y} → f ≈ g → dual₁ f ≈ dual₁ g
+dual₁-resp-≈ f≈g = dual₁-as-cup-transpose
+  ○ cupᵀ-resp-≈ (f≈g ⟩⊗⟨refl ⟩∘⟨refl) ○ ⟺ dual₁-as-cup-transpose
+
+private
+  dual₁-composite-cup : {f : X ⇒ Y} {g : Y ⇒ Z} →
+    (id ⊗₁ (dual₁ f ∘ dual₁ g)) ∘ η ≈ ((g ∘ f) ⊗₁ id) ∘ η
+  dual₁-composite-cup {f = f} {g} = begin
+    (id ⊗₁ (dual₁ f ∘ dual₁ g)) ∘ η             ≈⟨ pushˡ split₂ˡ ⟩
+    (id ⊗₁ dual₁ f) ∘ (id ⊗₁ dual₁ g) ∘ η       ≈⟨ refl⟩∘⟨ dual₁-cup ⟩
+    (id ⊗₁ dual₁ f) ∘ (g ⊗₁ id) ∘ η             ≈⟨ extendʳ (⟺ whisker-comm) ⟩
+    (g ⊗₁ id) ∘ (id ⊗₁ dual₁ f) ∘ η             ≈⟨ refl⟩∘⟨ dual₁-cup ⟩
+    (g ⊗₁ id) ∘ (f ⊗₁ id) ∘ η                   ≈⟨ pullˡ merge₁ˡ ⟩
+    ((g ∘ f) ⊗₁ id) ∘ η                         ∎
+
+dual₁-homomorphism : {f : X ⇒ Y} {g : Y ⇒ Z} → dual₁ (g ∘ f) ≈ dual₁ f ∘ dual₁ g
+dual₁-homomorphism = dual₁-as-cup-transpose ○ cupᵀ-resp-≈ (⟺ dual₁-composite-cup) ○ cupᵀ-unbend
+
+dualFunctor : Functor C (Category.op C)
+dualFunctor = record
+  { F₀           = _⁻¹
+  ; F₁           = dual₁
+  ; identity     = dual₁-identity
+  ; homomorphism = dual₁-homomorphism
+  ; F-resp-≈     = dual₁-resp-≈
+  }
+
+capᵀ : W ⊗₀ X ⇒ unit → W ⇒ X ⁻¹
+capᵀ cap = transposeˡ cap η
+
+capᵀ-ε : (cap : W ⊗₀ X ⇒ unit) → ε ∘ (capᵀ cap ⊗₁ id) ≈ cap
+capᵀ-ε cap = transposeˡ-cap-cancel
+
+private
+  transposeˡ-resp-cap : {cap cap′ : Z ⊗₀ X ⇒ unit} {cup : unit ⇒ X ⊗₀ W} →
+    cap ≈ cap′ → transposeˡ cap cup ≈ transposeˡ cap′ cup
+  transposeˡ-resp-cap cap≈cap′ = cap-bendˡ-resp cap≈cap′ ⟩∘⟨refl
+
+  -- Precomposition slides into the cap: `g` enters along the spectator wire, walks
+  -- left past the cup and the associator, and is absorbed by `cap`.
+  transposeˡ-natural : {cap : Z ⊗₀ X ⇒ unit} {cup : unit ⇒ X ⊗₀ W} {g : Y ⇒ Z} →
+    transposeˡ cap cup ∘ g ≈ transposeˡ (cap ∘ (g ⊗₁ id)) cup
+  transposeˡ-natural {cap = cap} {cup} {g} = begin
+    transposeˡ cap cup ∘ g                              ≈⟨ pullʳ (⟺ (cup-openʳ-commute cup)) ⟩
+    cap-bendˡ cap ∘ (g ⊗₁ id) ∘ cup-openʳ cup           ≈˘⟨ refl⟩∘⟨ (refl⟩⊗⟨ ⊗.identity) ⟩∘⟨refl ⟩
+    cap-bendˡ cap ∘ (g ⊗₁ (id ⊗₁ id)) ∘ cup-openʳ cup  ≈⟨ pullˡ (cap-bendˡ-⊗ cap) ⟩
+    transposeˡ (cap ∘ (g ⊗₁ id)) cup                   ∎
+
+-- The two transposes compose into a single one: `capᵀ cap` slides into `cupᵀ`'s
+-- counit (`capᵀ-ε`), leaving `cap` where `ε` was.
+cupᵀ-capᵀ : {cup : unit ⇒ X ⊗₀ Z} {cap : Z ⊗₀ X ⇒ unit} →
+  cupᵀ cup ∘ capᵀ cap ≈ λ⇒ ∘ (cap ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ cup) ∘ ρ⇐
+cupᵀ-capᵀ {cup = cup} {cap} = begin
+  transposeˡ ε cup ∘ capᵀ cap               ≈⟨ transposeˡ-natural ⟩
+  transposeˡ (ε ∘ (capᵀ cap ⊗₁ id)) cup     ≈⟨ transposeˡ-resp-cap (capᵀ-ε cap) ⟩
+  transposeˡ cap cup                        ≈⟨ assoc²αε ⟩
+  λ⇒ ∘ (cap ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ cup) ∘ ρ⇐  ∎
+
+capᵀ-cup : {cup : unit ⇒ X ⊗₀ Z} {cap : Z ⊗₀ X ⇒ unit} →
+  ρ⇒ ∘ (id ⊗₁ cap) ∘ α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐ ≈ id →
+  (id ⊗₁ capᵀ cap) ∘ cup ≈ η
+capᵀ-cup snake = transposeˡ-cup-cancel snake
+
+------------------------------------------------------------------------------
+-- Uniqueness of left duals.
+--
+-- Two dual structures on the same object give two ways to bend a wire, and the
+-- transposes below turn one into the other.  The composites are identities because
+-- each is a snake in disguise: bending out with one cup and back with the other's
+-- cap leaves a zig-zag, and a zig-zag is a straight wire.
+--
+--        D ⁻¹                         A
+--         │                           │
+--         │   ╭──────────╮            │
+--         │   │          │  ← ε       │
+--         ╰───╯          │      =     │      (`capᵀ`'s cap against `cupᵀ`'s cup)
+--            ↑ cup       │            │
+--                        │            │
+--                        A           D ⁻¹
+--
+-- If an object `A` is exhibited as a left dual of `D` by a cup/cap pair
+-- satisfying the two snake (zig-zag) identities, then `A` is canonically
+-- isomorphic to the chosen dual `D ⁻¹` — via the transposes of its cap and cup.
+-- Nothing beyond rigidity is needed.  `snakeᴰ` closes the `D`-loop (yielding the
+-- other composite through rigidity of `D ⁻¹`) and `snakeᴬ` the `A`-loop.
+
+module _ {D A : Obj}
+    (cup : unit ⇒ D ⊗₀ A) (cap : A ⊗₀ D ⇒ unit)
+    (snakeᴰ : ρ⇒ ∘ (id {D} ⊗₁ cap) ∘ α⇒ ∘ (cup ⊗₁ id {D}) ∘ λ⇐ ≈ id {D})
+    (snakeᴬ : λ⇒ ∘ (cap ⊗₁ id {A}) ∘ α⇐ ∘ (id {A} ⊗₁ cup) ∘ ρ⇐ ≈ id {A})
+    where
+
+  private
+    -- `capᵀ cap ∘ cupᵀ cup` acts trivially on the cup `η`, so it is the identity.
+    cupᵀ-capᵀ-η : (id {D} ⊗₁ (capᵀ cap ∘ cupᵀ cup)) ∘ η {D} ≈ η
+    cupᵀ-capᵀ-η = begin
+      (id ⊗₁ (capᵀ cap ∘ cupᵀ cup)) ∘ η          ≈⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ capᵀ cap) ∘ (id ⊗₁ cupᵀ cup) ∘ η    ≈⟨ refl⟩∘⟨ cupᵀ-η cup ⟩
+      (id ⊗₁ capᵀ cap) ∘ cup                     ≈⟨ capᵀ-cup snakeᴰ ⟩
+      η                                          ∎
+
+  dual-uniqueˡ : A ≅ D ⁻¹
+  dual-uniqueˡ = record
+    { from = capᵀ cap
+    ; to   = cupᵀ cup
+    ; iso  = record
+      { isoˡ = to-from
+      ; isoʳ = from-to
+      }
+    }
+    where
+      abstract
+        to-from : cupᵀ cup ∘ capᵀ cap ≈ id
+        to-from = cupᵀ-capᵀ ○ snakeᴬ
+
+        from-to : capᵀ cap ∘ cupᵀ cup ≈ id
+        from-to = cupᵀ-unique (cupᵀ-capᵀ-η ○ ⟺ (elimˡ ⊗.identity))

--- a/src/Categories/Category/Monoidal/Rigid/Functor.agda
+++ b/src/Categories/Category/Monoidal/Rigid/Functor.agda
@@ -1,0 +1,66 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+-- --lossy-unification makes this typecheck in ~3s instead of ~25s
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Category.Monoidal.Rigid using (LeftRigid)
+
+module Categories.Category.Monoidal.Rigid.Functor
+    {o ℓ e} {C : Category o ℓ e} (M : Monoidal C) (L : LeftRigid M) where
+
+open import Data.Product using (_,_)
+
+open import Categories.Category.Monoidal.Bundle using (MonoidalCategory)
+open import Categories.Category.Monoidal.Construction.Reverse
+  using (Reverse-MonoidalCategory)
+open import Categories.Category.Product using (_⁂_)
+open import Categories.Functor using (_∘F_)
+open import Categories.Functor.Monoidal
+  using (IsStrongMonoidalFunctor; StrongMonoidalFunctor)
+open import Categories.Morphism C using (_≅_)
+open import Categories.Morphism.Duality C using (Iso⇒op-Iso; ≅⇒op-≅)
+open import Categories.NaturalTransformation.NaturalIsomorphism
+  using (_≃_; niHelper)
+
+open Category C using (assoc; sym-assoc; module HomReasoning)
+open HomReasoning
+open import Categories.Category.Monoidal.Rigid.Dual M L
+  using (dualFunctor)
+import Categories.Category.Monoidal.Rigid.Properties M as RigidProperties
+open RigidProperties.Left L
+  using ( ⁻¹-unit-iso; ⁻¹-flip-⊗; ⁻¹-flip-⊗⁻¹; ⁻¹-flip-⊗⁻¹-assoc
+        ; ⁻¹-flip-⊗⁻¹-natural; ⁻¹-flip-⊗⁻¹-unitaryˡ; ⁻¹-flip-⊗⁻¹-unitaryʳ
+        ; ⁻¹-flip-⊗-iso )
+
+private
+  C-monoidal : MonoidalCategory o ℓ e
+  C-monoidal = record { monoidal = M }
+
+  C-op-reverse : MonoidalCategory o ℓ e
+  C-op-reverse = Reverse-MonoidalCategory (MonoidalCategory.op C-monoidal)
+
+  ⊗-homo :
+    MonoidalCategory.⊗ C-op-reverse ∘F (dualFunctor ⁂ dualFunctor)
+    ≃ dualFunctor ∘F MonoidalCategory.⊗ C-monoidal
+  ⊗-homo = niHelper record
+    { η       = λ (X , Y) → ⁻¹-flip-⊗⁻¹ {X} {Y}
+    ; η⁻¹     = λ (X , Y) → ⁻¹-flip-⊗ {X} {Y}
+    ; commute = λ _ → ⁻¹-flip-⊗⁻¹-natural
+    ; iso     = λ _ → Iso⇒op-Iso (_≅_.iso ⁻¹-flip-⊗-iso)
+    }
+
+dual-IsStrongMonoidalFunctor :
+  IsStrongMonoidalFunctor C-monoidal C-op-reverse dualFunctor
+dual-IsStrongMonoidalFunctor = record
+  { ε             = ≅⇒op-≅ ⁻¹-unit-iso
+  ; ⊗-homo        = ⊗-homo
+  ; associativity = assoc ○ ⁻¹-flip-⊗⁻¹-assoc ○ sym-assoc
+  ; unitaryˡ      = assoc ○ ⁻¹-flip-⊗⁻¹-unitaryˡ
+  ; unitaryʳ      = assoc ○ ⁻¹-flip-⊗⁻¹-unitaryʳ
+  }
+
+dual-StrongMonoidalFunctor : StrongMonoidalFunctor C-monoidal C-op-reverse
+dual-StrongMonoidalFunctor = record
+  { F = dualFunctor
+  ; isStrongMonoidal = dual-IsStrongMonoidalFunctor
+  }

--- a/src/Categories/Category/Monoidal/Rigid/Functor/Symmetric.agda
+++ b/src/Categories/Category/Monoidal/Rigid/Functor/Symmetric.agda
@@ -1,0 +1,103 @@
+{-# OPTIONS --without-K --safe --lossy-unification #-}
+-- --lossy-unification makes this typecheck in ~4s instead of ~23s
+
+-- In a symmetric rigid monoidal category, dualization is a strong symmetric
+-- monoidal equivalence with the opposite category.
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Category.Monoidal.Symmetric using (Symmetric)
+
+module Categories.Category.Monoidal.Rigid.Functor.Symmetric
+    {o ℓ e} {C : Category o ℓ e}
+    (M : Monoidal C) (S : Symmetric M) where
+
+open import Categories.Category.Equivalence using (StrongEquivalence)
+open import Categories.Category.Monoidal.Bundle using (SymmetricMonoidalCategory)
+open import Categories.Category.Monoidal.Rigid using (LeftRigid; RightRigid)
+open import Categories.Functor using (Functor; _∘F_) renaming (id to idF)
+import Categories.Functor.Monoidal.Symmetric as SymmetricFunctor
+open import Categories.NaturalTransformation.NaturalIsomorphism
+  using (NaturalIsomorphism; _≃_; niHelper)
+open import Data.Sum
+
+import Categories.Category.Monoidal.Construction.Reverse as Reverse
+import Categories.Category.Monoidal.Rigid.Functor as RigidFunctor
+import Categories.Category.Monoidal.Rigid.Symmetry as RigidSymmetry
+open import Categories.Morphism C using (_≅_)
+
+module Symmetry = RigidSymmetry M S
+
+symmetricMonoidalCategory : SymmetricMonoidalCategory o ℓ e
+symmetricMonoidalCategory = record { symmetric = S }
+
+private
+  C-op-reverse : SymmetricMonoidalCategory o ℓ e
+  C-op-reverse = Reverse.Reverse-SymmetricMonoidalCategory
+    (SymmetricMonoidalCategory.op symmetricMonoidalCategory)
+
+module DoubleDualˡ (L : LeftRigid M) where
+  open import Categories.Category.Monoidal.Rigid.Dual M L using (dualFunctor)
+  open Symmetry.DoubleDualˡ L
+    using (⁻¹⁻¹≅; double-dual-natural; dual-braiding-compat; j⇒; j⇐)
+  module DualFunctor = RigidFunctor M L
+
+  dual-Reverse-StrongSymmetricMonoidalFunctor :
+    SymmetricFunctor.Strong.SymmetricMonoidalFunctor
+      symmetricMonoidalCategory C-op-reverse
+  dual-Reverse-StrongSymmetricMonoidalFunctor = record
+    { F = dualFunctor
+    ; isBraidedMonoidal = record
+      { isStrongMonoidal = DualFunctor.dual-IsStrongMonoidalFunctor
+      ; braiding-compat = dual-braiding-compat
+      }
+    }
+
+  dual-StrongSymmetricMonoidalFunctor :
+    SymmetricFunctor.Strong.SymmetricMonoidalFunctor
+      symmetricMonoidalCategory
+      (SymmetricMonoidalCategory.op symmetricMonoidalCategory)
+  dual-StrongSymmetricMonoidalFunctor =
+    Reverse.unreverse-StrongSymmetricMonoidal
+      dual-Reverse-StrongSymmetricMonoidalFunctor
+
+  double-dual≃id : Functor.op dualFunctor ∘F dualFunctor ≃ idF
+  double-dual≃id = niHelper record
+    { η       = λ _ → j⇒
+    ; η⁻¹     = λ _ → j⇐
+    ; commute = double-dual-natural
+    ; iso     = λ _ → _≅_.iso ⁻¹⁻¹≅
+    }
+
+  dual-equivalence : StrongEquivalence C (Category.op C)
+  dual-equivalence = record
+    { F = dualFunctor
+    ; G = Functor.op dualFunctor
+    ; weak-inverse = record
+      { F∘G≈id = NaturalIsomorphism.op′ double-dual≃id
+      ; G∘F≈id = double-dual≃id
+      }
+    }
+
+module DoubleDualʳ (R : RightRigid M) where
+  dual-equivalence : StrongEquivalence C (Category.op C)
+  dual-equivalence = DoubleDualˡ.dual-equivalence (Symmetry.right⇒left R)
+
+  dual-StrongSymmetricMonoidalFunctor :
+    SymmetricFunctor.Strong.SymmetricMonoidalFunctor
+      symmetricMonoidalCategory
+      (SymmetricMonoidalCategory.op symmetricMonoidalCategory)
+  dual-StrongSymmetricMonoidalFunctor =
+    DoubleDualˡ.dual-StrongSymmetricMonoidalFunctor (Symmetry.right⇒left R)
+
+dual-equivalence : LeftRigid M ⊎ RightRigid M → StrongEquivalence C (Category.op C)
+dual-equivalence = [ DoubleDualˡ.dual-equivalence , DoubleDualʳ.dual-equivalence ]′
+
+dual-StrongSymmetricMonoidalFunctor : LeftRigid M ⊎ RightRigid M →
+  SymmetricFunctor.Strong.SymmetricMonoidalFunctor
+    symmetricMonoidalCategory
+    (SymmetricMonoidalCategory.op symmetricMonoidalCategory)
+dual-StrongSymmetricMonoidalFunctor =
+  [ DoubleDualˡ.dual-StrongSymmetricMonoidalFunctor
+  , DoubleDualʳ.dual-StrongSymmetricMonoidalFunctor
+  ]′

--- a/src/Categories/Category/Monoidal/Rigid/Properties.agda
+++ b/src/Categories/Category/Monoidal/Rigid/Properties.agda
@@ -1,0 +1,494 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Consequences of rigidity: rigidity transfers to the opposite monoidal category
+-- (`rigidˡ-Op` / `rigidʳ-Op`), and duals are closed under tensor — `[ X ⊗ Y ]⁻¹`
+-- with its cup/cap and the flip iso `[ X ⊗ Y ]⁻¹ ≅ Y ⁻¹ ⊗₀ X ⁻¹` (modules `Left`/`Right`).
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+
+module Categories.Category.Monoidal.Rigid.Properties
+    {o ℓ e} {C : Category o ℓ e} (M : Monoidal C) where
+
+import Categories.Category.Monoidal.Rigid M as Rigid
+open Rigid using (LeftRigid; RightRigid)
+import Categories.Category.Monoidal.Rigid as RigidModule
+import Categories.Category.Monoidal.Rigid.Dual as RigidDual
+
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Morphism.Reasoning C
+open import Categories.Morphism C using (_≅_)
+open import Categories.Category.Monoidal.Properties M
+  using (coherence-inv₃; monoidal-Op)
+open import Categories.Category.Monoidal.Reassociation M
+  using ( α⇐-id⊗-commute; λ⇐-assoc; λ⇒-assoc; ρ⇐-assoc
+        ; pentagon-collapse-inv; whisker-comm )
+open import Categories.Category.Monoidal.CupCap M
+import Categories.Category.Monoidal.Utilities M as MonUtil
+
+open Category C
+  using (Obj; _⇒_; _≈_; id; _∘_; assoc; sym-assoc; identity²; module Equiv)
+open Monoidal M
+open MonUtil.Shorthands
+
+private
+  variable
+    A B W X Y Z : Obj
+
+  merge₂³-tail : {f : Y ⇒ Z} {g : X ⇒ Y} {h : W ⇒ X} {k : B ⇒ A ⊗₀ W} →
+    (id ⊗₁ f) ∘ (id ⊗₁ g) ∘ (id ⊗₁ h) ∘ k ≈ (id ⊗₁ (f ∘ g ∘ h)) ∘ k
+  merge₂³-tail = assoc²εβ ○ (merge₂³ ⟩∘⟨refl)
+
+rigidʳ-Op : RightRigid → RigidModule.LeftRigid monoidal-Op
+rigidʳ-Op R = record
+  { _⁻¹ = Rigid.RightRigid._⁻¹ R
+  ; η = Rigid.RightRigid.ε R
+  ; ε = Rigid.RightRigid.η R
+  ; snake₁ = assoc²αε ○ assoc ○ Rigid.RightRigid.snake₁ R
+  ; snake₂ = assoc²αε ○ assoc ○ Rigid.RightRigid.snake₂ R
+  }
+
+rigidˡ-Op : LeftRigid → RigidModule.RightRigid monoidal-Op
+rigidˡ-Op L = record
+  { _⁻¹ = Rigid.LeftRigid._⁻¹ L
+  ; η = Rigid.LeftRigid.ε L
+  ; ε = Rigid.LeftRigid.η L
+  ; snake₁ = assoc²αε ○ assoc ○ Rigid.LeftRigid.snake₁ L
+  ; snake₂ = assoc²αε ○ assoc ○ Rigid.LeftRigid.snake₂ L
+  }
+
+module Left (L : LeftRigid) where
+  open LeftRigid L using (_⁻¹; η; ε; snake₁; dual₁)
+  open RigidDual M L
+    using ( capˡ; capᵀ; capᵀ-cup; capᵀ-ε; cupᵀ; cupᵀ-unbend; cupˡ
+          ; cupᵀ-η; cupᵀ-unique; dual-uniqueˡ; dual₁-cup; snakeˡ-wire
+          ; snakeˡ-dual )
+
+  infix 4 [_⊗_]⁻¹
+
+  [_⊗_]⁻¹ : Obj → Obj → Obj
+  [ X ⊗ Y ]⁻¹ = Y ⁻¹ ⊗₀ X ⁻¹
+
+  private
+    -- `ε`, with `k` run along its wire first.
+    capₖ : {k : Y ⇒ X} → X ⁻¹ ⊗₀ Y ⇒ unit
+    capₖ {k = k} = ε ∘ (id ⊗₁ k)
+
+    unit-cap-natural :
+      λ⇒ {X = unit ⊗₀ unit} ∘ (id {unit} ⊗₁ λ⇐ {X = unit})
+      ≈ λ⇐ {X = unit} ∘ λ⇒ {X = unit}
+    unit-cap-natural = unitorˡ-commute-from
+
+    abstract
+      unit-snakeˡ :
+        ρ⇒ ∘ (id {unit} ⊗₁ λ⇒) ∘ α⇒ ∘ (λ⇐ ⊗₁ id) ∘ λ⇐ ≈ id
+      unit-snakeˡ = begin
+        ρ⇒ ∘ (id ⊗₁ λ⇒) ∘ α⇒ ∘ (λ⇐ ⊗₁ id) ∘ λ⇐
+          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ (coherence-inv₃ ⟩⊗⟨refl) ⟩∘⟨ coherence-inv₃ ⟩
+        ρ⇒ ∘ (id ⊗₁ λ⇒) ∘ α⇒ ∘ (ρ⇐ ⊗₁ id) ∘ ρ⇐  ≈⟨ refl⟩∘⟨ pullˡ triangle ⟩
+        ρ⇒ ∘ (ρ⇒ ⊗₁ id) ∘ (ρ⇐ ⊗₁ id) ∘ ρ⇐
+          ≈⟨ refl⟩∘⟨ cancelˡ (⊗-cancel unitorʳ.isoʳ identity²) ⟩
+        ρ⇒ ∘ ρ⇐                                          ≈⟨ unitorʳ.isoʳ ⟩
+        id                                               ∎
+
+      unit-snakeʳ :
+        λ⇒ ∘ (λ⇒ ⊗₁ id {unit}) ∘ α⇐ ∘ (id ⊗₁ λ⇐) ∘ ρ⇐ ≈ id
+      unit-snakeʳ = begin
+        λ⇒ ∘ (λ⇒ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ λ⇐) ∘ ρ⇐    ≈⟨ refl⟩∘⟨ pullˡ λ⇒-assoc ⟩
+        λ⇒ ∘ λ⇒ ∘ (id ⊗₁ λ⇐) ∘ ρ⇐                 ≈⟨ refl⟩∘⟨ extendʳ unit-cap-natural ⟩
+        λ⇒ ∘ λ⇐ ∘ λ⇒ ∘ ρ⇐                         ≈⟨ cancelˡ unitorˡ.isoʳ ⟩
+        λ⇒ ∘ ρ⇐                                   ≈˘⟨ refl⟩∘⟨ coherence-inv₃ ⟩
+        λ⇒ ∘ λ⇐                                   ≈⟨ unitorˡ.isoʳ ⟩
+        id                                        ∎
+
+  ⁻¹-unit-iso : unit ≅ unit ⁻¹
+  ⁻¹-unit-iso = dual-uniqueˡ λ⇐ λ⇒ unit-snakeˡ unit-snakeʳ
+
+  -- The tensor dual `[ X ⊗ Y ]⁻¹ = Y ⁻¹ ⊗₀ X ⁻¹` is dual to `X ⊗₀ Y` by nesting
+  -- one bend inside the other — and that nesting is exactly why the dual reverses
+  -- its factors: the `X`-bend has to reach around the `Y`-bend.
+  --
+  --                ⊗-cup                                ⊗-cap
+  --
+  --   X      Y     Y ⁻¹    X ⁻¹            ╭───────────────────────────╮
+  --   │      │      │       │              │       ╭───────────╮       │
+  --   │      ╰──────╯       │   ← η        │       │           │       │
+  --   │         ↑ inner     │              │       │           │       │
+  --   ╰─────────────────────╯   ← η      Y ⁻¹    X ⁻¹          X       Y
+  --             ↑ outer                              ↑ inner ε
+  --                                          ↑ outer ε
+
+  ⊗-cup : unit ⇒ (X ⊗₀ Y) ⊗₀ [ X ⊗ Y ]⁻¹
+  ⊗-cup = cup-nest η η
+
+  ⊗-cap : [ X ⊗ Y ]⁻¹ ⊗₀ (X ⊗₀ Y) ⇒ unit
+  ⊗-cap = ε ∘ (id ⊗₁ capˡ) ∘ α⇒
+
+  private
+    cup-core : (cup : unit ⇒ X ⊗₀ Y) → A ⊗₀ B ⇒ X ⊗₀ ((Y ⊗₀ A) ⊗₀ B)
+    cup-core cup = α⇒ ∘ (cup-bendˡ cup ⊗₁ id)
+
+    cupˡ-core : A ⊗₀ B ⇒ Y ⊗₀ ((Y ⁻¹ ⊗₀ A) ⊗₀ B)
+    cupˡ-core = cup-core η
+
+    open-nest :
+      (cup₀ : unit ⇒ A ⊗₀ B) (cup₁ : unit ⇒ X ⊗₀ Y) →
+      cup-bendˡ {A = Z} (cup-nest cup₀ cup₁)
+      ≈ (α⇐ ∘ (id ⊗₁ cup-core cup₁)) ∘ cup-bendˡ cup₀
+    open-nest cup₀ cup₁ = begin
+      α⇒ ∘ (cup-nest cup₀ cup₁ ⊗₁ id) ∘ λ⇐  ≈⟨ split ⟩
+      unit-conjˡ nested                            ≈⟨ cup-slideˡ ⟩
+      (head ∘ (α⇒ ∘ (cup₀ ⊗₁ id))) ∘ λ⇐          ≈⟨ pullʳ assoc ⟩
+      head ∘ cup-bendˡ cup₀                       ∎
+      where
+        nested = (α⇐ ⊗₁ id) ∘ ((id ⊗₁ cup-bendˡ cup₁) ⊗₁ id) ∘ (cup₀ ⊗₁ id)
+        head = α⇐ ∘ (id ⊗₁ cup-core cup₁)
+        split = refl⟩∘⟨ split₁³ ⟩∘⟨refl
+
+    -- `cupˡ` is natural in `k`: walk `k` down the cup's three factors, past the
+    -- associator, through the cup itself, and out along the unitor.
+    cupˡ-natural : {k : A ⇒ B} →
+      (id {X} ⊗₁ (id {X ⁻¹} ⊗₁ k)) ∘ cupˡ ≈ cupˡ ∘ k
+    cupˡ-natural = cup-bendˡ-commute η
+
+    cupˡ-map : {f : X ⇒ Y} {k : A ⇒ B} →
+      (id {Y} ⊗₁ (dual₁ f ⊗₁ k)) ∘ cupˡ ≈ (f ⊗₁ id) ∘ cupˡ ∘ k
+    cupˡ-map {f = f} {k} = begin
+      (id ⊗₁ (dual₁ f ⊗₁ k)) ∘ cupˡ
+        ≈⟨ (split₂ serialize₁₂ ⟩∘⟨ Equiv.refl) ⟩
+      (id ⊗₁ (dual₁ f ⊗₁ id)) ∘ (id ⊗₁ (id ⊗₁ k)) ∘ cupˡ
+        ≈⟨ refl⟩∘⟨ cupˡ-natural ⟩
+      (id ⊗₁ (dual₁ f ⊗₁ id)) ∘ cupˡ ∘ k
+        ≈⟨ pullˡ (cup-bendˡ-⊗ η) ⟩
+      cup-bendˡ ((id ⊗₁ dual₁ f) ∘ η) ∘ k
+        ≈⟨ cup-bendˡ-resp dual₁-cup ⟩∘⟨refl ⟩
+      cup-bendˡ ((f ⊗₁ id) ∘ η) ∘ k
+        ≈˘⟨ pullˡ (cup-bendˡ-⊗ η) ⟩
+      (f ⊗₁ (id ⊗₁ id)) ∘ cupˡ ∘ k
+        ≈⟨ (refl⟩⊗⟨ ⊗.identity) ⟩∘⟨refl ⟩
+      (f ⊗₁ id) ∘ cupˡ ∘ k  ∎
+
+    snakeˡ : {k : Z ⇒ Y} → (ρ⇒ ∘ (id ⊗₁ capₖ)) ∘ cupˡ ≈ k
+    snakeˡ {k = k} = begin
+      (ρ⇒ ∘ (id ⊗₁ capₖ)) ∘ cupˡ                   ≈⟨ pullʳ (pushˡ split₂ˡ) ⟩
+      ρ⇒ ∘ (id ⊗₁ ε) ∘ (id ⊗₁ (id ⊗₁ k)) ∘ cupˡ    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cupˡ-natural ⟩
+      ρ⇒ ∘ (id ⊗₁ ε) ∘ cupˡ ∘ k                    ≈⟨ assoc²εβ ⟩
+      (ρ⇒ ∘ (id ⊗₁ ε) ∘ cupˡ) ∘ k                  ≈⟨ elimˡ snake₁ ⟩
+      k                                            ∎
+
+    -- The same fold, under a whisker and between the associators the caller has it in.
+    cupˡ-core-fold : (id {X ⊗₀ Y} ⊗₁ α⇒ {Y ⁻¹} {A} {B}) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)
+                     ≈ α⇐ ∘ (id ⊗₁ cupˡ)
+    cupˡ-core-fold = begin
+      (id ⊗₁ α⇒) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)           ≈⟨ pullˡ α⇐-id⊗-commute ⟩
+      (α⇐ ∘ (id ⊗₁ (id ⊗₁ α⇒))) ∘ (id ⊗₁ cupˡ-core) ≈⟨ pullʳ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ α⇒) ∘ cupˡ-core))         ≈⟨ refl⟩∘⟨ (refl⟩⊗⟨ cup-bendˡ-assoc η) ⟩
+      α⇐ ∘ (id ⊗₁ cupˡ)                             ∎
+
+    -- The cap `ε ∘ (id ⊗₁ k) ∘ α⇒`, whiskered by `X ⊗₀ Y` and fed the nested cup, is
+    -- just `k` under the same whisker: `cupˡ-core-fold` straightens the cup out and
+    -- `snakeˡ` runs the loop.  (`⊗-cap` is this cap with `k = capˡ`.)
+    inner-snake : {k : A ⊗₀ B ⇒ Y} →
+      ρ⇒ ∘ (id {X ⊗₀ Y} ⊗₁ (ε ∘ (id ⊗₁ k) ∘ α⇒)) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)
+      ≈ id ⊗₁ k
+    inner-snake {k = k} = begin
+      ρ⇒ ∘ (id ⊗₁ (ε ∘ (id ⊗₁ k) ∘ α⇒)) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)
+        ≈⟨ refl⟩∘⟨ split₂³ ⟩∘⟨refl ⟩
+      ρ⇒ ∘ ((id ⊗₁ ε) ∘ (id ⊗₁ (id ⊗₁ k)) ∘ (id ⊗₁ α⇒)) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)
+        ≈⟨ refl⟩∘⟨ assoc²βε ⟩
+      ρ⇒ ∘ (id ⊗₁ ε) ∘ (id ⊗₁ (id ⊗₁ k)) ∘ (id ⊗₁ α⇒) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ cupˡ-core-fold ⟩
+      ρ⇒ ∘ (id ⊗₁ ε) ∘ (id ⊗₁ (id ⊗₁ k)) ∘ α⇐ ∘ (id ⊗₁ cupˡ)
+        ≈⟨ refl⟩∘⟨ pullˡ merge₂ˡ ⟩
+      ρ⇒ ∘ (id ⊗₁ capₖ) ∘ α⇐ ∘ (id ⊗₁ cupˡ)        ≈⟨ sym-assoc ⟩
+      cap-closeʳ capₖ ∘ α⇐ ∘ (id ⊗₁ cupˡ)          ≈⟨ pullˡ cap-closeʳ-natural ⟩
+      (id ⊗₁ cap-closeʳ capₖ) ∘ (id ⊗₁ cupˡ)       ≈⟨ merge₂ˡ ⟩
+      id ⊗₁ (cap-closeʳ capₖ ∘ cupˡ)               ≈⟨ refl⟩⊗⟨ snakeˡ ⟩
+      id ⊗₁ k                                      ∎
+
+    -- Bending `⊗-cup` into place plants the outer cup `cupˡ` and leaves the inner
+    -- one, `cupˡ-core`, waiting under an associator for the cap to come and meet it.
+    ⊗-cup-open : α⇒ ∘ (⊗-cup {X} {Y} ⊗₁ id {X ⊗₀ Y}) ∘ λ⇐
+      ≈ α⇐ ∘ (id ⊗₁ cupˡ-core) ∘ cupˡ
+    ⊗-cup-open = open-nest η η ○ assoc
+
+    -- The `X ⊗₀ Y` snake: `⊗-cup-open` plants both cups, `inner-snake` runs the
+    -- inner loop, and what is left is the outer one — the nested snake, straightened
+    -- by `snakeˡ-wire`.
+    ⊗-snakeˡ : ρ⇒ ∘ (id ⊗₁ ⊗-cap {X} {Y}) ∘ α⇒ ∘ (⊗-cup ⊗₁ id) ∘ λ⇐ ≈ id
+    ⊗-snakeˡ = begin
+      ρ⇒ ∘ (id ⊗₁ ⊗-cap) ∘ α⇒ ∘ (⊗-cup ⊗₁ id) ∘ λ⇐          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⊗-cup-open ⟩
+      ρ⇒ ∘ (id ⊗₁ ⊗-cap) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core) ∘ cupˡ    ≈⟨ reassoc-tail₅ ⟩
+      (ρ⇒ ∘ (id ⊗₁ ⊗-cap) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)) ∘ cupˡ  ≈⟨ inner-snake ⟩∘⟨refl ⟩
+      (id ⊗₁ capˡ) ∘ cupˡ                                   ≈⟨ snakeˡ-wire ⟩
+      id                                                    ∎
+
+  abstract
+    ⊗-cup-natural : {f : X ⇒ Y} {g : A ⇒ B} →
+      (id ⊗₁ (dual₁ g ⊗₁ dual₁ f)) ∘ ⊗-cup
+      ≈ ((f ⊗₁ g) ⊗₁ id) ∘ ⊗-cup
+    ⊗-cup-natural {f = f} {g} = begin
+      (id ⊗₁ (dual₁ g ⊗₁ dual₁ f)) ∘ α⇐ ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈⟨ extendʳ α⇐-id⊗-commute ⟩
+      α⇐ ∘ (id ⊗₁ (id ⊗₁ (dual₁ g ⊗₁ dual₁ f))) ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈⟨ refl⟩∘⟨ pullˡ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ (dual₁ g ⊗₁ dual₁ f)) ∘ cupˡ)) ∘ η       ≈⟨ refl⟩∘⟨ (refl⟩⊗⟨ cupˡ-map) ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ ((g ⊗₁ id) ∘ cupˡ ∘ dual₁ f)) ∘ η
+        ≈⟨ refl⟩∘⟨ pushˡ split₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ (g ⊗₁ id)) ∘ (id ⊗₁ (cupˡ ∘ dual₁ f)) ∘ η
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ pushˡ split₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ (g ⊗₁ id)) ∘ (id ⊗₁ cupˡ) ∘ (id ⊗₁ dual₁ f) ∘ η
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ dual₁-cup ⟩
+      α⇐ ∘ (id ⊗₁ (g ⊗₁ id)) ∘ (id ⊗₁ cupˡ) ∘ (f ⊗₁ id) ∘ η
+        ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ extendʳ whisker-comm ⟩
+      α⇐ ∘ (id ⊗₁ (g ⊗₁ id)) ∘ (f ⊗₁ id) ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈⟨ refl⟩∘⟨ pullˡ (⟺ serialize₂₁) ⟩
+      α⇐ ∘ (f ⊗₁ (g ⊗₁ id)) ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈⟨ extendʳ assoc-commute-to ⟩
+      ((f ⊗₁ g) ⊗₁ id) ∘ ⊗-cup                            ∎
+
+  -- `⊗-cup`/`⊗-cap` exhibit `[ X ⊗ Y ]⁻¹` as *a* dual of `X ⊗₀ Y`, and `η`/`ε`
+  -- exhibit `(X ⊗₀ Y) ⁻¹` as *the* chosen one.  Duals are unique up to canonical
+  -- iso, so the two are isomorphic — transpose one pair's cap along the other's.
+
+  ⁻¹-flip-⊗ : [ X ⊗ Y ]⁻¹ ⇒ (X ⊗₀ Y) ⁻¹
+  ⁻¹-flip-⊗ {X} {Y} = capᵀ ⊗-cap
+
+  ⁻¹-flip-⊗⁻¹ : (X ⊗₀ Y) ⁻¹ ⇒ [ X ⊗ Y ]⁻¹
+  ⁻¹-flip-⊗⁻¹ {X} {Y} = cupᵀ ⊗-cup
+
+  private abstract
+    cupˡ-cupᵀ : (cup : unit ⇒ X ⊗₀ Z) →
+      (id {X} ⊗₁ (cupᵀ cup ⊗₁ id {A})) ∘ cupˡ
+      ≈ α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐
+    cupˡ-cupᵀ cup = begin
+      (id ⊗₁ (cupᵀ cup ⊗₁ id)) ∘ cupˡ
+        ≈⟨ extendʳ (⟺ assoc-commute-from) ⟩
+      α⇒ ∘ (((id ⊗₁ cupᵀ cup) ⊗₁ id) ∘ (η ⊗₁ id) ∘ λ⇐)
+        ≈⟨ refl⟩∘⟨ pullˡ merge₁ˡ ⟩
+      α⇒ ∘ ((((id ⊗₁ cupᵀ cup) ∘ η) ⊗₁ id) ∘ λ⇐)
+        ≈⟨ refl⟩∘⟨ (cupᵀ-η cup ⟩⊗⟨refl) ⟩∘⟨refl ⟩
+      α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐  ∎
+
+  abstract
+    cupˡ-⊗ :
+      (id {X ⊗₀ Y} ⊗₁ (⁻¹-flip-⊗⁻¹ ⊗₁ id {Z})) ∘ cupˡ
+      ≈ α⇒ ∘ (⊗-cup ⊗₁ id) ∘ λ⇐
+    cupˡ-⊗ = cupˡ-cupᵀ ⊗-cup
+
+    ⁻¹-flip-⊗⁻¹-natural : {f : X ⇒ Y} {g : A ⇒ B} →
+      (dual₁ g ⊗₁ dual₁ f) ∘ ⁻¹-flip-⊗⁻¹
+      ≈ ⁻¹-flip-⊗⁻¹ ∘ dual₁ (f ⊗₁ g)
+    ⁻¹-flip-⊗⁻¹-natural {f = f} {g} = cupᵀ-unique (begin
+      (id ⊗₁ ((dual₁ g ⊗₁ dual₁ f) ∘ ⁻¹-flip-⊗⁻¹)) ∘ η  ≈⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ (dual₁ g ⊗₁ dual₁ f)) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η
+        ≈⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟩
+      (id ⊗₁ (dual₁ g ⊗₁ dual₁ f)) ∘ ⊗-cup               ≈⟨ ⊗-cup-natural ⟩
+      ((f ⊗₁ g) ⊗₁ id) ∘ ⊗-cup                           ≈˘⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟩
+      ((f ⊗₁ g) ⊗₁ id) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η         ≈⟨ extendʳ whisker-comm ⟩
+      (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ ((f ⊗₁ g) ⊗₁ id) ∘ η
+        ≈˘⟨ refl⟩∘⟨ dual₁-cup ⟩
+      (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ (id ⊗₁ dual₁ (f ⊗₁ g)) ∘ η   ≈⟨ pullˡ merge₂ˡ ⟩
+      (id ⊗₁ (⁻¹-flip-⊗⁻¹ ∘ dual₁ (f ⊗₁ g))) ∘ η         ∎)
+
+  private abstract
+    ⊗-cup-dual : {f : X ⊗₀ Y ⇒ Z} {k : [ X ⊗ Y ]⁻¹ ⇒ A} →
+      (id ⊗₁ (k ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ f)) ∘ η
+      ≈ (f ⊗₁ id) ∘ (id ⊗₁ k) ∘ ⊗-cup
+    ⊗-cup-dual {f = f} {k} = begin
+      (id ⊗₁ (k ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ f)) ∘ η                ≈⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ k) ∘ (id ⊗₁ (⁻¹-flip-⊗⁻¹ ∘ dual₁ f)) ∘ η       ≈⟨ refl⟩∘⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ k) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ (id ⊗₁ dual₁ f) ∘ η ≈⟨ refl⟩∘⟨ refl⟩∘⟨ dual₁-cup ⟩
+      (id ⊗₁ k) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ (f ⊗₁ id) ∘ η        ≈⟨ refl⟩∘⟨ extendʳ (⟺ whisker-comm) ⟩
+      (id ⊗₁ k) ∘ (f ⊗₁ id) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η        ≈⟨ extendʳ (⟺ whisker-comm) ⟩
+      (f ⊗₁ id) ∘ (id ⊗₁ k) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟩
+      (f ⊗₁ id) ∘ (id ⊗₁ k) ∘ ⊗-cup                          ∎
+
+    ⊗-cup-nest₁ : (cup : unit ⇒ X ⊗₀ A) →
+      (id {X ⊗₀ Y} ⊗₁ (id ⊗₁ cupᵀ cup)) ∘ ⊗-cup
+      ≈ cup-nest cup η
+    ⊗-cup-nest₁ cup = begin
+      (id ⊗₁ (id ⊗₁ cupᵀ cup)) ∘ ⊗-cup
+        ≈⟨ extendʳ α⇐-id⊗-commute ⟩
+      α⇐ ∘ (id ⊗₁ (id ⊗₁ (id ⊗₁ cupᵀ cup))) ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈⟨ refl⟩∘⟨ pullˡ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ (id ⊗₁ cupᵀ cup)) ∘ cupˡ)) ∘ η
+        ≈⟨ refl⟩∘⟨ (refl⟩⊗⟨ cupˡ-natural) ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ (cupˡ ∘ cupᵀ cup)) ∘ η          ≈⟨ refl⟩∘⟨ pushˡ split₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ cupˡ) ∘ (id ⊗₁ cupᵀ cup) ∘ η    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cupᵀ-η cup ⟩
+      α⇐ ∘ (id ⊗₁ cupˡ) ∘ cup                     ∎
+
+    ⊗-cup-nest₂ : (cup : unit ⇒ Y ⊗₀ A) →
+      (id {X ⊗₀ Y} ⊗₁ (cupᵀ cup ⊗₁ id {X ⁻¹})) ∘ ⊗-cup
+      ≈ cup-nest η cup
+    ⊗-cup-nest₂ cup = begin
+      (id ⊗₁ (cupᵀ cup ⊗₁ id)) ∘ ⊗-cup
+        ≈⟨ extendʳ α⇐-id⊗-commute ⟩
+      α⇐ ∘ (id ⊗₁ (id ⊗₁ (cupᵀ cup ⊗₁ id))) ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈⟨ refl⟩∘⟨ pullˡ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ (cupᵀ cup ⊗₁ id)) ∘ cupˡ)) ∘ η
+        ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ cupˡ-cupᵀ cup ⟩∘⟨refl ⟩
+      cup-nest η cup  ∎
+
+    cup-bendˡ-nest :
+      (cup₀ : unit ⇒ A ⊗₀ B) (cup₁ : unit ⇒ X ⊗₀ Y) →
+      (id ⊗₁ α⇒) ∘ cup-bendˡ {A = Z} (cup-nest cup₀ cup₁)
+      ≈ α⇐ ∘ (id ⊗₁ cup-bendˡ cup₁) ∘ cup-bendˡ cup₀
+    cup-bendˡ-nest cup₀ cup₁ = begin
+      (id ⊗₁ α⇒) ∘ cup-bendˡ (cup-nest cup₀ cup₁)
+        ≈⟨ refl⟩∘⟨ open-nest cup₀ cup₁ ⟩
+      (id ⊗₁ α⇒) ∘ (α⇐ ∘ (id ⊗₁ cup-core cup₁)) ∘ cup-bendˡ cup₀
+        ≈⟨ refl⟩∘⟨ assoc ⟩
+      (id ⊗₁ α⇒) ∘ α⇐ ∘ (id ⊗₁ cup-core cup₁) ∘ cup-bendˡ cup₀
+        ≈⟨ extendʳ α⇐-id⊗-commute ⟩
+      α⇐ ∘ (id ⊗₁ (id ⊗₁ α⇒)) ∘ (id ⊗₁ cup-core cup₁) ∘ cup-bendˡ cup₀
+        ≈⟨ refl⟩∘⟨ pullˡ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ α⇒) ∘ cup-core cup₁)) ∘ cup-bendˡ cup₀
+        ≈⟨ refl⟩∘⟨ (refl⟩⊗⟨ cup-bendˡ-assoc cup₁) ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ cup-bendˡ cup₁) ∘ cup-bendˡ cup₀  ∎
+
+    cup-nest-assoc :
+      (cup₀ : unit ⇒ A ⊗₀ B) (cup₁ : unit ⇒ W ⊗₀ X) (cup₂ : unit ⇒ Y ⊗₀ Z) →
+      (α⇒ ⊗₁ id) ∘ cup-nest (cup-nest cup₀ cup₁) cup₂
+      ≈ (id ⊗₁ α⇒) ∘ cup-nest cup₀ (cup-nest cup₁ cup₂)
+    cup-nest-assoc cup₀ cup₁ cup₂ =
+      let
+        b₁ = cup-bendˡ cup₁
+        b₂ = cup-bendˡ cup₂
+        b₁₂ = cup-bendˡ (cup-nest cup₁ cup₂)
+        tail = (id ⊗₁ (id ⊗₁ b₂)) ∘ (id ⊗₁ b₁) ∘ cup₀
+      in begin
+        α⇒ ⊗₁ id ∘ α⇐ ∘ id ⊗₁ b₂ ∘ α⇐ ∘ id ⊗₁ b₁ ∘ cup₀
+          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ extendʳ α⇐-id⊗-commute ⟩
+        α⇒ ⊗₁ id ∘ α⇐ ∘ α⇐ ∘ tail                    ≈⟨ assoc²εβ ⟩
+        (α⇒ ⊗₁ id ∘ α⇐ ∘ α⇐) ∘ tail                  ≈⟨ pentagon-collapse-inv ⟩∘⟨refl ⟩
+        (α⇐ ∘ id ⊗₁ α⇐) ∘ tail                       ≈⟨ pullʳ merge₂³-tail ⟩
+        α⇐ ∘ id ⊗₁ (α⇐ ∘ id ⊗₁ b₂ ∘ b₁) ∘ cup₀
+          ≈˘⟨ refl⟩∘⟨ (refl⟩⊗⟨ cup-bendˡ-nest cup₁ cup₂) ⟩∘⟨refl ⟩
+        α⇐ ∘ id ⊗₁ (id ⊗₁ α⇒ ∘ b₁₂) ∘ cup₀          ≈⟨ refl⟩∘⟨ pushˡ split₂ˡ ⟩
+        α⇐ ∘ id ⊗₁ (id ⊗₁ α⇒) ∘ id ⊗₁ b₁₂ ∘ cup₀    ≈⟨ extendʳ (⟺ α⇐-id⊗-commute) ⟩
+        (id ⊗₁ α⇒) ∘ cup-nest cup₀ (cup-nest cup₁ cup₂)  ∎
+
+  abstract
+    ⊗-cup-assoc :
+      (α⇒ {X} {Y} {Z} ⊗₁ id)
+        ∘ (id ⊗₁ (id ⊗₁ ⁻¹-flip-⊗⁻¹)) ∘ ⊗-cup
+      ≈ (id ⊗₁ α⇒) ∘ (id ⊗₁ (⁻¹-flip-⊗⁻¹ ⊗₁ id)) ∘ ⊗-cup
+    ⊗-cup-assoc = begin
+      (α⇒ ⊗₁ id) ∘ (id ⊗₁ (id ⊗₁ ⁻¹-flip-⊗⁻¹)) ∘ ⊗-cup  ≈⟨ refl⟩∘⟨ ⊗-cup-nest₁ ⊗-cup ⟩
+      (α⇒ ⊗₁ id) ∘ cup-nest ⊗-cup η                       ≈⟨ cup-nest-assoc η η η ⟩
+      (id ⊗₁ α⇒) ∘ cup-nest η ⊗-cup                       ≈˘⟨ refl⟩∘⟨ ⊗-cup-nest₂ ⊗-cup ⟩
+      (id ⊗₁ α⇒) ∘ (id ⊗₁ (⁻¹-flip-⊗⁻¹ ⊗₁ id)) ∘ ⊗-cup  ∎
+
+    ⁻¹-flip-⊗⁻¹-assoc :
+      (id {Z ⁻¹} ⊗₁ ⁻¹-flip-⊗⁻¹ {X} {Y}) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ α⇒
+      ≈ α⇒ ∘ (⁻¹-flip-⊗⁻¹ ⊗₁ id) ∘ ⁻¹-flip-⊗⁻¹
+    ⁻¹-flip-⊗⁻¹-assoc = cupᵀ-unique (begin
+      (id ⊗₁ ((id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ α⇒)) ∘ η
+        ≈⟨ ⊗-cup-dual ⟩
+      (α⇒ ⊗₁ id) ∘ (id ⊗₁ (id ⊗₁ ⁻¹-flip-⊗⁻¹)) ∘ ⊗-cup  ≈⟨ ⊗-cup-assoc ⟩
+      (id ⊗₁ α⇒) ∘ (id ⊗₁ (⁻¹-flip-⊗⁻¹ ⊗₁ id)) ∘ ⊗-cup
+        ≈˘⟨ refl⟩∘⟨ (refl⟩∘⟨ cupᵀ-η ⊗-cup) ⟩
+      (id ⊗₁ α⇒) ∘ (id ⊗₁ (⁻¹-flip-⊗⁻¹ ⊗₁ id)) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η
+        ≈⟨ refl⟩∘⟨ pullˡ merge₂ˡ ⟩
+      (id ⊗₁ α⇒) ∘ (id ⊗₁ ((⁻¹-flip-⊗⁻¹ ⊗₁ id) ∘ ⁻¹-flip-⊗⁻¹)) ∘ η  ≈⟨ pullˡ merge₂ˡ ⟩
+      (id ⊗₁ (α⇒ ∘ (⁻¹-flip-⊗⁻¹ ⊗₁ id) ∘ ⁻¹-flip-⊗⁻¹)) ∘ η  ∎)
+
+    ⁻¹-flip-⊗⁻¹-unitaryˡ : (id {X ⁻¹} ⊗₁ _≅_.to ⁻¹-unit-iso) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ λ⇒ ≈ ρ⇐
+    ⁻¹-flip-⊗⁻¹-unitaryˡ = cupᵀ-unique (begin
+      (id ⊗₁ ((id ⊗₁ _≅_.to ⁻¹-unit-iso) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ λ⇒)) ∘ η
+        ≈⟨ ⊗-cup-dual ⟩
+      (λ⇒ ⊗₁ id) ∘ (id ⊗₁ (id ⊗₁ _≅_.to ⁻¹-unit-iso)) ∘ ⊗-cup
+        ≈⟨ refl⟩∘⟨ ⊗-cup-nest₁ λ⇐ ⟩
+      (λ⇒ ⊗₁ id) ∘ cup-nest λ⇐ η
+        ≈⟨ pullˡ λ⇒-assoc ⟩
+      λ⇒ ∘ (id ⊗₁ cupˡ) ∘ λ⇐                 ≈⟨ extendʳ unitorˡ-commute-from ⟩
+      cupˡ ∘ λ⇒ ∘ λ⇐                         ≈⟨ elimʳ unitorˡ.isoʳ ⟩
+      cupˡ                                    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ coherence-inv₃ ⟩
+      α⇒ ∘ (η ⊗₁ id) ∘ ρ⇐                   ≈˘⟨ refl⟩∘⟨ unitorʳ-commute-to ⟩
+      α⇒ ∘ ρ⇐ ∘ η                            ≈⟨ pullˡ (⟺ ρ⇐-assoc) ⟩
+      (id ⊗₁ ρ⇐) ∘ η                        ∎)
+
+    ⁻¹-flip-⊗⁻¹-unitaryʳ : (_≅_.to ⁻¹-unit-iso ⊗₁ id {X ⁻¹}) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ ρ⇒ ≈ λ⇐
+    ⁻¹-flip-⊗⁻¹-unitaryʳ = cupᵀ-unique (begin
+      (id ⊗₁ ((_≅_.to ⁻¹-unit-iso ⊗₁ id) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ ρ⇒)) ∘ η
+        ≈⟨ ⊗-cup-dual ⟩
+      (ρ⇒ ⊗₁ id) ∘ (id ⊗₁ (_≅_.to ⁻¹-unit-iso ⊗₁ id)) ∘ ⊗-cup
+        ≈⟨ refl⟩∘⟨ ⊗-cup-nest₂ λ⇐ ⟩
+      (ρ⇒ ⊗₁ id) ∘ cup-nest η λ⇐
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ (refl⟩⊗⟨ pullˡ λ⇐-assoc) ⟩∘⟨refl ⟩
+      (ρ⇒ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ (λ⇐ ∘ λ⇐)) ∘ η
+        ≈⟨ pullˡ (⟺ (switch-fromtoʳ associator triangle)) ⟩
+      (id ⊗₁ λ⇒) ∘ (id ⊗₁ (λ⇐ ∘ λ⇐)) ∘ η       ≈⟨ pullˡ merge₂ˡ ⟩
+      (id ⊗₁ (λ⇒ ∘ (λ⇐ ∘ λ⇐))) ∘ η             ≈⟨ (refl⟩⊗⟨ cancelˡ unitorˡ.isoʳ) ⟩∘⟨refl ⟩
+      (id ⊗₁ λ⇐) ∘ η                            ∎)
+
+    ⁻¹-flip-⊗-cup : (id {X ⊗₀ Y} ⊗₁ ⁻¹-flip-⊗) ∘ ⊗-cup ≈ η
+    ⁻¹-flip-⊗-cup = capᵀ-cup ⊗-snakeˡ
+
+    ⁻¹-flip-⊗-cap : ε {X ⊗₀ Y} ∘ (⁻¹-flip-⊗ ⊗₁ id) ≈ ⊗-cap
+    ⁻¹-flip-⊗-cap = capᵀ-ε ⊗-cap
+
+  private abstract
+    snakeʳ : [ X ⊗ Y ]⁻¹ ⇒ [ X ⊗ Y ]⁻¹
+    snakeʳ = λ⇒ ∘ (⊗-cap ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ ⊗-cup) ∘ ρ⇐
+
+    snakeʳ-cap : ([ X ⊗ Y ]⁻¹ ⊗₀ (X ⊗₀ Y)) ⊗₀ [ X ⊗ Y ]⁻¹ ⇒ unit ⊗₀ [ X ⊗ Y ]⁻¹
+    snakeʳ-cap = (ε ⊗₁ id) ∘ ((id ⊗₁ capˡ) ⊗₁ id) ∘ (α⇒ ⊗₁ id)
+
+    nested-cup : unit ⇒ X ⊗₀ (Y ⊗₀ [ X ⊗ Y ]⁻¹)
+    nested-cup {X} = (id ⊗₁ cupˡ {X = X ⁻¹}) ∘ η
+
+    -- `id ⊗₁ ⊗-cup` with only its leading associator split off — the shape
+    -- `⊗-snakeʳ` produces (via `split₂ˡ`) and `snakeʳ-core-fold` consumes.
+    snakeʳ-cup : [ X ⊗ Y ]⁻¹ ⊗₀ unit ⇒ [ X ⊗ Y ]⁻¹ ⊗₀ ((X ⊗₀ Y) ⊗₀ [ X ⊗ Y ]⁻¹)
+    snakeʳ-cup = (id ⊗₁ α⇐) ∘ (id ⊗₁ nested-cup)
+
+    nested-cap : ([ X ⊗ Y ]⁻¹ ⊗₀ (X ⊗₀ Y)) ⊗₀ [ X ⊗ Y ]⁻¹ ⇒ (Y ⁻¹ ⊗₀ Y) ⊗₀ [ X ⊗ Y ]⁻¹
+    nested-cap = ((id ⊗₁ capˡ) ∘ α⇒) ⊗₁ id
+
+    snakeʳ-core : [ X ⊗ Y ]⁻¹ ⇒ (Y ⁻¹ ⊗₀ Y) ⊗₀ [ X ⊗ Y ]⁻¹
+    snakeʳ-core = nested-cap ∘ α⇐ ∘ snakeʳ-cup ∘ ρ⇐
+
+    nested-cap-slide : nested-cap {X} {Y} ∘ α⇐ ∘ (id {[ X ⊗ Y ]⁻¹} ⊗₁ α⇐)
+      ≈ α⇐ ∘ (id ⊗₁ capˡ) ∘ α⇒
+    nested-cap-slide = begin
+      nested-cap ∘ α⇐ ∘ (id ⊗₁ α⇐)  ≈⟨ cap-slideʳ ⟩
+      α⇐ ∘ (id ⊗₁ ((capˡ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐))) ∘ α⇒
+        ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ cap-bendˡ-assoc ε ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ capˡ) ∘ α⇒        ∎
+
+    snakeʳ-core-fold : snakeʳ-core {X} {Y} ≈ α⇐ ∘ (id ⊗₁ cupˡ)
+    snakeʳ-core-fold = begin
+      snakeʳ-core                                                  ≈⟨ refl⟩∘⟨ assoc²δα ⟩
+      nested-cap ∘ (((α⇐ ∘ (id ⊗₁ α⇐)) ∘ (id ⊗₁ nested-cup)) ∘ ρ⇐)
+        ≈⟨ pull-first nested-cap-slide ⟩
+      (α⇐ ∘ (id ⊗₁ capˡ) ∘ α⇒) ∘ ((id ⊗₁ nested-cup) ∘ ρ⇐)          ≈⟨ assoc²βε ⟩
+      α⇐ ∘ (id ⊗₁ capˡ) ∘ (α⇒ ∘ cup-openʳ nested-cup)
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cup-openʳ-natural ⟩
+      α⇐ ∘ (id ⊗₁ capˡ) ∘ (id ⊗₁ cup-openʳ nested-cup)              ≈⟨ refl⟩∘⟨ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ (capˡ ∘ (id ⊗₁ nested-cup) ∘ ρ⇐))
+        ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ cupᵀ-unbend ⟩
+      α⇐ ∘ (id ⊗₁ cupˡ)                                             ∎
+
+    ⊗-snakeʳ : λ⇒ ∘ (⊗-cap {X} {Y} ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ ⊗-cup) ∘ ρ⇐ ≈ id
+    ⊗-snakeʳ = begin
+      snakeʳ
+        ≈⟨ refl⟩∘⟨ split₁³ ⟩∘⟨ refl⟩∘⟨ split₂ˡ ⟩∘⟨refl ⟩
+      λ⇒ ∘ snakeʳ-cap ∘ α⇐ ∘ snakeʳ-cup ∘ ρ⇐
+        ≈⟨ refl⟩∘⟨ (refl⟩∘⟨ merge₁ˡ) ⟩∘⟨refl ⟩
+      λ⇒ ∘ ((ε ⊗₁ id) ∘ nested-cap) ∘ α⇐ ∘ snakeʳ-cup ∘ ρ⇐  ≈⟨ refl⟩∘⟨ assoc ⟩
+      λ⇒ ∘ (ε ⊗₁ id) ∘ snakeʳ-core                          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ snakeʳ-core-fold ⟩
+      λ⇒ ∘ (ε ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ cupˡ)                    ≈⟨ assoc²εα ⟩
+      capˡ ∘ (id ⊗₁ cupˡ)                                   ≈⟨ snakeˡ-dual ⟩
+      id                                                    ∎
+
+  -- `Y ⁻¹ ⊗₀ X ⁻¹` and the chosen dual `(X ⊗₀ Y) ⁻¹` are both left duals of
+  -- `X ⊗₀ Y` — the former via `⊗-cup`/`⊗-cap` (with snakes `⊗-snakeˡ`/`⊗-snakeʳ`),
+  -- the latter canonically — so the flip isomorphism is just an instance of the
+  -- uniqueness of left duals.  Its `from`/`to` are `⁻¹-flip-⊗`/`⁻¹-flip-⊗⁻¹`.
+  ⁻¹-flip-⊗-iso : [ X ⊗ Y ]⁻¹ ≅ (X ⊗₀ Y) ⁻¹
+  ⁻¹-flip-⊗-iso = dual-uniqueˡ ⊗-cup ⊗-cap ⊗-snakeˡ ⊗-snakeʳ
+
+module Right (R : RightRigid) where
+  open RigidDual monoidal-Op (rigidʳ-Op R) public

--- a/src/Categories/Category/Monoidal/Rigid/Symmetry.agda
+++ b/src/Categories/Category/Monoidal/Rigid/Symmetry.agda
@@ -1,0 +1,359 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Consequences of a symmetric monoidal structure for rigid monoidal categories:
+-- * A left rigid structure induces a right rigid structure, and vice versa.
+--   (This makes any symmetric rigid monoidal category a compact closed category.)
+-- * The left and right duals of an object are isomorphic, and the isomorphism is natural.
+-- * The dual of the dual of an object is canonically isomorphic to the original object
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Category.Monoidal.Symmetric using (Symmetric)
+
+module Categories.Category.Monoidal.Rigid.Symmetry
+    {o ℓ e} {C : Category o ℓ e}
+    (M : Monoidal C) (S : Symmetric M) where
+
+open import Categories.Category.Monoidal.Rigid using (LeftRigid; RightRigid)
+
+open Category C
+open Monoidal M
+open Symmetric S using (braided; commutative)
+import Categories.Category.Monoidal.Utilities M as MonUtil
+open import Categories.Category.Monoidal.Braided.Properties braided
+  renaming (module Shorthands to BraidShorthands)
+import Categories.Category.Monoidal.Braided.Properties as BraidedProperties
+import Categories.Category.Monoidal.Construction.Reverse as Reverse
+import Categories.Category.Monoidal.Interchange.Symmetric as SymmetricInterchange
+import Categories.Category.Monoidal.Rigid.Dual as RigidDual
+import Categories.Category.Monoidal.Rigid.Properties as RigidPropertiesModule
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Category.Monoidal.Properties M using (coherence-inv₃)
+open import Categories.Category.Monoidal.Reassociation M
+  using (α⇐-id⊗-commute; whisker-comm)
+open import Categories.Category.Monoidal.CupCap M
+  using ( cup-bendˡ; cup-bendˡ-resp; cup-bendˡ-⊗; cup-openˡ; cup-openʳ
+        ; parallel-cups-commute )
+open import Categories.Category.Monoidal.Symmetric.Properties S
+  using (braiding-selfInverse; cup-swap; middle-braid; mirrorˡ)
+open import Categories.Morphism.Reasoning C
+open import Categories.Morphism C using (_≅_; module ≅)
+
+open MonUtil.Shorthands
+open BraidShorthands
+
+private
+  module Interchange = SymmetricInterchange S
+  module RevProps = BraidedProperties (Reverse.Reverse-Braided braided)
+  open Interchange using (swapInner-braiding′)
+
+  variable
+    A B X Y Z : Obj
+
+  i⇒ : (A ⊗₀ B) ⊗₀ (X ⊗₀ Y) ⇒ (A ⊗₀ X) ⊗₀ (B ⊗₀ Y)
+  i⇒ = _≅_.from Interchange.swapInner-iso
+
+  mirror-assoc : (id {X} ⊗₁ σ⇒ {Z} {Y})
+                  ∘ σ⇐ {X} {Z ⊗₀ Y} ∘ α⇐
+                  ∘ σ⇐ {Z} {Y ⊗₀ X} ∘ (σ⇒ ⊗₁ id)
+                  ≈ α⇒
+  mirror-assoc = begin
+    id ⊗₁ σ⇒ ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ σ⇒ ⊗₁ id  ≈⟨ extendʳ mirrorˡ ⟩
+    σ⇒ ∘ σ⇒ ⊗₁ id ∘ α⇐ ∘ σ⇐ ∘ σ⇒ ⊗₁ id
+      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ braiding-selfInverse ⟩⊗⟨refl ⟩
+    σ⇒ ∘ σ⇒ ⊗₁ id ∘ α⇐ ∘ σ⇐ ∘ σ⇐ ⊗₁ id
+      ≈⟨ RevProps.assoc-reverse ⟩
+    α⇒ ∎
+
+  module Transpose {A B Y} {ε : A ⊗₀ Y ⇒ unit} {η : unit ⇒ Y ⊗₀ B} where
+    ε-split : id {B} ⊗₁ ε ≈ (id ⊗₁ (ε ∘ σ⇒)) ∘ (id ⊗₁ σ⇒)
+    ε-split = begin
+      id ⊗₁ ε                     ≈⟨ refl⟩⊗⟨ introʳ commutative ⟩
+      id ⊗₁ (ε ∘ (σ⇒ ∘ σ⇒))       ≈⟨ refl⟩⊗⟨ sym-assoc ⟩
+      id ⊗₁ ((ε ∘ σ⇒) ∘ σ⇒)       ≈⟨ split₂ˡ ⟩
+      id ⊗₁ (ε ∘ σ⇒) ∘ id ⊗₁ σ⇒   ∎
+
+    η-split : η ⊗₁ id {A} ≈ (σ⇒ ⊗₁ id) ∘ ((σ⇒ ∘ η) ⊗₁ id)
+    η-split = begin
+      η ⊗₁ id                     ≈⟨ introˡ commutative ⟩⊗⟨refl ⟩
+      ((σ⇒ ∘ σ⇒) ∘ η) ⊗₁ id       ≈⟨ assoc ⟩⊗⟨refl ⟩
+      (σ⇒ ∘ (σ⇒ ∘ η)) ⊗₁ id       ≈⟨ split₁ˡ ⟩
+      σ⇒ ⊗₁ id ∘ (σ⇒ ∘ η) ⊗₁ id   ∎
+
+    η′ : unit ⊗₀ A ⇒ (B ⊗₀ Y) ⊗₀ A
+    η′ = (σ⇒ ∘ η) ⊗₁ id
+
+    -- Reassociate the braided snake so its core matches `mirror-assoc`.
+    braid-tail : (id ⊗₁ σ⇒) ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ (σ⇒ ⊗₁ id) ∘ η′ ≈ α⇒ ∘ η′
+    braid-tail = begin
+      id ⊗₁ σ⇒ ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ σ⇒ ⊗₁ id ∘ η′     ≈⟨ reassoc-tail₆ ⟩
+      (id ⊗₁ σ⇒ ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ σ⇒ ⊗₁ id) ∘ η′   ≈⟨ mirror-assoc ⟩∘⟨refl ⟩
+      α⇒ ∘ η′                                     ∎
+
+    middle : (id ⊗₁ ε) ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ (η ⊗₁ id)
+             ≈ (id ⊗₁ (ε ∘ σ⇒)) ∘ α⇒ ∘ ((σ⇒ ∘ η) ⊗₁ id)
+    middle = begin
+      id ⊗₁ ε ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ η ⊗₁ id
+        ≈⟨ pushˡ ε-split ⟩
+      id ⊗₁ (ε ∘ σ⇒) ∘ id ⊗₁ σ⇒ ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ η ⊗₁ id
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ η-split ⟩
+      id ⊗₁ (ε ∘ σ⇒) ∘ id ⊗₁ σ⇒ ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ σ⇒ ⊗₁ id ∘ η′
+        ≈⟨ refl⟩∘⟨ braid-tail ⟩
+      id ⊗₁ (ε ∘ σ⇒) ∘ α⇒ ∘ η′ ∎
+
+    middle-slide : (id ⊗₁ ε) ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ cup-openˡ η
+                   ≈ (id ⊗₁ (ε ∘ σ⇒)) ∘ cup-bendˡ (σ⇒ ∘ η)
+    middle-slide = begin
+      id ⊗₁ ε ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ cup-openˡ η             ≈⟨ reassoc-tail₆ ⟩
+      (id ⊗₁ ε ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ η ⊗₁ id) ∘ λ⇐         ≈⟨ middle ⟩∘⟨refl ⟩
+      (id ⊗₁ (ε ∘ σ⇒) ∘ α⇒ ∘ (σ⇒ ∘ η) ⊗₁ id) ∘ λ⇐     ≈⟨ assoc²βε ⟩
+      id ⊗₁ (ε ∘ σ⇒) ∘ cup-bendˡ (σ⇒ ∘ η)              ∎
+
+transposeˡ⇒ʳ : {ε : A ⊗₀ Y ⇒ unit} {η : unit ⇒ Y ⊗₀ B} →
+  λ⇒ ∘ (ε ⊗₁ id) ∘ α⇐ ∘ cup-openʳ η
+  ≈ ρ⇒ ∘ (id ⊗₁ (ε ∘ σ⇒)) ∘ cup-bendˡ (σ⇒ ∘ η)
+transposeˡ⇒ʳ {ε = ε} {η = η} =
+  let open Transpose {ε = ε} {η = η} in begin
+  λ⇒ ∘ ε ⊗₁ id ∘ α⇐ ∘ id ⊗₁ η ∘ ρ⇐  ≈⟨ pushˡ (⟺ inv-braiding-coherence) ⟩
+  ρ⇒ ∘ σ⇐ ∘ ε ⊗₁ id ∘ α⇐ ∘ id ⊗₁ η ∘ ρ⇐      ≈⟨ refl⟩∘⟨ extendʳ σ⇐-comm ⟩
+  ρ⇒ ∘ id ⊗₁ ε ∘ σ⇐ ∘ α⇐ ∘ id ⊗₁ η ∘ ρ⇐      ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ cup-swap ⟩
+  ρ⇒ ∘ id ⊗₁ ε ∘ σ⇐ ∘ α⇐ ∘ σ⇐ ∘ η ⊗₁ id ∘ λ⇐  ≈⟨ refl⟩∘⟨ middle-slide ⟩
+  ρ⇒ ∘ id ⊗₁ (ε ∘ σ⇒) ∘ cup-bendˡ (σ⇒ ∘ η)    ∎
+
+transposeʳ⇒ˡ : {ε : A ⊗₀ Y ⇒ unit} {η : unit ⇒ Y ⊗₀ B} →
+  ρ⇒ ∘ (id ⊗₁ (ε ∘ σ⇒)) ∘ cup-bendˡ (σ⇒ ∘ η)
+  ≈ λ⇒ ∘ (ε ⊗₁ id) ∘ α⇐ ∘ cup-openʳ η
+transposeʳ⇒ˡ = ⟺ transposeˡ⇒ʳ
+
+braid-snakeˡ : {ηₗ : unit ⇒ X ⊗₀ Y} {εₗ : Y ⊗₀ X ⇒ unit} →
+  ρ⇒ ∘ (id ⊗₁ εₗ) ∘ cup-bendˡ ηₗ                    ≈ id →
+  λ⇒ ∘ ((εₗ ∘ σ⇒) ⊗₁ id) ∘ α⇐ ∘ cup-openʳ (σ⇒ ∘ ηₗ) ≈ id
+braid-snakeˡ {ηₗ = ηₗ} {εₗ} snake = begin
+  λ⇒ ∘ (εₗ ∘ σ⇒) ⊗₁ id ∘ α⇐ ∘ cup-openʳ (σ⇒ ∘ ηₗ) ≈⟨ transposeˡ⇒ʳ ⟩
+  ρ⇒ ∘ id ⊗₁ ((εₗ ∘ σ⇒) ∘ σ⇒) ∘ cup-bendˡ (σ⇒ ∘ (σ⇒ ∘ ηₗ))
+    ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ cancelʳ commutative ⟩∘⟨refl ⟩
+  ρ⇒ ∘ id ⊗₁ εₗ ∘ cup-bendˡ (σ⇒ ∘ (σ⇒ ∘ ηₗ))
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cup-bendˡ-resp (cancelˡ commutative) ⟩
+  ρ⇒ ∘ id ⊗₁ εₗ ∘ cup-bendˡ ηₗ                    ≈⟨ snake ⟩
+  id                                              ∎
+
+braid-snakeʳ : {ηᵣ : unit ⇒ Y ⊗₀ X} {εᵣ : X ⊗₀ Y ⇒ unit} →
+  λ⇒ ∘ (εᵣ ⊗₁ id) ∘ α⇐ ∘ cup-openʳ ηᵣ               ≈ id →
+  ρ⇒ ∘ (id ⊗₁ (εᵣ ∘ σ⇒)) ∘ cup-bendˡ (σ⇒ ∘ ηᵣ)  ≈ id
+braid-snakeʳ {ηᵣ = ηᵣ} {εᵣ = εᵣ} snake = begin
+  ρ⇒ ∘ id ⊗₁ (εᵣ ∘ σ⇒) ∘ cup-bendˡ (σ⇒ ∘ ηᵣ)    ≈⟨ transposeʳ⇒ˡ ⟩
+  λ⇒ ∘ εᵣ ⊗₁ id ∘ α⇐ ∘ cup-openʳ ηᵣ             ≈⟨ snake ⟩
+  id                                            ∎
+
+left⇒right : LeftRigid M → RightRigid M
+left⇒right L = record
+  { _⁻¹ = _⁻¹
+  ; η = σ⇒ ∘ η
+  ; ε = ε ∘ σ⇒
+  ; snake₁ = braid-snakeˡ snake₁
+  ; snake₂ = braid-snakeʳ snake₂
+  }
+  where open LeftRigid L using (_⁻¹; η; ε; snake₁; snake₂)
+
+right⇒left : RightRigid M → LeftRigid M
+right⇒left R = record
+  { _⁻¹ = _⁻¹
+  ; η = σ⇒ ∘ η
+  ; ε = ε ∘ σ⇒
+  ; snake₁ = braid-snakeʳ snake₁
+  ; snake₂ = braid-snakeˡ snake₂
+  }
+  where open RightRigid R using (_⁻¹; η; ε; snake₁; snake₂)
+
+-- Both round-trips just cancel a braiding against its inverse.
+η-roundtripˡ : (L : LeftRigid M) →
+  LeftRigid.η (right⇒left (left⇒right L)) {X} ≈ LeftRigid.η L
+η-roundtripˡ L = cancelˡ commutative
+
+ε-roundtripˡ : (L : LeftRigid M) →
+  LeftRigid.ε (right⇒left (left⇒right L)) {X} ≈ LeftRigid.ε L
+ε-roundtripˡ L = cancelʳ commutative
+
+η-roundtripʳ : (R : RightRigid M) →
+  RightRigid.η (left⇒right (right⇒left R)) {X} ≈ RightRigid.η R
+η-roundtripʳ R = cancelˡ commutative
+
+ε-roundtripʳ : (R : RightRigid M) →
+  RightRigid.ε (left⇒right (right⇒left R)) {X} ≈ RightRigid.ε R
+ε-roundtripʳ R = cancelʳ commutative
+
+dual₁ˡ≈dual₁ʳ : (L : LeftRigid M) → (f : X ⇒ Y) →
+  LeftRigid.dual₁ L f ≈ RightRigid.dual₁ (left⇒right L) f
+dual₁ˡ≈dual₁ʳ L f = begin
+  dual₁ f                                                 ≈⟨ transposeˡ⇒ʳ ⟩
+  ρ⇒ ∘ (id ⊗₁ (ε ∘ σ⇒)) ∘ cup-bendˡ (σ⇒ ∘ (f ⊗₁ id ∘ η))
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cup-bendˡ-resp (extendʳ σ⇒-comm) ⟩
+  ρ⇒ ∘ (id ⊗₁ (ε ∘ σ⇒)) ∘ cup-bendˡ ((id ⊗₁ f) ∘ ηʳ)
+    ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ cup-bendˡ-⊗ ηʳ ⟩
+  ρ⇒ ∘ (id ⊗₁ (ε ∘ σ⇒)) ∘ (id ⊗₁ f ⊗₁ id) ∘ cup-bendˡ ηʳ  ∎
+  where
+    open LeftRigid L using (_⁻¹; η; ε; dual₁)
+
+    ηʳ : unit ⇒ X ⁻¹ ⊗₀ X
+    ηʳ = σ⇒ ∘ η
+
+dual₁-roundtripʳ : (R : RightRigid M) → (f : X ⇒ Y) →
+  RightRigid.dual₁ (left⇒right (right⇒left R)) f ≈ RightRigid.dual₁ R f
+dual₁-roundtripʳ R f = begin
+  RightRigid.dual₁ (left⇒right (right⇒left R)) f
+    ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ ε-roundtripʳ R ⟩∘⟨refl ⟩
+  ρ⇒ ∘ (id ⊗₁ RightRigid.ε R) ∘ (id ⊗₁ (f ⊗₁ id))
+    ∘ cup-bendˡ (RightRigid.η (left⇒right (right⇒left R)))
+    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ cup-bendˡ-resp (η-roundtripʳ R) ⟩
+  RightRigid.dual₁ R f ∎
+
+dual₁-roundtripˡ : (L : LeftRigid M) → (f : X ⇒ Y) →
+  LeftRigid.dual₁ (right⇒left (left⇒right L)) f ≈ LeftRigid.dual₁ L f
+dual₁-roundtripˡ L f = begin
+  LeftRigid.dual₁ (right⇒left (left⇒right L)) f
+    ≈⟨ dual₁ˡ≈dual₁ʳ (right⇒left (left⇒right L)) f ⟩
+  RightRigid.dual₁ (left⇒right (right⇒left (left⇒right L))) f
+    ≈⟨ dual₁-roundtripʳ (left⇒right L) f ⟩
+  RightRigid.dual₁ (left⇒right L) f
+    ≈˘⟨ dual₁ˡ≈dual₁ʳ L f ⟩
+  LeftRigid.dual₁ L f
+    ∎
+
+dual₁ʳ≈dual₁ˡ : (R : RightRigid M) → (f : X ⇒ Y) →
+  RightRigid.dual₁ R f ≈ LeftRigid.dual₁ (right⇒left R) f
+dual₁ʳ≈dual₁ˡ R f = begin
+  RightRigid.dual₁ R f                            ≈˘⟨ dual₁-roundtripʳ R f ⟩
+  RightRigid.dual₁ (left⇒right (right⇒left R)) f  ≈˘⟨ dual₁ˡ≈dual₁ʳ (right⇒left R) f ⟩
+  LeftRigid.dual₁ (right⇒left R) f                ∎
+
+-- The Drinfeld double-dual isomorphism `(X ⁻¹) ⁻¹ ≅ X`.  It holds in any braided
+-- rigid category, but the strict-left-dual route below picks up the ribbon twist
+-- `σ⇒ ∘ σ⇒`, which vanishes only under symmetry — so we prove just that case.
+--
+-- `η`/`ε` make `X ⁻¹` a left dual of `X`; braiding them makes `X` a *left* dual of
+-- `X ⁻¹` (the bends are the same, read with the two wires crossed), and uniqueness
+-- of left duals then identifies `X` with `(X ⁻¹) ⁻¹`.
+--
+--   X ⁻¹        X                X          X ⁻¹
+--     │         │                 ╲        ╱
+--     │         │                  ╲      ╱          σ⇒ ∘ η : the same bend,
+--     ╰─────────╯   ← η             ╲────╱           with the wires crossed
+--
+-- The twist is where a merely braided category would differ: undoing the crossing
+-- on the other side costs a second `σ⇒`, and `σ⇒ ∘ σ⇒ ≈ id` is exactly symmetry.
+
+-- The braiding recasts `X` (a right dual of `X ⁻¹`) as a left dual of `X ⁻¹`;
+-- uniqueness of left duals identifies it with `(X ⁻¹) ⁻¹`.
+module DoubleDualˡ (L : LeftRigid M) where
+  open LeftRigid L using (_⁻¹; η; ε; snake₁; snake₂; dual₁)
+  open import Categories.Category.Monoidal.Rigid.Dual M L
+    using (cupˡ; cupᵀ-η; cupᵀ-unique; dual-uniqueˡ; dual₁-cup)
+  module RigidProperties = RigidPropertiesModule M
+  open RigidProperties.Left L using (⊗-cup; ⁻¹-flip-⊗⁻¹)
+
+  private
+    ⊗-cup-interchange :
+      i⇒ {X} {X ⁻¹} {Y} {Y ⁻¹} ∘ (η ⊗₁ η) ∘ λ⇐ ≈ (id ⊗₁ σ⇒) ∘ ⊗-cup
+    ⊗-cup-interchange = begin
+      i⇒ ∘ (η ⊗₁ η) ∘ λ⇐
+        ≈⟨ refl⟩∘⟨ pushˡ serialize₁₂ ⟩
+      i⇒ ∘ (η ⊗₁ id) ∘ (id ⊗₁ η) ∘ λ⇐
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ unitorˡ-commute-to ⟩
+      i⇒ ∘ (η ⊗₁ id) ∘ λ⇐ ∘ η                   ≈⟨ assoc²βε ⟩
+      α⇐ ∘ (id ⊗₁ (α⇒ ∘ (σ⇒ ⊗₁ id) ∘ α⇐)) ∘ α⇒
+        ∘ (η ⊗₁ id) ∘ λ⇐ ∘ η
+        ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ parallel-cups-commute ⟩
+      α⇐ ∘ (id ⊗₁ (α⇒ ∘ (σ⇒ ⊗₁ id) ∘ α⇐))
+        ∘ (id ⊗₁ cup-openʳ η) ∘ η
+        ≈⟨ refl⟩∘⟨ pullˡ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ ((α⇒ ∘ (σ⇒ ⊗₁ id) ∘ α⇐) ∘ cup-openʳ η)) ∘ η
+        ≈⟨ refl⟩∘⟨ (refl⟩⊗⟨ (refl⟩∘⟨ cup-swap)) ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ ((α⇒ ∘ (σ⇒ ⊗₁ id) ∘ α⇐) ∘ σ⇐
+        ∘ (η ⊗₁ id) ∘ λ⇐)) ∘ η
+        ≈⟨ refl⟩∘⟨ (refl⟩⊗⟨ extendʳ middle-braid) ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ σ⇒) ∘ cupˡ)) ∘ η
+        ≈⟨ refl⟩∘⟨ pushˡ split₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ (id ⊗₁ σ⇒)) ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈˘⟨ extendʳ α⇐-id⊗-commute ⟩
+      (id ⊗₁ σ⇒) ∘ α⇐ ∘ (id ⊗₁ cupˡ) ∘ η  ∎
+
+    tensor-cup-braiding : (σ⇒ {X} {Y} ⊗₁ id {Y ⁻¹ ⊗₀ X ⁻¹}) ∘ ⊗-cup {X} {Y}
+                          ≈ (id {Y ⊗₀ X} ⊗₁ σ⇒ {X ⁻¹} {Y ⁻¹}) ∘ ⊗-cup {Y} {X}
+    tensor-cup-braiding = begin
+      (σ⇒ ⊗₁ id) ∘ ⊗-cup                    ≈⟨ intro-center idσ-σid ⟩
+      (σ⇒ ⊗₁ id) ∘ ((id ⊗₁ σ⇒ ∘ id ⊗₁ σ⇒) ∘ ⊗-cup)
+        ≈⟨ pull-first (⟺ serialize₁₂) ⟩
+      (σ⇒ ⊗₁ σ⇒) ∘ (id ⊗₁ σ⇒) ∘ ⊗-cup       ≈˘⟨ refl⟩∘⟨ ⊗-cup-interchange ⟩
+      (σ⇒ ⊗₁ σ⇒) ∘ i⇒ ∘ (η ⊗₁ η) ∘ λ⇐       ≈⟨ extendʳ swapInner-braiding′ ⟩
+      i⇒ ∘ σ⇒ ∘ (η ⊗₁ η) ∘ λ⇐               ≈⟨ refl⟩∘⟨ extendʳ σ⇒-comm ⟩
+      i⇒ ∘ (η ⊗₁ η) ∘ σ⇒ ∘ λ⇐               ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ braiding-selfInverse ⟩∘⟨refl ⟩
+      i⇒ ∘ (η ⊗₁ η) ∘ σ⇐ ∘ λ⇐               ≈⟨ refl⟩∘⟨ refl⟩∘⟨ braiding-coherence-inv ⟩
+      i⇒ ∘ (η ⊗₁ η) ∘ ρ⇐                    ≈˘⟨ refl⟩∘⟨ refl⟩∘⟨ coherence-inv₃ ⟩
+      i⇒ ∘ (η ⊗₁ η) ∘ λ⇐                    ≈⟨ ⊗-cup-interchange ⟩
+      (id ⊗₁ σ⇒) ∘ ⊗-cup                    ∎
+      where idσ-σid = ⊗-cancel identity² commutative
+
+  dual-braiding-compat : ⁻¹-flip-⊗⁻¹ {X} {Y} ∘ dual₁ σ⇒ ≈ σ⇒ ∘ ⁻¹-flip-⊗⁻¹
+  dual-braiding-compat = cupᵀ-unique (begin
+    (id ⊗₁ (⁻¹-flip-⊗⁻¹ ∘ dual₁ σ⇒)) ∘ η        ≈⟨ pushˡ split₂ˡ ⟩
+    (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ (id ⊗₁ dual₁ σ⇒) ∘ η  ≈⟨ refl⟩∘⟨ dual₁-cup ⟩
+    (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ (σ⇒ ⊗₁ id) ∘ η        ≈⟨ extendʳ (⟺ whisker-comm) ⟩
+    (σ⇒ ⊗₁ id) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η        ≈⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟩
+    (σ⇒ ⊗₁ id) ∘ ⊗-cup                          ≈⟨ tensor-cup-braiding ⟩
+    (id ⊗₁ σ⇒) ∘ ⊗-cup                          ≈˘⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟩
+    (id ⊗₁ σ⇒) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η        ≈⟨ pullˡ merge₂ˡ ⟩
+    (id ⊗₁ (σ⇒ ∘ ⁻¹-flip-⊗⁻¹)) ∘ η              ∎)
+
+  ⁻¹⁻¹≅ : (X ⁻¹) ⁻¹ ≅ X
+  ⁻¹⁻¹≅ = ≅.sym (dual-uniqueˡ (σ⇒ ∘ η) (ε ∘ σ⇒)
+                              (braid-snakeʳ snake₂) (braid-snakeˡ snake₁))
+
+  j⇒ : (X ⁻¹) ⁻¹ ⇒ X
+  j⇒ = _≅_.from ⁻¹⁻¹≅
+
+  j⇐ : X ⇒ (X ⁻¹) ⁻¹
+  j⇐ = _≅_.to ⁻¹⁻¹≅
+
+  private
+    j-cup : (id {X ⁻¹} ⊗₁ j⇒ {X}) ∘ η {X ⁻¹} ≈ σ⇒ ∘ η {X}
+    j-cup = cupᵀ-η (σ⇒ ∘ η)
+
+    double-dual-cup : (f : X ⇒ Y) →
+      (id {X ⁻¹} ⊗₁ (j⇒ {Y} ∘ dual₁ (dual₁ f))) ∘ η {X ⁻¹}
+      ≈ (id ⊗₁ (f ∘ j⇒)) ∘ η
+    double-dual-cup f = begin
+      (id ⊗₁ (j⇒ ∘ dual₁ (dual₁ f))) ∘ η            ≈⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ j⇒) ∘ (id ⊗₁ dual₁ (dual₁ f)) ∘ η      ≈⟨ refl⟩∘⟨ dual₁-cup ⟩
+      (id ⊗₁ j⇒) ∘ (dual₁ f ⊗₁ id) ∘ η              ≈⟨ extendʳ (⟺ whisker-comm) ⟩
+      (dual₁ f ⊗₁ id) ∘ (id ⊗₁ j⇒) ∘ η              ≈⟨ refl⟩∘⟨ j-cup ⟩
+      (dual₁ f ⊗₁ id) ∘ σ⇒ ∘ η                      ≈⟨ extendʳ (⟺ σ⇒-comm) ⟩
+      σ⇒ ∘ (id ⊗₁ dual₁ f) ∘ η                      ≈⟨ refl⟩∘⟨ dual₁-cup ⟩
+      σ⇒ ∘ (f ⊗₁ id) ∘ η                            ≈⟨ extendʳ σ⇒-comm ⟩
+      (id ⊗₁ f) ∘ σ⇒ ∘ η                            ≈˘⟨ refl⟩∘⟨ j-cup ⟩
+      (id ⊗₁ f) ∘ (id ⊗₁ j⇒) ∘ η                    ≈⟨ pullˡ merge₂ˡ ⟩
+      (id ⊗₁ (f ∘ j⇒)) ∘ η                          ∎
+
+  double-dual-natural : (f : X ⇒ Y) →
+    j⇒ {Y} ∘ dual₁ (dual₁ f) ≈ f ∘ j⇒ {X}
+  double-dual-natural f = cupᵀ-unique (double-dual-cup f)
+
+  double-dual-on-morphisms : (f : X ⇒ Y) →
+    dual₁ (dual₁ f) ≈ j⇐ ∘ f ∘ j⇒
+  double-dual-on-morphisms {Y = Y} f = switch-fromtoˡ (⁻¹⁻¹≅ {X = Y}) (double-dual-natural f)
+
+module DoubleDualʳ (R : RightRigid M) where
+  open RightRigid R using (_⁻¹; dual₁)
+  open DoubleDualˡ (right⇒left R) public using (⁻¹⁻¹≅; j⇒; j⇐)
+
+  private
+    module L = LeftRigid (right⇒left R)
+    module D = RigidDual M (right⇒left R)
+
+  double-dual-on-morphisms : (f : X ⇒ Y) →
+    dual₁ (dual₁ f)
+    ≈ _≅_.to (⁻¹⁻¹≅ {X = Y}) ∘ f ∘ _≅_.from (⁻¹⁻¹≅ {X = X})
+  double-dual-on-morphisms f = begin
+    dual₁ (dual₁ f)        ≈⟨ dual₁ʳ≈dual₁ˡ R (dual₁ f) ⟩
+    L.dual₁ (dual₁ f)      ≈⟨ D.dual₁-resp-≈ (dual₁ʳ≈dual₁ˡ R f) ⟩
+    L.dual₁ (L.dual₁ f)    ≈⟨ DoubleDualˡ.double-dual-on-morphisms (right⇒left R) f ⟩
+    _≅_.to ⁻¹⁻¹≅ ∘ f ∘ _≅_.from ⁻¹⁻¹≅  ∎


### PR DESCRIPTION
## Summary

Package the rigid dual calculus as monoidal and compact-closed structure.

This adds:

- a strong monoidal dualization functor into the reversed opposite category
- the symmetric monoidal upgrade and equivalence with the opposite category
- compact-closed symmetric monoidal and opposite-category bundles
- the canonical double-dual natural isomorphism `dual²≃id`

## Stack

This draft follows #538, which in turn depends on the generic monoidal
infrastructure in #539. The compact-closed record functions exposing both
handednesses of rigidity are intentionally part of #538; this PR contains only
the functorial and bundled packaging built from that calculus.

## Motivation

Dualization in a compact closed category is contravariant, reverses tensor
order, and is involutive up to the canonical double-dual isomorphism. Packaging
these facts as a strong symmetric monoidal functor and an equivalence with the
opposite category gives downstream constructions a standard categorical API
instead of requiring them to manipulate cups, caps, and tensor-dual coherence
directly.

The immediate downstream use is the canonical Joyal–Street–Verity trace on a
compact closed category.
