### PR TITLE
Add the definition of factorization systems

### DIFF
--- a/src/Categories/Morphism/FactorizationSystem/Core.agda
+++ b/src/Categories/Morphism/FactorizationSystem/Core.agda
@@ -1,0 +1,72 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category
+open import Categories.Morphism.Lifts using (MorphismClass)
+
+
+-- Consider a category 𝒞 and two morphism classes ℰ and ℳ.
+-- The level of the morphism equalities is called `eq`
+-- such that the identifier `e` stays fresh for members of ℰ.
+module Categories.Morphism.FactorizationSystem.Core
+       {o ℓ eq} (𝒞 : Category o ℓ eq)
+       {ℓℰ ℓℳ} (ℰ : MorphismClass 𝒞 ℓℰ) (ℳ : MorphismClass 𝒞 ℓℳ) where
+
+open import Level
+
+open Category 𝒞
+open Definitions 𝒞 using (CommutativeSquare)
+open import Categories.Morphism.Lifts 𝒞 using (MorphismClassMember; ≈-closed; UniqueDiagonal; Diagonal)
+open import Categories.Morphism {o} {ℓ} {eq} 𝒞 using (IsIso)
+open MorphismClassMember using (mor)
+
+private
+  variable
+    A B C D : Obj
+
+-- We write ->> / ↠ for morphisms in ℰ
+_↠_ : Obj → Obj → Set (ℓ ⊔ ℓℰ)
+_↠_ = MorphismClassMember ℰ
+
+-- We write >-> / ↣ for morphisms in ℳ
+_↣_ : Obj → Obj → Set (ℓ ⊔ ℓℳ)
+_↣_ = MorphismClassMember ℳ
+
+record Factorization (h : A ⇒ B) : Set (o ⊔ ℓ ⊔ eq ⊔ ℓℰ ⊔ ℓℳ) where
+  field
+    Im : Obj
+    e : A ↠ Im
+    m : Im ↣ B
+    m∘e≈h : mor m ∘ mor e ≈ h
+
+-- A factorization system (also called factorization structure) for
+-- morphisms in the category 𝒞, see section 14 of "Abstract and
+-- Concrete Categories - The Joy of Cats" by Adámek, Herrlich, Strecker, 2004.
+record FactorizationSystem : Set (o ⊔ ℓ ⊔ eq ⊔ ℓℰ ⊔ ℓℳ) where
+  field
+    ℰ-resp-≈ : ≈-closed ℰ
+    ℳ-resp-≈ : ≈-closed ℳ
+    -- 1. every morphism admits an (ℰ,ℳ)-factorization
+    factor : ∀ (f : A ⇒ B) → Factorization f
+    -- 2. ℰ and ℳ are closed under compositions with isomorphisms:
+    Iso∘ℰ : ∀ {h : B ⇒ C} → IsIso h → (e : A ↠ B) → ℰ (h ∘ mor e)
+    ℳ∘Iso : ∀ (m : B ↣ C) → {h : A ⇒ B} → IsIso h → ℳ (mor m ∘ h)
+    -- 3. every commutative square of the form
+    --      e
+    --   A ───>> B
+    --   │     / │
+    --   │  ∃!╱  │
+    -- f │   ╱   │ g
+    --   │  ╱    │
+    --   V V     V
+    --    C >──> D
+    --      m
+    --  has a unique diagonal filler.
+    diagonal-filler : {f : A ⇒ C} {g : B ⇒ D} (e : A ↠ B) (m : C ↣ D)
+                      (comm : CommutativeSquare (mor e) f g (mor m))
+                      → UniqueDiagonal (mor e) f g (mor m)
+  diag-unique₂ : {f : A ⇒ C} {g : B ⇒ D} (e : A ↠ B) (m : C ↣ D)
+            → (d₁ d₂ : Diagonal (mor e) f g (mor m))
+            → Diagonal.d d₁ ≈ Diagonal.d d₂
+  diag-unique₂ {f = f} {g = g} e m d₁ d₂ =
+    UniqueDiagonal.unique₂ (diagonal-filler e m (Diagonal.comm d₁)) d₁ d₂
+

--- a/src/Categories/Morphism/FactorizationSystem/Core.agda
+++ b/src/Categories/Morphism/FactorizationSystem/Core.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --without-K --safe #-}
 
-open import Categories.Category
+open import Categories.Category.Core using (Category)
 open import Categories.Morphism.Lifts using (MorphismClass)
 
 

--- a/src/Categories/Morphism/FactorizationSystem/Core.agda
+++ b/src/Categories/Morphism/FactorizationSystem/Core.agda
@@ -1,6 +1,7 @@
 {-# OPTIONS --without-K --safe #-}
 
 open import Categories.Category.Core using (Category)
+open import Categories.Category using (module Definitions)
 open import Categories.Morphism.Lifts using (MorphismClass)
 
 

--- a/src/Categories/Morphism/FactorizationSystem/Core.agda
+++ b/src/Categories/Morphism/FactorizationSystem/Core.agda
@@ -14,10 +14,10 @@ module Categories.Morphism.FactorizationSystem.Core
 
 open import Level
 
-open Category 𝒞
-open Definitions 𝒞 using (CommutativeSquare)
 open import Categories.Morphism.Lifts 𝒞 using (MorphismClassMember; ≈-closed; UniqueDiagonal; Diagonal)
 open import Categories.Morphism {o} {ℓ} {eq} 𝒞 using (IsIso)
+open Category 𝒞
+open Definitions 𝒞 using (CommutativeSquare)
 open MorphismClassMember using (mor)
 
 private

--- a/src/Categories/Morphism/Lifts.agda
+++ b/src/Categories/Morphism/Lifts.agda
@@ -1,6 +1,7 @@
 {-# OPTIONS --without-K --safe #-}
 
 open import Categories.Category
+import Categories.Morphism.Reasoning
 
 -- Lifting Properties
 module Categories.Morphism.Lifts {o ℓ e} (𝒞 : Category o ℓ e) where
@@ -9,6 +10,7 @@ open import Level
 
 open Category 𝒞
 open Definitions 𝒞
+open Categories.Morphism.Reasoning 𝒞 using (pullˡ)
 
 -- A pair of morphisms has the lifting property if every commutative
 -- square admits a diagonal filler. We say that 'i' has the left lifting
@@ -42,6 +44,62 @@ record Filler {A B X Y} {i : A ⇒ B} {f : A ⇒ X} {g : B ⇒ Y} {p : X ⇒ Y}
 
 Lifts : ∀ {A B X Y} → (i : A ⇒ B) → (p : X ⇒ Y) → Set (ℓ ⊔ e)
 Lifts i p = ∀ {f g} → (comm : CommutativeSquare i f g p) → Filler comm
+-- The diagonal in a square. The record does not require the square to commute
+-- but rather deduces this from the existence of the diagonal.
+-- The reason is that if the record is parametrized by a morphism equality,
+-- then record types differ if there are multiple (unequal) proofs of
+-- morphism equality. Then, properties like FactorizationSystem.diag-unique₂
+-- would become more complicated. Thus, Diagonal does not use
+-- above Filler record, which is parametric in a morphism equality.
+record Diagonal {A B X Y} (i : A ⇒ B) (f : A ⇒ X)
+                (g : B ⇒ Y) (p : X ⇒ Y) : Set (ℓ ⊔ e) where
+  field
+    --      i
+    --   A ────> B
+    --   │     / │
+    --   │  d ╱  │
+    -- f │   ╱   │ g
+    --   │  ╱    │
+    --   V V     V
+    --    C ───> D
+    --      m
+    d : B ⇒ X
+    commˡ : d ∘ i ≈ f
+    commʳ : p ∘ d ≈ g
+
+  comm : CommutativeSquare i f g p
+  comm = begin
+    g ∘ i      ≈⟨ pullˡ commʳ ⟨
+    p ∘ d ∘ i  ≈⟨ refl⟩∘⟨ commˡ ⟩
+    p ∘ f      ∎
+    where open HomReasoning
+
+  toFiller : Filler comm
+  toFiller = Filler.constructor d commˡ commʳ
+
+Filler⇒Diagonal : ∀ {A B X Y} {i : A ⇒ B} {f : A ⇒ X} {g : B ⇒ Y} {p : X ⇒ Y}
+                  {comm : CommutativeSquare i f g p}
+                  → Filler comm
+                  → Diagonal i f g p
+Filler⇒Diagonal f = record { d = filler ; commˡ = fill-commˡ ; commʳ = fill-commʳ }
+  where open Filler f
+
+record UniqueDiagonal {A B X Y} (i : A ⇒ B) (f : A ⇒ X)
+                      (g : B ⇒ Y) (p : X ⇒ Y) : Set (ℓ ⊔ e) where
+  field
+    diagonal : Diagonal i f g p
+  open Diagonal diagonal public
+  field
+    unique : ∀ (v : Diagonal i f g p) → d ≈ Diagonal.d v
+
+  unique₂ : ∀ (v w : Diagonal i f g p) → Diagonal.d v ≈ Diagonal.d w
+  unique₂ v w = begin
+    Diagonal.d v  ≈⟨ unique v ⟨
+    d             ≈⟨ unique w ⟩
+    Diagonal.d w  ∎
+    where open HomReasoning
+
+
 
 --------------------------------------------------------------------------------
 -- Lifings of Morphism Classes
@@ -49,6 +107,15 @@ Lifts i p = ∀ {f g} → (comm : CommutativeSquare i f g p) → Filler comm
 -- Shorthand for denoting a class of morphisms.
 MorphismClass : (p : Level) → Set (o ⊔ ℓ ⊔ suc p)
 MorphismClass p = ∀ {X Y} → X ⇒ Y → Set p
+
+≈-closed : {p : Level} → (M : MorphismClass p) → Set (o ⊔ ℓ ⊔ e ⊔ p)
+≈-closed M = ∀ {X Y} → {f g : X ⇒ Y} → f ≈ g → M f → M g
+
+-- Bundled structure for members of a morphism class
+record MorphismClassMember {p : Level} (M : MorphismClass p) (A B : Obj) : Set (p ⊔ ℓ) where
+  field
+    mor : A ⇒ B
+    in-class : M mor
 
 -- A morphism 'i' is called "projective" with respect to some morphism class 'J'
 -- if it has the left-lifting property against every element of 'J'.

--- a/src/Categories/Morphism/Lifts.agda
+++ b/src/Categories/Morphism/Lifts.agda
@@ -51,8 +51,8 @@ Lifts i p = ∀ {f g} → (comm : CommutativeSquare i f g p) → Filler comm
 -- morphism equality. Then, properties like FactorizationSystem.diag-unique₂
 -- would become more complicated. Thus, Diagonal does not use
 -- above Filler record, which is parametric in a morphism equality.
-record Diagonal {A B X Y} (i : A ⇒ B) (f : A ⇒ X)
-                (g : B ⇒ Y) (p : X ⇒ Y) : Set (ℓ ⊔ e) where
+record Diagonal {A B C D} (i : A ⇒ B) (f : A ⇒ C)
+                (g : B ⇒ D) (p : C ⇒ D) : Set (ℓ ⊔ e) where
   field
     --      i
     --   A ────> B
@@ -63,7 +63,7 @@ record Diagonal {A B X Y} (i : A ⇒ B) (f : A ⇒ X)
     --   V V     V
     --    C ───> D
     --      m
-    d : B ⇒ X
+    d : B ⇒ C
     commˡ : d ∘ i ≈ f
     commʳ : p ∘ d ≈ g
 


### PR DESCRIPTION
This introduces the ℰ,ℳ-factorization system of morphisms in a category, following the definitions of the Adámek, Herrlich, Strecker book ("Joy of cats"). The record `FactorizationSystem` is Definition 14.1 of that book, together with the properties that the morphism classes ℰ and ℳ are each closed under morphism equality ≈.

Concretely, this adds the following:

* In `Categories.Morphism.Lifts`:
    * A new record `Diagonal`, which is like `Filler` but does not depend on a commutativity proof.
    * A new record `MorphismClassMember` that allows a uniform treatment of morphisms in Epi, Mono, etc.
* In `Categories.Morphism.FactorizationSystem.Core`: The main definitions of `Factorization` and `FactorizationSystem` for a category 𝒞 and morphism classes ℰ and ℳ (as module parameters).
* In `Categories.Morphism.FactorizationSystem`: Same without module parameters 𝒞, ℰ, ℳ  to define the syntax `[ ℰ , ℳ ]-structured 𝒞`.