### PR TITLE
Add factorization structures for morphisms

### DIFF
--- a/src/Categories/Morphism/FactorizationStructure.agda
+++ b/src/Categories/Morphism/FactorizationStructure.agda
@@ -1,0 +1,24 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Level
+open import Categories.Category
+open import Categories.Morphism.Lifts using (MorphismClass)
+
+module Categories.Morphism.FactorizationStructure where
+
+
+private
+  variable
+    o ℓ e ℓℰ ℓℳ : Level
+    𝒞 : Category o ℓ e
+
+open import Categories.Morphism.FactorizationStructure.Core
+
+FactorizationStructure-syntax : (𝒞 : Category o ℓ e) → MorphismClass 𝒞 ℓℰ → MorphismClass 𝒞 ℓℳ → Set (o ⊔ ℓ ⊔ e ⊔ ℓℰ ⊔ ℓℳ)
+FactorizationStructure-syntax 𝒞 ℰ ℳ = FactorizationStructure 𝒞 ℰ ℳ
+
+syntax FactorizationStructure-syntax 𝒞 ℰ ℳ = [ ℰ , ℳ ]-structured 𝒞
+
+
+
+

--- a/src/Categories/Morphism/FactorizationStructure/Core.agda
+++ b/src/Categories/Morphism/FactorizationStructure/Core.agda
@@ -1,0 +1,74 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category
+open import Categories.Morphism.Lifts using (MorphismClass)
+
+
+-- Consider a category 𝒞 and to morphism classes ℰ and ℳ.
+-- The level of the morphism equalities is called `eq`
+-- such that the identifier `e` stays fresh for members of ℰ.
+module Categories.Morphism.FactorizationStructure.Core
+       {o ℓ eq} (𝒞 : Category o ℓ eq)
+       {ℓℰ ℓℳ} (ℰ : MorphismClass 𝒞 ℓℰ) (ℳ : MorphismClass 𝒞 ℓℳ) where
+
+open import Level
+
+open Category 𝒞
+open Definitions 𝒞
+open import Categories.Morphism.Lifts 𝒞 hiding (MorphismClass)
+open import Categories.Morphism {o} {ℓ} {eq} 𝒞 using (IsIso)
+
+private
+  variable
+    A B C D : Obj
+
+-- We write ->> / ↠ for morphisms in ℰ
+_↠_ : Obj → Obj → Set (ℓ ⊔ ℓℰ)
+_↠_ = MorphismClassMember ℰ
+
+-- We write >-> / ↣ for morphisms in ℳ
+_↣_ : Obj → Obj → Set (ℓ ⊔ ℓℳ)
+_↣_ = MorphismClassMember ℳ
+
+open MorphismClassMember using (mor)
+
+
+record Factorization (h : A ⇒ B) : Set (o ⊔ ℓ ⊔ eq ⊔ ℓℰ ⊔ ℓℳ) where
+  field
+    Im : Obj
+    e : A ↠ Im
+    m : Im ↣ B
+    m∘e≈h : mor m ∘ mor e ≈ h
+
+-- A factorization structure for morphisms in the category 𝒞,
+-- see section 14 of "Abstract and Concrete Categories - The Joy of Cats"
+-- by Adámek, Herrlich, Strecker, 2004.
+record FactorizationStructure : Set (o ⊔ ℓ ⊔ eq ⊔ ℓℰ ⊔ ℓℳ) where
+  field
+    ℰ-resp-≈ : ≈-closed ℰ
+    ℳ-resp-≈ : ≈-closed ℳ
+    -- 1. every morphism admits an (ℰ,ℳ)-factorization
+    factor : ∀ (f : A ⇒ B) → Factorization f
+    -- 2. ℰ and ℳ are closed under compositions with isomorphisms:
+    Iso∘ℰ : ∀ {h : B ⇒ C} → IsIso h → (e : A ↠ B) → ℰ (h ∘ mor e)
+    ℳ∘Iso : ∀ (m : B ↣ C) → {h : A ⇒ B} → IsIso h → ℳ (mor m ∘ h)
+    -- 3. every computative square of the form
+    --      e
+    --   A ───>> B
+    --   │     / │
+    --   │  ∃!╱  │
+    -- f │   ╱   │ g
+    --   │  ╱    │
+    --   V V     V
+    --    C >──> D
+    --      m
+    --  has a unique diagonal filler.
+    diagonalization : {f : A ⇒ C} {g : B ⇒ D} (e : A ↠ B) (m : C ↣ D)
+                      (comm : CommutativeSquare (mor e) f g (mor m))
+                      → UniqueDiagonal (mor e) f g (mor m)
+  d-unique₂ : {f : A ⇒ C} {g : B ⇒ D} (e : A ↠ B) (m : C ↣ D)
+            → (d₁ d₂ : Diagonal (mor e) f g (mor m))
+            → Diagonal.d d₁ ≈ Diagonal.d d₂
+  d-unique₂ {f = f} {g = g} e m d₁ d₂ =
+    UniqueDiagonal.unique₂ (diagonalization e m (Diagonal.comm d₁)) d₁ d₂
+

--- a/src/Categories/Morphism/FactorizationStructure/Core.agda
+++ b/src/Categories/Morphism/FactorizationStructure/Core.agda
@@ -52,7 +52,7 @@ record FactorizationStructure : Set (o ⊔ ℓ ⊔ eq ⊔ ℓℰ ⊔ ℓℳ) whe
     -- 2. ℰ and ℳ are closed under compositions with isomorphisms:
     Iso∘ℰ : ∀ {h : B ⇒ C} → IsIso h → (e : A ↠ B) → ℰ (h ∘ mor e)
     ℳ∘Iso : ∀ (m : B ↣ C) → {h : A ⇒ B} → IsIso h → ℳ (mor m ∘ h)
-    -- 3. every computative square of the form
+    -- 3. every commutative square of the form
     --      e
     --   A ───>> B
     --   │     / │

--- a/src/Categories/Morphism/FactorizationStructure/Core.agda
+++ b/src/Categories/Morphism/FactorizationStructure/Core.agda
@@ -4,7 +4,7 @@ open import Categories.Category
 open import Categories.Morphism.Lifts using (MorphismClass)
 
 
--- Consider a category 𝒞 and to morphism classes ℰ and ℳ.
+-- Consider a category 𝒞 and two morphism classes ℰ and ℳ.
 -- The level of the morphism equalities is called `eq`
 -- such that the identifier `e` stays fresh for members of ℰ.
 module Categories.Morphism.FactorizationStructure.Core

--- a/src/Categories/Morphism/FactorizationStructure/Duality.agda
+++ b/src/Categories/Morphism/FactorizationStructure/Duality.agda
@@ -1,0 +1,85 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Level
+open import Categories.Category
+open import Categories.Morphism.Lifts
+open import Categories.Morphism using (IsIso; Iso)
+
+module Categories.Morphism.FactorizationStructure.Duality where
+
+
+private
+  variable
+    ℓℰ ℓℳ : Level
+    o ℓ eq : Level
+    𝒞 : Category o ℓ eq
+    ℰ : MorphismClass 𝒞 ℓℰ
+    ℳ : MorphismClass 𝒞 ℓℳ
+
+open import Categories.Morphism.Lifts
+open import Categories.Morphism.FactorizationStructure
+open import Categories.Morphism.FactorizationStructure.Core
+
+Diagonal^op : ∀ {A B C D : Category.Obj 𝒞}
+                {e : 𝒞 [ A , B ]} {f : 𝒞 [ A , C ]}
+                {g : 𝒞 [ B , D ]} {m : 𝒞 [ C , D ]}
+                → Diagonal 𝒞 e f g m
+                → Diagonal (Category.op 𝒞) m g f e
+Diagonal^op diag = record
+  { d = diag .d
+  ; commˡ = commʳ diag
+  ; commʳ = commˡ diag
+  }
+  where open Diagonal
+
+dual-factorizations : {ℰ : MorphismClass 𝒞 ℓℰ} {ℳ : MorphismClass 𝒞 ℓℳ}
+                    → [ ℰ , ℳ ]-structured 𝒞
+                    → [ ℳ , ℰ ]-structured (Category.op 𝒞)
+dual-factorizations {𝒞 = 𝒞} factorizationstructure = record
+  { ℰ-resp-≈ = ℳ-resp-≈
+  ; ℳ-resp-≈ = ℰ-resp-≈
+  ; factor = λ f →
+           let
+             open Factorization (factor f)
+           in
+           record
+           { Im = Im
+           ; e = record { mor = m .mor ; in-class = m .in-class }
+           ; m = record { mor = e .mor ; in-class = e .in-class }
+           ; m∘e≈h = m∘e≈h
+           }
+  ; Iso∘ℰ = λ h m →
+      ℳ∘Iso
+      (record { mor = m .mor ; in-class = m .in-class })
+      (record { inv = h .inv
+              ; iso = record
+                      { isoˡ = isoʳ (h .iso)
+                      ; isoʳ = isoˡ (h .iso) } })
+  ; ℳ∘Iso = λ e h →
+      Iso∘ℰ
+      (record { inv = h .inv
+              ; iso = record
+                    { isoˡ = isoʳ (h .iso)
+                    ; isoʳ = isoˡ (h .iso)}})
+      (record { mor = e .mor ; in-class = e .in-class })
+  ; diagonalization = λ e^op m^op comm →
+      let
+        e = record { mor = m^op .mor ; in-class = m^op .in-class }
+        m = record { mor = e^op .mor ; in-class = e^op .in-class }
+        d : UniqueDiagonal 𝒞 (m^op .mor) _ _ (e^op .mor)
+        d = diagonalization e m (Equiv.sym comm)
+      in
+      record
+      { diagonal = Diagonal^op {𝒞 = 𝒞} (d .diagonal)
+      ; unique = λ v → (d. unique) (Diagonal^op v)
+      }
+  }
+  where
+    open FactorizationStructure factorizationstructure
+    open MorphismClassMember
+    open Category 𝒞
+    open IsIso
+    open Iso
+    open Diagonal
+    open UniqueDiagonal
+

--- a/src/Categories/Morphism/FactorizationStructure/Duality.agda
+++ b/src/Categories/Morphism/FactorizationStructure/Duality.agda
@@ -20,17 +20,32 @@ open import Categories.Morphism.Lifts
 open import Categories.Morphism.FactorizationStructure
 open import Categories.Morphism.FactorizationStructure.Core
 
-Diagonal^op : ∀ {A B C D : Category.Obj 𝒞}
+Diagonalᵒᵖ : ∀ {A B C D : Category.Obj 𝒞}
                 {e : 𝒞 [ A , B ]} {f : 𝒞 [ A , C ]}
                 {g : 𝒞 [ B , D ]} {m : 𝒞 [ C , D ]}
                 → Diagonal 𝒞 e f g m
                 → Diagonal (Category.op 𝒞) m g f e
-Diagonal^op diag = record
+Diagonalᵒᵖ diag = record
   { d = diag .d
   ; commˡ = commʳ diag
   ; commʳ = commˡ diag
   }
   where open Diagonal
+
+_ᵒᵖ : {p : Level} {M : MorphismClass 𝒞 p}
+      → {A B : Category.Obj 𝒞}
+      → MorphismClassMember 𝒞 M A B
+      → MorphismClassMember (Category.op 𝒞) M B A
+_ᵒᵖ f = record { mor = f .mor ; in-class = f .in-class }
+  where open MorphismClassMember
+
+
+_≅ᵒᵖ : {A B : Category.Obj 𝒞} → {h : 𝒞 [ A , B ]} → IsIso 𝒞 h → IsIso (Category.op 𝒞) h
+_≅ᵒᵖ {h = h} h-iso = record
+  { inv = inv
+  ; iso = record { isoˡ = isoʳ ; isoʳ = isoˡ }
+  }
+  where open IsIso h-iso
 
 dual-factorizations : {ℰ : MorphismClass 𝒞 ℓℰ} {ℳ : MorphismClass 𝒞 ℓℳ}
                     → [ ℰ , ℳ ]-structured 𝒞
@@ -39,47 +54,28 @@ dual-factorizations {𝒞 = 𝒞} factorizationstructure = record
   { ℰ-resp-≈ = ℳ-resp-≈
   ; ℳ-resp-≈ = ℰ-resp-≈
   ; factor = λ f →
-           let
-             open Factorization (factor f)
-           in
+           let open Factorization (factor f) in
            record
            { Im = Im
-           ; e = record { mor = m .mor ; in-class = m .in-class }
-           ; m = record { mor = e .mor ; in-class = e .in-class }
+           ; e = m ᵒᵖ
+           ; m = e ᵒᵖ
            ; m∘e≈h = m∘e≈h
            }
-  ; Iso∘ℰ = λ h m →
-      ℳ∘Iso
-      (record { mor = m .mor ; in-class = m .in-class })
-      (record { inv = h .inv
-              ; iso = record
-                      { isoˡ = isoʳ (h .iso)
-                      ; isoʳ = isoˡ (h .iso) } })
-  ; ℳ∘Iso = λ e h →
-      Iso∘ℰ
-      (record { inv = h .inv
-              ; iso = record
-                    { isoˡ = isoʳ (h .iso)
-                    ; isoʳ = isoˡ (h .iso)}})
-      (record { mor = e .mor ; in-class = e .in-class })
-  ; diagonalization = λ e^op m^op comm →
+  ; Iso∘ℰ = λ h m → ℳ∘Iso (m ᵒᵖ) (h ≅ᵒᵖ)
+  ; ℳ∘Iso = λ e h → Iso∘ℰ (h ≅ᵒᵖ) (e ᵒᵖ)
+  ; diagonalization = λ eᵒᵖ mᵒᵖ comm →
       let
-        e = record { mor = m^op .mor ; in-class = m^op .in-class }
-        m = record { mor = e^op .mor ; in-class = e^op .in-class }
-        d : UniqueDiagonal 𝒞 (m^op .mor) _ _ (e^op .mor)
-        d = diagonalization e m (Equiv.sym comm)
+        d : UniqueDiagonal 𝒞 (mᵒᵖ .mor) _ _ (eᵒᵖ .mor)
+        d = diagonalization (mᵒᵖ ᵒᵖ) (eᵒᵖ ᵒᵖ) (Equiv.sym comm)
       in
       record
-      { diagonal = Diagonal^op {𝒞 = 𝒞} (d .diagonal)
-      ; unique = λ v → (d. unique) (Diagonal^op v)
+      { diagonal = Diagonalᵒᵖ {𝒞 = 𝒞} (d .diagonal)
+      ; unique = λ v → (d .unique) (Diagonalᵒᵖ v)
       }
   }
   where
     open FactorizationStructure factorizationstructure
-    open MorphismClassMember
+    open MorphismClassMember using (mor)
     open Category 𝒞
-    open IsIso
-    open Iso
-    open Diagonal
     open UniqueDiagonal
 

--- a/src/Categories/Morphism/FactorizationStructure/Instance/Setoids.agda
+++ b/src/Categories/Morphism/FactorizationStructure/Instance/Setoids.agda
@@ -1,0 +1,211 @@
+{-# OPTIONS --without-K --safe #-}
+open import Level
+
+-- ------------------------------------------------------------------
+-- The category Setoids c ℓ has a [ Surj , Inj ]-factorization system
+-- ------------------------------------------------------------------
+
+module Categories.Morphism.FactorizationStructure.Instance.Setoids {c ℓ : Level} where
+
+open import Categories.Morphism.FactorizationStructure
+open import Categories.Category.Instance.Setoids
+open import Categories.Morphism (Setoids c ℓ) using (Epi; Mono; _≅_)
+open import Categories.Morphism.Lifts (Setoids c ℓ) using (MorphismClass; _⊆_; ≈-closed; MorphismClassMember; Diagonal; UniqueDiagonal)
+open import Categories.Morphism.Properties (Setoids c ℓ)
+open import Categories.Category
+open import Function.Bundles using (Func; _⟨$⟩_; Surjection; LeftInverse; Injection; Inverse)
+open import Data.Maybe
+open import Data.Unit
+open import Function.Definitions
+open import Relation.Binary using (Rel)
+open import Relation.Binary.Bundles using (Setoid)
+open import Relation.Binary.PropositionalEquality.Properties using (setoid)
+import Function.Construct.Composition as compose
+import Function.Construct.Constant as constant
+import Relation.Binary.Reasoning.Setoid as SetoidR
+open import Data.Product.Base
+
+open Category (Setoids c ℓ)
+open Definitions (Setoids c ℓ) using (CommutativeSquare)
+open import Categories.Morphism (Setoids c ℓ) using (IsIso; Iso; _RetractOf_)
+open MorphismClassMember
+open import Categories.Morphism.Lifts.Properties (Setoids c ℓ) using (Mono⇒UniqueDiagonal)
+
+private
+  variable
+    A B C D : Setoid c ℓ
+
+-- A helper to convert properties from `Function.Definitions` to morphism classes
+FuncClass : {p : Level}
+          → ({A : Set c} {B : Set c} (_≈₁_ : Rel A ℓ) (_≈₂_ : Rel B ℓ) → (A → B) → Set p)
+          → ({A B : Setoid c ℓ} → A ⇒ B → Set p)
+FuncClass property {A} {B} f = property (Setoid._≈_ A) (Setoid._≈_ B) (Func.to f)
+
+Surj : MorphismClass (c ⊔ ℓ)
+Surj = FuncClass Surjective
+
+Inj : MorphismClass (c ⊔ ℓ)
+Inj = FuncClass Injective
+
+-- We show that Setoids c ℓ are [ Surj , Inj ]-structured:
+open import Categories.Morphism.FactorizationStructure.Core (Setoids c ℓ) Surj Inj
+
+-- --------------------------------------------------------------------
+-- 1. Morphism classes Surj and Inj are closed under morphism equality:
+-- --------------------------------------------------------------------
+
+Surj-resp-≈ : ≈-closed Surj
+Surj-resp-≈ {Y = Y} {f} {g} f≈g f-surjective y = f-surjective y .proj₁ , λ {x'} x'≈x →
+  begin
+  g ⟨$⟩ x' ≈⟨ f≈g ⟨
+  f ⟨$⟩ x' ≈⟨ f-surjective y .proj₂ x'≈x ⟩
+  y ∎
+  where open SetoidR Y
+
+Inj-resp-≈ : ≈-closed Inj
+Inj-resp-≈ {Y = Y} {f} {g} f≈g f-injective {x} {x'} g[x]≈g[x'] =
+  f-injective (begin
+    f ⟨$⟩ x    ≈⟨ f≈g ⟩
+    g ⟨$⟩ x    ≈⟨ g[x]≈g[x'] ⟩
+    g ⟨$⟩ x'   ≈⟨ f≈g ⟨
+    f ⟨$⟩ x'   ∎)
+  where open SetoidR Y
+
+-- -----------------------------------------------------
+-- 2. Surj is closed under composition with isomorphisms
+-- -----------------------------------------------------
+
+Retract⇒Inverseʳ : (g : C ⇒ D) (g⁻¹ : D ⇒ C) → g⁻¹ RetractOf g
+        → Inverseʳ (Setoid._≈_ C) (Setoid._≈_ D) (Func.to g) (Func.to g⁻¹)
+Retract⇒Inverseʳ {C} {D} g g⁻¹ g⁻¹∘g≈id y≈g[x] = Setoid.trans C (Func.cong g⁻¹ y≈g[x]) g⁻¹∘g≈id
+
+Iso⇒Inverse : ∀ {f : A ⇒ B} → IsIso f → Inverse A B
+Iso⇒Inverse {f = f} f-inv = record
+  { to = f .to
+  ; from = inv .to
+  ; to-cong = f .cong
+  ; from-cong = inv .cong
+  ; inverse = Retract⇒Inverseʳ inv f isoʳ , Retract⇒Inverseʳ f inv isoˡ
+  }
+  where open Func
+        open IsIso f-inv
+
+Iso∘Surj⊆Surj : ∀ {h : B ⇒ C} → IsIso h → (e : MorphismClassMember Surj A B) → Surj (h ∘ mor e)
+Iso∘Surj⊆Surj {B} {C} {A} {h = h} h⁻¹ e =
+  compose.surjective (A ._≈_) (B ._≈_) (C ._≈_)
+    (e .in-class)
+    (Surjection.surjective (LeftInverse.surjection (Inverse.leftInverse (Iso⇒Inverse h⁻¹))))
+  where open Setoid
+  -- Here, we do not go via Epi, because the direction
+  -- `Epi ⊆ Surj` would require c ⊑ ℓ
+
+-- ----------------------------------------------------------------------------------
+-- 3. Inj is closed under composition with isomorphisms. Here we show that Inj ≐ Mono
+--    and then use the respective property of monomorphisms:
+-- ----------------------------------------------------------------------------------
+
+Inj⊆Mono : Inj ⊆ Mono
+Inj⊆Mono f-Inj = λ g₁ g₂ f[g₁[x]]≈f[g₂[x]] → f-Inj f[g₁[x]]≈f[g₂[x]]
+
+Mono⊆Inj : Mono ⊆ Inj
+Mono⊆Inj f-Mono {x₁} {x₂} f[x₁]≈f[x₂] =
+  f-Mono (! x₁) (! x₂) f[x₁]≈f[x₂] {x₁}
+  where
+    -- we use constant endo-functions instead of
+    -- constant functions from Data.Unit.⊤ because
+    -- the Setoid C already has the right levels
+    !_ : (Setoid.Carrier C) → (C ⇒ C)
+    !_ {C} = constant.function C C
+
+Inj∘Iso⊆Inj : ∀ (m : MorphismClassMember Inj B C) {h : A ⇒ B} → IsIso h → Inj (mor m ∘ h)
+Inj∘Iso⊆Inj m {h} h⁻¹ =
+  Mono⊆Inj {f = mor m ∘ h}
+    (Mono-∘ {f = mor m} {g = h}
+      (Inj⊆Mono {f = mor m} (m .in-class))
+      (Iso⇒Mono {f = h} (IsIso.iso h⁻¹)))
+
+-- ------------------------------------------------------
+-- 4. The actual image factorization of a Setoid function
+-- ------------------------------------------------------
+Im[_] : ∀ {X} {Y} (f : X ⇒ Y) → Setoid c ℓ
+Im[_] {X} {Y} f = record
+  { Carrier = Setoid.Carrier X
+  ; _≈_ = λ x x' → (Setoid._≈_ Y) (f ⟨$⟩ x) (f ⟨$⟩ x')
+  ; isEquivalence = record
+    { refl = λ {x} → Func.cong f (Setoid.refl X)
+    ; sym = Setoid.sym Y
+    ; trans = Setoid.trans Y
+    }
+  }
+
+Dom↠Im[_] : ∀ {X} {Y} (f : X ⇒ Y) → X ↠ Im[ f ]
+Dom↠Im[_] f = record
+  { mor = record
+    { to = λ x → x
+    ; cong = Func.cong f
+    }
+  ; in-class = λ x → x , (λ {x'} → f .Func.cong)
+  }
+
+Im[_]↣Codom : ∀ {X} {Y} (f : X ⇒ Y) → Im[ f ] ↣ Y
+Im[_]↣Codom f = record
+  { mor = record
+    { to = Func.to f
+    ; cong = λ f[x]≈f[x'] → f[x]≈f[x']
+    }
+  ; in-class = λ f[x]≈f[x'] → f[x]≈f[x']
+  }
+
+diagonalization : {f : A ⇒ C} {g : B ⇒ D} (e : A ↠ B) (m : C ↣ D)
+                  → CommutativeSquare (mor e) f g (mor m)
+                  → UniqueDiagonal (mor e) f g (mor m)
+diagonalization {A} {C} {B} {D} {f} {g} e m g∘e≈m∘f =
+  Mono⇒UniqueDiagonal (Inj⊆Mono {f = mor m} (m .in-class)) g∘e≈m∘f d m∘d≈g
+  where
+    open Setoid
+    open SetoidR D
+
+    -- consider a splitting of the surjection e
+    s : B .Carrier → A .Carrier
+    s b = proj₁ (e .in-class b)
+
+    e∘s : ∀ b → Setoid._≈_ B (mor e ⟨$⟩ (s b)) b
+    e∘s b = proj₂ (e .in-class b) (refl A)
+
+    d₀ : B .Carrier → C .Carrier
+    d₀ b = f ⟨$⟩ s b
+
+    -- one of the triangles, the other comes
+    -- automatically because m ∈ Inj ⊆ Mono
+    m∘d≈g : ∀ {b} → Setoid._≈_ D (mor m ⟨$⟩ d₀ b) (g ⟨$⟩ b)
+    m∘d≈g {b} = begin
+      mor m ⟨$⟩ d₀ b            ≡⟨⟩
+      (mor m ∘ f) ⟨$⟩ s b       ≈⟨ g∘e≈m∘f ⟨
+      g ⟨$⟩ (mor e ⟨$⟩ s b)      ≈⟨ Func.cong g (e∘s b) ⟩
+      g ⟨$⟩ (b) ∎
+
+    d : B ⇒ C
+    d = record
+      { to = d₀
+      ; cong = λ {b} {b'} b≈b' → m .in-class (begin
+             mor m ⟨$⟩ d₀ b   ≈⟨ m∘d≈g ⟩
+             g ⟨$⟩ b          ≈⟨ Func.cong g b≈b' ⟩
+             g ⟨$⟩ b'         ≈⟨ m∘d≈g ⟨
+             mor m ⟨$⟩ d₀ b'  ∎)
+      }
+
+
+[Surj,Inj]-factorizations : [ Surj , Inj ]-structured (Setoids c ℓ)
+[Surj,Inj]-factorizations = record
+  { ℰ-resp-≈ = λ {X} {Y} {f} {g} → Surj-resp-≈ {X} {Y} {f} {g}
+  ; ℳ-resp-≈ = λ {X} {Y} {f} {g} → Inj-resp-≈ {X} {Y} {f} {g}
+  ; factor = λ {X} f → record
+           { Im = Im[ f ]
+           ; e = Dom↠Im[ f ]
+           ; m = Im[ f ]↣Codom
+           ; m∘e≈h = λ {x} → Func.cong f (Setoid.refl X)
+           }
+  ; Iso∘ℰ = Iso∘Surj⊆Surj
+  ; ℳ∘Iso = Inj∘Iso⊆Inj
+  ; diagonalization = diagonalization
+  }

--- a/src/Categories/Morphism/FactorizationStructure/Properties.agda
+++ b/src/Categories/Morphism/FactorizationStructure/Properties.agda
@@ -1,0 +1,266 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category
+open import Categories.Morphism.Lifts using (MorphismClass)
+open import Relation.Unary using (_∈_)
+
+open import Categories.Morphism.FactorizationStructure.Core using (FactorizationStructure)
+
+-- Consider an ℰ,ℳ-factorization system on a category 𝒞:
+module Categories.Morphism.FactorizationStructure.Properties
+       {o ℓ eq} {𝒞 : Category o ℓ eq}
+       {ℓℰ ℓℳ} {ℰ : MorphismClass 𝒞 ℓℰ} {ℳ : MorphismClass 𝒞 ℓℳ}
+       (ℰ,ℳ-structured : FactorizationStructure 𝒞 ℰ ℳ)
+       where
+
+open import Level
+
+open import Categories.Morphism.Reasoning 𝒞
+open import Categories.Morphism.Properties 𝒞 using (id-is-iso)
+open Category 𝒞
+open Definitions 𝒞
+open import Categories.Morphism.Lifts 𝒞 hiding (MorphismClass)
+open import Categories.Morphism {o} {ℓ} {eq} 𝒞 using (IsIso)
+open import Categories.Morphism.FactorizationStructure.Core 𝒞 ℰ ℳ hiding (FactorizationStructure)
+open FactorizationStructure ℰ,ℳ-structured
+open MorphismClassMember using (mor)
+
+private
+  variable
+    A B C D : Obj
+
+open HomReasoning
+
+-- In the trivial commuting square, the identity is always a diagonal:
+id-Diagonal : ∀ (g : A ⇒ B) (f : B ⇒ C) → Diagonal g g f f
+id-Diagonal g f = record { d = id ; commˡ = identityˡ ; commʳ = identityʳ }
+
+module Lemma-ℰ∩SplitMono (e : A ↠ B) (m : B ↣ C) {f : A ⇒ C} (diag : Diagonal (mor e) id (mor m) f) where
+  open Diagonal diag
+  -- This module captures a lemma that one almost never needs when working
+  -- with factorization systems, but it is used in all the other proofs
+  -- of the basic factorization system properties:
+  --
+  -- Lemmas from section 14 of
+  -- Lemma 14.5 of
+  -- "Abstract and Concrete Categories - The Joy of Cats"
+  -- by Adámek, Herrlich, Strecker, 2004:
+  --        e
+  --     A ──>> B
+  --     │    ╱ V
+  --  id │  d╱  │ m
+  --     │  ╱   │
+  --     V └    V
+  --     A ───> C
+  --        f
+  -- we have that (1) e is an isomorphism and (2) f is in ℳ.
+  then-e-IsIso : IsIso (mor e)
+  then-e-IsIso = record
+    { inv = d
+    ; iso = record
+      { isoˡ = commˡ
+      ; isoʳ = d-unique₂ e m e∘d (id-Diagonal (mor e) (mor m))
+      }
+    }
+    where
+      -- we consider two diagonals id and e ∘ d in
+      -- the trivial square m ∘ e ≈ m ∘ e:
+      open HomReasoning
+      e∘d : Diagonal (mor e) (mor e) (mor m) (mor m)
+      e∘d = record
+        { d = mor e ∘ d
+        ; commˡ = cancelʳ commˡ
+        ; commʳ = begin
+            mor m ∘ (mor e ∘ d)  ≈⟨ extendʳ comm ⟩
+            f ∘ (id ∘ d)         ≈⟨ refl⟩∘⟨ identityˡ ⟩
+            f ∘ d                ≈⟨ commʳ ⟩
+            mor m                ∎
+        }
+
+  then-f∈ℳ : f ∈ ℳ
+  then-f∈ℳ = ℳ-resp-≈ m∘e≈f (ℳ∘Iso m then-e-IsIso)
+    where
+      m∘e≈f : mor m ∘ mor e ≈ f
+      m∘e≈f = comm ○ identityʳ
+
+module Lemma-ℳ∩SplitEpi (e : A ↠ B) (m : B ↣ C) {f : A ⇒ C} (diag : Diagonal f (mor e) id (mor m)) where
+  open Diagonal diag
+  -- The dual version of Lemma-ℰ∩SplitMono; we prove it explicitly to avoid dependencies
+  -- to Categories.Morphism.FactorizationStructure.Properties. In
+  --        f
+  --     A ───> C
+  --     │    ╱ │
+  --   e │  d╱  │ id
+  --     V  ╱   │
+  --     V └    V
+  --     A >──> C
+  --        m
+  -- we have (1) m is an isomorphism and (2) f ∈ ℰ
+  then-m-IsIso : IsIso (mor m)
+  then-m-IsIso = record
+    { inv = d
+    ; iso = record
+      { isoˡ = d-unique₂ e m d∘m (id-Diagonal (mor e) (mor m))
+      ; isoʳ = commʳ
+      }
+    }
+    where
+      -- we consider two diagonals id and e ∘ d in
+      -- the trivial square m ∘ e ≈ m ∘ e:
+      open HomReasoning
+      d∘m : Diagonal (mor e) (mor e) (mor m) (mor m)
+      d∘m = record
+        { d = d ∘ mor m
+        ; commˡ = begin
+            (d ∘ mor m) ∘ mor e ≈⟨ extendˡ comm ⟨
+            (d ∘ id) ∘ f        ≈⟨ identityʳ ⟩∘⟨refl ⟩
+            d ∘ f               ≈⟨ commˡ ⟩
+            mor e ∎
+        ; commʳ = cancelˡ commʳ
+        }
+  then-f∈ℰ : f ∈ ℰ
+  then-f∈ℰ = ℰ-resp-≈ m∘e≈f (Iso∘ℰ then-m-IsIso e)
+    where
+      m∘e≈f : mor m ∘ mor e ≈ f
+      m∘e≈f = ⟺ comm ○ identityˡ
+
+
+-- --------------------------------------------------
+-- ℰ and ℳ determine each other via (non-unique) diagonalization
+-- where one of the vertical arrows is identity
+-- --------------------------------------------------
+ℰ-orthogonal⊆ℳ : ∀ (f : A ⇒ B)
+                   → (∀ {D} (e : A ↠ D) → Lifts (mor e) f)
+                   → f ∈ ℳ
+ℰ-orthogonal⊆ℳ f f-lifts = Lemma-ℰ∩SplitMono.then-f∈ℳ e m (Filler⇒Diagonal d)
+  where
+    -- take the ℰ,ℳ-factorization
+    open Factorization (factor f)
+    -- and apply the lifting property to the ℰ-part:
+    comm : CommutativeSquare (mor e) id (mor m) f
+    comm = m∘e≈h ○ (⟺ identityʳ)
+    d : Filler comm
+    d = f-lifts e comm
+
+ℳ-orthogonal⊆ℰ : ∀ (f : A ⇒ B)
+                   → (∀ {C} (m : C ↣ B) → Lifts f (mor m))
+                   → f ∈ ℰ
+ℳ-orthogonal⊆ℰ f f-lifts = Lemma-ℳ∩SplitEpi.then-f∈ℰ e m (Filler⇒Diagonal d)
+  where
+    -- take the ℰ,ℳ-factorization
+    open Factorization (factor f)
+    -- and apply the lifting property to the ℰ-part:
+    comm : CommutativeSquare f (mor e) id (mor m)
+    comm = identityˡ ○ ⟺ m∘e≈h
+    d : Filler comm
+    d = f-lifts m comm
+
+-- -----------------------------------------
+-- Morphism Class Inclusions
+-- -----------------------------------------
+ℰ∩ℳ⊆Iso : ∀ {h : A ⇒ B} → ℰ h → ℳ h → IsIso h
+ℰ∩ℳ⊆Iso {A} {B} {h} h∈ℰ h∈ℳ = record
+  { inv = d
+  ; iso = record
+    { isoˡ = commˡ
+    ; isoʳ = commʳ
+    } }
+  where
+    -- consider the diagonal for the trivial commutative square:
+    open UniqueDiagonal (diagonalization (mor∈class h∈ℰ) (mor∈class h∈ℳ) (begin
+          id ∘ h   ≈⟨ identityˡ ⟩
+          h        ≈⟨ identityʳ ⟨
+          h ∘ id   ∎))
+
+Iso⊆ℳ : IsIso ⊆ ℳ
+Iso⊆ℳ {f = h} h⁻¹ = Lemma-ℰ∩SplitMono.then-f∈ℳ e m (record
+  { d = h⁻¹ .inv ∘ mor m
+  ; commˡ = begin
+          (h⁻¹ .inv ∘ mor m) ∘ mor e    ≈⟨ pullʳ m∘e≈h ⟩
+          h⁻¹ .inv ∘ h                  ≈⟨  h⁻¹ .isoˡ ⟩
+          id                            ∎
+  ; commʳ = cancelˡ (h⁻¹ .isoʳ)
+  })
+  where
+    -- consider a factorization of h into e and m
+    open Factorization (factor h)
+    open IsIso
+    open HomReasoning
+
+Iso⊆ℰ : IsIso ⊆ ℰ
+Iso⊆ℰ {f = h} h⁻¹ = Lemma-ℳ∩SplitEpi.then-f∈ℰ e m (record
+  { d = mor e ∘ h⁻¹ .inv
+  ; commˡ = cancelʳ (h⁻¹ .isoˡ)
+  ; commʳ = begin
+          mor m ∘ mor e ∘ h⁻¹ .inv  ≈⟨ pullˡ m∘e≈h ⟩
+          h ∘ h⁻¹ .inv              ≈⟨ h⁻¹ .isoʳ ⟩
+          id                        ∎
+  })
+  where
+    -- consider a factorization of h into e and m
+    open Factorization (factor h)
+    open IsIso
+    open HomReasoning
+
+ℳ∘ℳ⊆ℳ : (g : B ↣ C) → (f : A ↣ B) → (mor g ∘ mor f) ∈ ℳ
+ℳ∘ℳ⊆ℳ g f = Lemma-ℰ∩SplitMono.then-f∈ℳ e m d₂′
+  where
+    -- take the factorization m ∘ e = g ∘ f
+    open Factorization (factor (mor g ∘ mor f))
+    -- and then construct two diagonals:
+    --        e
+    --     A ────────>> Im
+    --     V         ⟋╱ V
+    --   id│    d₂⟋  ╱  │ m
+    --     │   ⟋    ╱d₁ │
+    --     V └     └    V
+    --     A >──> B >─> C
+    --        f      g
+    open UniqueDiagonal
+    open HomReasoning
+    d₁ : UniqueDiagonal (mor e) (mor f) (mor m) (mor g)
+    d₁ = diagonalization e g m∘e≈h
+    d₂ : UniqueDiagonal (mor e) id (d₁ .d) (mor f)
+    d₂ = diagonalization e f (begin
+      d₁ .d ∘ mor e   ≈⟨ d₁ .commˡ ⟩
+      mor f           ≈⟨ identityʳ ⟨
+      mor f ∘ id      ∎)
+    -- so d₂ is also a diagonal for the big square
+    d₂′ : Diagonal (mor e) id (mor m) (mor g ∘ mor f)
+    d₂′ = record
+       { d = d₂ .d
+       ; commˡ = d₂ .commˡ
+       ; commʳ = glueTrianglesˡ (d₁ .commʳ) (d₂ .commʳ)
+       }
+
+ℰ∘ℰ⊆ℰ : (g : B ↠ C) → (f : A ↠ B) → (mor g ∘ mor f) ∈ ℰ
+ℰ∘ℰ⊆ℰ g f = Lemma-ℳ∩SplitEpi.then-f∈ℰ e m d₂′
+  where
+    -- take the factorization m ∘ e = g ∘ f
+    open Factorization (factor (mor g ∘ mor f))
+    -- and then construct two diagonals:
+    --        f      g
+    --     A ──>> B ─>> C
+    --     │     ╱    ⟋ │
+    --    e│  d₁╱  ⟋ d₂ │ id
+    --     V   ╱ ⟋      │
+    --     V └  └       V
+    --    Im >────────> B
+    --           m
+    open UniqueDiagonal
+    open HomReasoning
+    d₁ : UniqueDiagonal (mor f) (mor e) (mor g) (mor m)
+    d₁ = diagonalization f m (⟺ m∘e≈h)
+    d₂ : UniqueDiagonal (mor g) (d₁ .d) id (mor m)
+    d₂ = diagonalization g m (begin
+      id ∘ mor g     ≈⟨ identityˡ ⟩
+      mor g          ≈⟨ d₁ .commʳ ⟨
+      mor m ∘ d₁ .d  ∎)
+    d₂′ : Diagonal (mor g ∘ mor f) (mor e) id (mor m)
+    d₂′ = record
+      { d = d₂ .d
+      ; commˡ = glueTrianglesʳ (d₂ .commˡ) (d₁ .commˡ)
+      ; commʳ = d₂ .commʳ
+      }
+
+

--- a/src/Categories/Morphism/Lifts.agda
+++ b/src/Categories/Morphism/Lifts.agda
@@ -32,6 +32,8 @@ open Definitions 𝒞
 -- For ease of use, we define lifts in two steps:
 -- * 'Filler' describes the data required to fill a /particular/ commutative square.
 -- * 'Lifts' then quantifies over all commutative squares.
+-- For the similar record parametrized only in i f g p but not 'comm',
+-- see Categories.Morphism.FactorizationStructure.Diagonal.
 
 record Filler {A B X Y} {i : A ⇒ B} {f : A ⇒ X} {g : B ⇒ Y} {p : X ⇒ Y}
               (comm : CommutativeSquare i f g p) : Set (ℓ ⊔ e) where
@@ -43,12 +45,84 @@ record Filler {A B X Y} {i : A ⇒ B} {f : A ⇒ X} {g : B ⇒ Y} {p : X ⇒ Y}
 Lifts : ∀ {A B X Y} → (i : A ⇒ B) → (p : X ⇒ Y) → Set (ℓ ⊔ e)
 Lifts i p = ∀ {f g} → (comm : CommutativeSquare i f g p) → Filler comm
 
+-- The diagonal in a square. The record does not require the square to commute
+-- but rather deduces this from the existence of the diagonal.
+-- The reason is that if the record is parametrized by a morphism equality,
+-- then record types differ if there are multiple (unequal) proofs of
+-- morphism equality. Then, properties like FactorizationStructure.d-unique₂
+-- would become more complicated. Thus, Diagonal does not use
+-- above Filler record, which is parametric in a morphism equality.
+record Diagonal {A B X Y} (i : A ⇒ B) (f : A ⇒ X)
+                (g : B ⇒ Y) (p : X ⇒ Y) : Set (ℓ ⊔ e) where
+  field
+    --      e
+    --   A ────> B
+    --   │     / │
+    --   │  d ╱  │
+    -- f │   ╱   │ g
+    --   │  ╱    │
+    --   V V     V
+    --    C ───> D
+    --      m
+    d : B ⇒ X
+    commˡ : d ∘ i ≈ f
+    commʳ : p ∘ d ≈ g
+
+  comm : CommutativeSquare i f g p
+  comm = begin
+    g ∘ i          ≈⟨ commʳ ⟩∘⟨refl ⟨
+    (p ∘ d) ∘ i    ≈⟨ assoc ⟩
+    p ∘ (d ∘ i)    ≈⟨ refl⟩∘⟨ commˡ ⟩
+    p ∘ f          ∎
+    where open HomReasoning
+
+  toFiller : Filler comm
+  toFiller = Filler.constructor d commˡ commʳ
+
+Filler⇒Diagonal : ∀ {A B X Y} {i : A ⇒ B} {f : A ⇒ X} {g : B ⇒ Y} {p : X ⇒ Y}
+                  {comm : CommutativeSquare i f g p}
+                  → Filler comm
+                  → Diagonal i f g p
+Filler⇒Diagonal f = record { d = filler ; commˡ = fill-commˡ ; commʳ = fill-commʳ }
+  where open Filler f
+
+record UniqueDiagonal {A B X Y} (i : A ⇒ B) (f : A ⇒ X)
+                      (g : B ⇒ Y) (p : X ⇒ Y) : Set (ℓ ⊔ e) where
+  field
+    diagonal : Diagonal i f g p
+  open Diagonal diagonal public
+  field
+    unique : ∀ (v : Diagonal i f g p) → d ≈ Diagonal.d v
+
+  unique₂ : ∀ (v w : Diagonal i f g p) → Diagonal.d v ≈ Diagonal.d w
+  unique₂ v w = begin
+    Diagonal.d v  ≈⟨ unique v ⟨
+    d             ≈⟨ unique w ⟩
+    Diagonal.d w  ∎
+    where open HomReasoning
+
+
 --------------------------------------------------------------------------------
 -- Lifings of Morphism Classes
 
 -- Shorthand for denoting a class of morphisms.
 MorphismClass : (p : Level) → Set (o ⊔ ℓ ⊔ suc p)
 MorphismClass p = ∀ {X Y} → X ⇒ Y → Set p
+
+_⊆_ : {p q : Level} → MorphismClass p → MorphismClass q → Set (o ⊔ ℓ ⊔ p ⊔ q)
+M ⊆ N = ∀ {X Y} → {f : X ⇒ Y} → M f → N f
+
+≈-closed : {p : Level} → (M : MorphismClass p) → Set (o ⊔ ℓ ⊔ e ⊔ p)
+≈-closed M = ∀ {X Y} → {f g : X ⇒ Y} → f ≈ g → M f → M g
+
+-- Bundled structure for members of a morphism class
+record MorphismClassMember {p : Level} (M : MorphismClass p) (A B : Obj) : Set (p ⊔ ℓ) where
+  field
+    mor : A ⇒ B
+    in-class : M mor
+
+mor∈class : ∀ {p : Level} {M : MorphismClass p} {A B : Obj} {h : A ⇒ B} → M h → MorphismClassMember M A B
+mor∈class {h = h} h∈M = record { mor = h ; in-class = h∈M }
 
 -- A morphism 'i' is called "projective" with respect to some morphism class 'J'
 -- if it has the left-lifting property against every element of 'J'.

--- a/src/Categories/Morphism/Lifts/Properties.agda
+++ b/src/Categories/Morphism/Lifts/Properties.agda
@@ -55,6 +55,47 @@ module _ {X Y T} {f : X ⇒ Y} {i : X ⇒ T} {p : T ⇒ Y} (factors : f ≈ p �
       open Filler (lifts (⟺ factors ○ ⟺ identityʳ))
 
 --------------------------------------------------------------------------------
+-- Uniqueness of Diagonals
+
+module _ {A B X Y : Obj} {i : A ⇒ B} {f : A ⇒ X}
+         {g : B ⇒ Y} {p : X ⇒ Y} where
+  Mono⇒UniqueDiagonal : Mono p
+                      → CommutativeSquare i f g p
+                      → (d : B ⇒ X)
+                      → p ∘ d ≈ g
+                      → UniqueDiagonal i f g p
+  Mono⇒UniqueDiagonal p-mono g∘i≈p∘f d p∘d≈g = record
+    { diagonal = diag
+    ; unique = λ v → p-mono d (Diagonal.d v) (diag .commʳ ○ ⟺ (v .commʳ))
+    }
+    where
+      diag : Diagonal _ _ _ _
+      diag = record
+        { d = d
+        ; commˡ = p-mono (d ∘ i) f (pullˡ p∘d≈g ○ g∘i≈p∘f)
+        ; commʳ = p∘d≈g
+        }
+      open Diagonal hiding (d)
+
+  Epi⇒UniqueDiagonal : Epi i
+                     → CommutativeSquare i f g p
+                     → (d : B ⇒ X)
+                     → d ∘ i ≈ f
+                     → UniqueDiagonal i f g p
+  Epi⇒UniqueDiagonal p-epi g∘i≈p∘f d d∘i≈f = record
+    { diagonal = diag
+    ; unique = λ v → p-epi d (Diagonal.d v) (diag .commˡ ○ ⟺ (v .commˡ))
+    }
+    where
+      diag : Diagonal _ _ _ _
+      diag = record
+        { d = d
+        ; commˡ = d∘i≈f
+        ; commʳ = p-epi (p ∘ d) g (pullʳ d∘i≈f ○ ⟺ g∘i≈p∘f)
+        }
+      open Diagonal hiding (d)
+
+--------------------------------------------------------------------------------
 -- Closure Properties of Injective and Projective morphisms.
 
 module _ {j} (J : MorphismClass j) where


### PR DESCRIPTION
This introduces the ℰ,ℳ-factorizations of morphisms in a category, following the definitions of the Adámek, Herrlich, Strecker book ("Joy of cats"). The record FactorizationStructure is Definition 14.1 of that book, together with the properties that the morphism classes ℰ and ℳ are each closed under morphism equality _≈_.

Beside the definition, the following concepts and results are added:

* Categories.Morphism.Lifts:
    * A new record `Diagonal`, which is like `Filler` but does not depend on a commutativity proof.
    * `MorphismClass` inclusion `_⊆_` and closure under morphism equality
    * A new record `MorphismClassMember` that allows a uniform treatment of morphisms in Epi, Mono, etc
* Categories.Morphism.FactorizationStructure.Core: The main definitions for a category 𝒞 and given morphism classes ℰ and ℳ
* Categories.Morphism.FactorizationStructure: The property of a category 𝒞 being [ ℰ , ℳ ]-structured
* Categories.Morphism.FactorizationStructure.Properties: Proofs of ℰ ∩ ℳ = Iso, ℰ∘ℰ⊆ℰ, ℳ∘ℳ⊆ℳ and that ℰ and ℳ determine each other by diagonalization.
* Categories.Morphism.FactorizationStructure.Duality: If 𝒞 is [ ℰ , ℳ ]-structured, then 𝒞ᵒᵖ is [ ℳ , ℰ ]-structured.
* Categories.Morphism.FactorizationStructure.Instance.Setoids: The category Setoids c ℓ is [ Surj , Inj ]-structured, where Surj resp. Inj are the classes of surjections resp. injections.