### PR TITLE
Add tensor products of enriched categories and functors

### DIFF
--- a/src/Categories/Category/Monoidal/Interchange/Symmetric.agda
+++ b/src/Categories/Category/Monoidal/Interchange/Symmetric.agda
@@ -15,17 +15,17 @@ import Categories.Category.Construction.Core C as Core
 import Categories.Category.Monoidal.Braided.Properties as BraidedProps
 open import Categories.Category.Monoidal.Interchange using (HasInterchange)
 import Categories.Category.Monoidal.Interchange.Braided as BraidedInterchange
-  using (module swapInner; swapInner-braiding)
+  using (module swapInner; swapInner-braiding; swapInner-unitˡ)
 import Categories.Category.Monoidal.Reasoning M as MonoidalReasoning
 import Categories.Category.Monoidal.Utilities M as MonoidalUtilities
 open import Categories.Functor using (_∘F_)
 open import Categories.NaturalTransformation.NaturalIsomorphism
   using (_≃_; niHelper)
-open import Categories.Morphism.IsoEquiv C using (to-unique)
+open import Categories.Morphism.IsoEquiv C using (from-unique; to-unique)
 open import Categories.Morphism.Reasoning C
-  using (elim-center; pushˡ; pullʳ; cancelInner; switch-fromtoˡ)
+  using (elim-center; pushˡ; pullʳ; cancelʳ; cancelInner; switch-fromtoˡ)
 
-open Category C using (Obj; _⇒_; _∘_; id; sym-assoc; ∘-resp-≈ʳ; module Equiv)
+open Category C
 open Commutation C
 open MonoidalReasoning
 open MonoidalUtilities using (_⊗ᵢ_)
@@ -76,6 +76,29 @@ swapInner-selfInverse : [ (X₁ ⊗₀ X₂) ⊗₀ (Y₁ ⊗₀ Y₂) ⇒
 swapInner-selfInverse =
   to-unique (iso swapInner-iso) swapInner.iso Equiv.refl
 
+abstract
+  swapInner-unitˡ⁻¹ : [ X ⊗₀ Y ⇒ unit ⊗₀ (X ⊗₀ Y) ]⟨
+                        λ⇐ ⊗₁ λ⇐  ⇒⟨ (unit ⊗₀ X) ⊗₀ (unit ⊗₀ Y) ⟩
+                        i⇒        ⇒⟨ (unit ⊗₀ unit) ⊗₀ (X ⊗₀ Y) ⟩
+                        λ⇒ ⊗₁ id
+                      ≈ λ⇐
+                      ⟩
+  swapInner-unitˡ⁻¹ {X} {Y} = from-unique (iso unit-insert) (iso (unitorˡ ⁻¹)) unit-remove
+    where
+    split-units : X ⊗₀ Y ≅ (unit ⊗₀ X) ⊗₀ (unit ⊗₀ Y)
+    split-units = (unitorˡ ⁻¹) ⊗ᵢ (unitorˡ ⁻¹)
+
+    join-units : (unit ⊗₀ unit) ⊗₀ (X ⊗₀ Y) ≅ unit ⊗₀ (X ⊗₀ Y)
+    join-units = unitorˡ ⊗ᵢ idᵢ
+
+    unit-insert : X ⊗₀ Y ≅ unit ⊗₀ (X ⊗₀ Y)
+    unit-insert = join-units ∘ᵢ swapInner-iso ∘ᵢ split-units
+
+    module unit-insert = _≅_ unit-insert
+
+    unit-remove : [ unit ⊗₀ (X ⊗₀ Y) ⇒ X ⊗₀ Y ]⟨ unit-insert.to ≈ λ⇒ ⟩
+    unit-remove = assoc ○ swapInner-unitˡ
+
 swapInner-braiding′ : [ (W ⊗₀ X) ⊗₀ (Y ⊗₀ Z) ⇒ (Y ⊗₀ W) ⊗₀ (Z ⊗₀ X) ]⟨
                         i⇒         ⇒⟨ (W ⊗₀ Y) ⊗₀ (X ⊗₀ Z) ⟩
                         σ⇒ ⊗₁ σ⇒
@@ -83,3 +106,27 @@ swapInner-braiding′ : [ (W ⊗₀ X) ⊗₀ (Y ⊗₀ Z) ⇒ (Y ⊗₀ W) ⊗�
                         i⇒
                       ⟩
 swapInner-braiding′ = switch-fromtoˡ swapInner-iso swapInner-braiding
+
+swapInner-braidingˡ : [ (W ⊗₀ X) ⊗₀ (Y ⊗₀ Z) ⇒ (Y ⊗₀ W) ⊗₀ (X ⊗₀ Z) ]⟨
+                        i⇒         ⇒⟨ (W ⊗₀ Y) ⊗₀ (X ⊗₀ Z) ⟩
+                        σ⇒ ⊗₁ id
+                      ≈ σ⇒         ⇒⟨ (Y ⊗₀ Z) ⊗₀ (W ⊗₀ X) ⟩
+                        i⇒         ⇒⟨ (Y ⊗₀ W) ⊗₀ (Z ⊗₀ X) ⟩
+                        id ⊗₁ σ⇒
+                      ⟩
+swapInner-braidingˡ = begin
+  (σ⇒ ⊗₁ id) ∘ i⇒                 ≈˘⟨ refl⟩⊗⟨ commutative ⟩∘⟨refl ⟩
+  (σ⇒ ⊗₁ (σ⇒ ∘ σ⇒)) ∘ i⇒          ≈⟨ split₂ˡ ⟩∘⟨refl ⟩
+  ((id ⊗₁ σ⇒) ∘ (σ⇒ ⊗₁ σ⇒)) ∘ i⇒  ≈⟨ pullʳ swapInner-braiding′ ⟩
+  (id ⊗₁ σ⇒) ∘ i⇒ ∘ σ⇒            ∎
+
+swapInner-braidingʳ : [ (W ⊗₀ X) ⊗₀ (Y ⊗₀ Z) ⇒ (X ⊗₀ Z) ⊗₀ (W ⊗₀ Y) ]⟨
+                        i⇒         ⇒⟨ (W ⊗₀ Y) ⊗₀ (X ⊗₀ Z) ⟩
+                        σ⇒
+                      ≈ σ⇒ ⊗₁ σ⇒  ⇒⟨ (X ⊗₀ W) ⊗₀ (Z ⊗₀ Y) ⟩
+                        i⇒
+                      ⟩
+swapInner-braidingʳ = begin
+  σ⇒ ∘ i⇒                       ≈˘⟨ swapInner-braiding ⟩∘⟨refl ⟩
+  (i⇒ ∘ (σ⇒ ⊗₁ σ⇒ ∘ i⇒)) ∘ i⇒   ≈⟨ pullʳ (cancelʳ swapInner-commutative) ⟩
+  i⇒ ∘ (σ⇒ ⊗₁ σ⇒)               ∎

--- a/src/Categories/Category/Monoidal/Symmetric/Properties.agda
+++ b/src/Categories/Category/Monoidal/Symmetric/Properties.agda
@@ -12,18 +12,19 @@ import Categories.Category.Construction.Core C as Core
 import Categories.Category.Monoidal.Utilities M as MonUtil
 
 open import Categories.Category.Monoidal.Properties M using (monoidal-Op)
+open import Categories.Category.Monoidal.Reasoning M
 open import Categories.Morphism C using (_≅_)
 open import Categories.Morphism.Reasoning C
 open import Data.Product using (_,_)
 
 open Category C
-open HomReasoning
 open Symmetric SM
 
 -- Shorthands for the braiding
 
 open BraidedProperties braided public using (module Shorthands)
 open BraidedProperties braided using (braiding-coherence-inv)
+  renaming (braiding-coherence′ to bc′)
 open Shorthands
 open Core.Shorthands using (idᵢ)
 open MonUtil using (_⊗ᵢ_)
@@ -76,3 +77,41 @@ symmetric-Op = record
     { braided = braided-Op
     ; commutative = inv-commutative
     }
+
+-- Cyclically rotate three tensor factors.
+module Rotation where
+  private
+    variable
+      X₁ X₂ Y₁ Y₂ Z₁ Z₂ : Obj
+      f : X₁ ⇒ X₂
+      g : Y₁ ⇒ Y₂
+      h : Z₁ ⇒ Z₂
+
+  cycle : (X₁ ⊗₀ Y₁) ⊗₀ Z₁ ⇒ Y₁ ⊗₀ (Z₁ ⊗₀ X₁)
+  cycle = (id ⊗₁ σ⇒) ∘ α⇒ ∘ (σ⇒ ⊗₁ id)
+
+  cycle-natural : cycle ∘ ((f ⊗₁ g) ⊗₁ h) ≈ (g ⊗₁ (h ⊗₁ f)) ∘ cycle
+  cycle-natural {f = f} {g = g} {h = h} = begin
+    cycle ∘ ((f ⊗₁ g) ⊗₁ h)                         ≈⟨ pullʳ (glue assoc-commute-from cycle-head) ⟩
+    (id ⊗₁ σ⇒) ∘ (g ⊗₁ (f ⊗₁ h)) ∘ α⇒ ∘ (σ⇒ ⊗₁ id)  ≈⟨ extendʳ cycle-tail ⟩
+    (g ⊗₁ (h ⊗₁ f)) ∘ cycle                         ∎
+    where
+      cycle-head = parallel σ⇒-comm id-comm-sym
+      cycle-tail = parallel id-comm-sym σ⇒-comm
+
+  cycle-cancel : cycle {Y₁} {X₁} {Z₁} ∘ (σ⇒ ⊗₁ id) ≈ (id ⊗₁ σ⇒) ∘ α⇒
+  cycle-cancel = begin
+    cycle ∘ (σ⇒ ⊗₁ id)  ≈⟨ pullʳ (cancelʳ (⊗-cancel commutative identity²)) ⟩
+    (id ⊗₁ σ⇒) ∘ α⇒     ∎
+
+  cycle-unit : (id ⊗₁ ρ⇒) ∘ cycle ∘ (λ⇐ ⊗₁ id) ≈ id {X₁ ⊗₀ Y₁}
+  cycle-unit = begin
+    (id ⊗₁ ρ⇒) ∘ cycle ∘ (λ⇐ ⊗₁ id)                     ≈⟨ pullˡ (pullˡ merge₂ˡ) ⟩
+    ((id ⊗₁ (ρ⇒ ∘ σ⇒)) ∘ α⇒ ∘ (σ⇒ ⊗₁ id)) ∘ (λ⇐ ⊗₁ id)  ≈⟨ refl⟩⊗⟨ bc′ ⟩∘⟨refl ⟩∘⟨refl ⟩
+    ((id ⊗₁ λ⇒) ∘ α⇒ ∘ (σ⇒ ⊗₁ id)) ∘ (λ⇐ ⊗₁ id)         ≈⟨ pullˡ triangle ⟩∘⟨refl ⟩
+    ((ρ⇒ ⊗₁ id) ∘ (σ⇒ ⊗₁ id)) ∘ (λ⇐ ⊗₁ id)              ≈⟨ merge₁ˡ ⟩∘⟨refl ⟩
+    ((ρ⇒ ∘ σ⇒) ⊗₁ id) ∘ (λ⇐ ⊗₁ id)                      ≈⟨ bc′ ⟩⊗⟨refl ⟩∘⟨refl ⟩
+    (λ⇒ ⊗₁ id) ∘ (λ⇐ ⊗₁ id)                             ≈⟨ ⊗-cancel unitorˡ.isoʳ identity² ⟩
+    id                                                  ∎
+
+open Rotation public

--- a/src/Categories/Enriched/Category/TensorProduct.agda
+++ b/src/Categories/Enriched/Category/TensorProduct.agda
@@ -1,0 +1,115 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Category.Monoidal.Interchange using (HasInterchange)
+
+-- The tensor product of enriched categories.  Composition exchanges the two
+-- middle hom objects once, then composes independently in each factor.
+
+module Categories.Enriched.Category.TensorProduct
+  {o ℓ e} {V : Category o ℓ e} {M : Monoidal V} (I : HasInterchange M) where
+
+open import Level using (_⊔_)
+open import Data.Product using (_×_; _,_; proj₁; proj₂)
+
+open Category V renaming (id to idV)
+open Monoidal M
+open HasInterchange I using (module swapInner)
+  renaming (natural to int-natural; assoc to int-assoc; unitˡ to int-unitˡ; unitʳ to int-unitʳ)
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Category.Monoidal.Utilities M
+open import Categories.Morphism.Reasoning V
+import Categories.Enriched.Category as Enriched
+open Shorthands
+
+private
+  i⇒ = swapInner.from
+
+module _ {a b} (𝒜 : Enriched.Category M a) (ℬ : Enriched.Category M b) where
+
+  infixr 7 _⊠_
+
+  private
+    module 𝒜 = Enriched.Category 𝒜
+    module ℬ = Enriched.Category ℬ
+
+    variable
+      A B C Z : 𝒜.Obj × ℬ.Obj -- source, intermediate, and target pairs
+
+    hom : 𝒜.Obj × ℬ.Obj → 𝒜.Obj × ℬ.Obj → Category.Obj V
+    hom A B = 𝒜.hom (proj₁ A) (proj₁ B) ⊗₀ ℬ.hom (proj₂ A) (proj₂ B)
+
+    id× : unit ⇒ hom A A
+    id× = (𝒜.id ⊗₁ ℬ.id) ∘ λ⇐
+
+    ⊚× : hom B C ⊗₀ hom A B ⇒ hom A C
+    ⊚× = (𝒜.⊚ ⊗₁ ℬ.⊚) ∘ i⇒
+
+  private abstract
+    ⊚×-assoc : ⊚× {B} {Z} {A} ∘ (⊚× {C} ⊗₁ idV)
+               ≈ ⊚× ∘ (idV ⊗₁ ⊚×) ∘ α⇒
+    ⊚×-assoc = begin
+      ⊚× ∘ (⊚× ⊗₁ idV)                                   ≈⟨ refl⟩∘⟨ split₁ˡ ⟩
+      ⊚× ∘ ((𝒜.⊚ ⊗₁ ℬ.⊚) ⊗₁ idV) ∘ (i⇒ ⊗₁ idV)          ≈˘⟨ refl⟩∘⟨ refl⟩⊗⟨ ⊗.identity ⟩∘⟨refl ⟩
+      ⊚× ∘ ((𝒜.⊚ ⊗₁ ℬ.⊚) ⊗₁ (idV ⊗₁ idV)) ∘ (i⇒ ⊗₁ idV) ≈⟨ extend² int-natural ⟩
+      ((𝒜.⊚ ⊗₁ ℬ.⊚) ∘ ((𝒜.⊚ ⊗₁ idV) ⊗₁ (ℬ.⊚ ⊗₁ idV)))
+        ∘ (i⇒ ∘ (i⇒ ⊗₁ idV))
+        ≈⟨ parallel 𝒜.⊚-assoc ℬ.⊚-assoc ⟩∘⟨refl ⟩
+      ((𝒜.⊚ ⊗₁ ℬ.⊚) ∘
+        (((idV ⊗₁ 𝒜.⊚) ∘ α⇒) ⊗₁ ((idV ⊗₁ ℬ.⊚) ∘ α⇒)))
+        ∘ (i⇒ ∘ (i⇒ ⊗₁ idV))
+        ≈⟨ pullʳ (pushˡ ⊗.homomorphism) ⟩
+      (𝒜.⊚ ⊗₁ ℬ.⊚) ∘
+        ((idV ⊗₁ 𝒜.⊚) ⊗₁ (idV ⊗₁ ℬ.⊚)) ∘
+        (α⇒ ⊗₁ α⇒) ∘ i⇒ ∘ (i⇒ ⊗₁ idV)
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ int-assoc ⟩
+      (𝒜.⊚ ⊗₁ ℬ.⊚) ∘
+        ((idV ⊗₁ 𝒜.⊚) ⊗₁ (idV ⊗₁ ℬ.⊚)) ∘
+        i⇒ ∘ (idV ⊗₁ i⇒) ∘ α⇒
+        ≈˘⟨ refl⟩∘⟨ extendʳ int-natural ⟩
+      (𝒜.⊚ ⊗₁ ℬ.⊚) ∘ i⇒ ∘
+        ((idV ⊗₁ idV) ⊗₁ (𝒜.⊚ ⊗₁ ℬ.⊚)) ∘ (idV ⊗₁ i⇒) ∘ α⇒
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ pullˡ merge₂ʳ ⟩
+      (𝒜.⊚ ⊗₁ ℬ.⊚) ∘ i⇒ ∘ ((idV ⊗₁ idV) ⊗₁ ⊚×) ∘ α⇒
+        ≈⟨ pushʳ (refl⟩∘⟨ ⊗.identity ⟩⊗⟨refl ⟩∘⟨refl) ⟩
+      ⊚× ∘ (idV ⊗₁ ⊚×) ∘ α⇒  ∎
+
+    ⊚×-unitˡ : ⊚× {B} {B} {A} ∘ (id× ⊗₁ idV) ≈ λ⇒
+    ⊚×-unitˡ = begin
+      ⊚× ∘ (id× ⊗₁ idV)                                   ≈⟨ refl⟩∘⟨ split₁ˡ ⟩
+      ⊚× ∘ ((𝒜.id ⊗₁ ℬ.id) ⊗₁ idV) ∘ (λ⇐ ⊗₁ idV)          ≈˘⟨ refl⟩∘⟨ refl⟩⊗⟨ ⊗.identity ⟩∘⟨refl ⟩
+      ⊚× ∘ ((𝒜.id ⊗₁ ℬ.id) ⊗₁ (idV ⊗₁ idV)) ∘ (λ⇐ ⊗₁ idV) ≈⟨ extend² int-natural ⟩
+      ((𝒜.⊚ ⊗₁ ℬ.⊚) ∘ ((𝒜.id ⊗₁ idV) ⊗₁ (ℬ.id ⊗₁ idV)))
+        ∘ (i⇒ ∘ (λ⇐ ⊗₁ idV))
+        ≈˘⟨ ⊗.homomorphism ⟩∘⟨refl ⟩
+      ((𝒜.⊚ ∘ (𝒜.id ⊗₁ idV)) ⊗₁ (ℬ.⊚ ∘ (ℬ.id ⊗₁ idV)))
+        ∘ (i⇒ ∘ (λ⇐ ⊗₁ idV))
+        ≈⟨ 𝒜.unitˡ ⟩⊗⟨ ℬ.unitˡ ⟩∘⟨refl ⟩
+      (λ⇒ ⊗₁ λ⇒) ∘ i⇒ ∘ (λ⇐ ⊗₁ idV)                       ≈⟨ int-unitˡ ⟩
+      λ⇒                                                  ∎
+
+    ⊚×-unitʳ : ⊚× {A} {B} ∘ (idV ⊗₁ id×) ≈ ρ⇒
+    ⊚×-unitʳ = begin
+      ⊚× ∘ (idV ⊗₁ id×)                                   ≈⟨ refl⟩∘⟨ split₂ˡ ⟩
+      ⊚× ∘ (idV ⊗₁ (𝒜.id ⊗₁ ℬ.id)) ∘ (idV ⊗₁ λ⇐)          ≈˘⟨ refl⟩∘⟨ ⊗.identity ⟩⊗⟨refl ⟩∘⟨refl ⟩
+      ⊚× ∘ ((idV ⊗₁ idV) ⊗₁ (𝒜.id ⊗₁ ℬ.id)) ∘ (idV ⊗₁ λ⇐) ≈⟨ extend² int-natural ⟩
+      ((𝒜.⊚ ⊗₁ ℬ.⊚) ∘ ((idV ⊗₁ 𝒜.id) ⊗₁ (idV ⊗₁ ℬ.id)))
+        ∘ (i⇒ ∘ (idV ⊗₁ λ⇐))
+        ≈˘⟨ ⊗.homomorphism ⟩∘⟨refl ⟩
+      ((𝒜.⊚ ∘ (idV ⊗₁ 𝒜.id)) ⊗₁ (ℬ.⊚ ∘ (idV ⊗₁ ℬ.id)))
+        ∘ (i⇒ ∘ (idV ⊗₁ λ⇐))
+        ≈⟨ 𝒜.unitʳ ⟩⊗⟨ ℬ.unitʳ ⟩∘⟨refl ⟩
+      (ρ⇒ ⊗₁ ρ⇒) ∘ i⇒ ∘ (idV ⊗₁ λ⇐)  ≈⟨ int-unitʳ ⟩
+      ρ⇒                                                       ∎
+
+  _⊠_ : Enriched.Category M (a ⊔ b)
+  _⊠_ = record
+    { Obj = 𝒜.Obj × ℬ.Obj
+    ; hom = hom
+    ; id = id×
+    ; ⊚ = ⊚×
+    ; ⊚-assoc = ⊚×-assoc
+    ; unitˡ = ⊚×-unitˡ
+    ; unitʳ = ⊚×-unitʳ
+    }

--- a/src/Categories/Enriched/Functor/TensorProduct.agda
+++ b/src/Categories/Enriched/Functor/TensorProduct.agda
@@ -1,0 +1,85 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category using (module Commutation) renaming (Category to Setoid-Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Category.Monoidal.Interchange using (HasInterchange)
+
+-- Tensor products of enriched functors.
+
+module Categories.Enriched.Functor.TensorProduct
+  {o ℓ e} {V : Setoid-Category o ℓ e} {M : Monoidal V} (I : HasInterchange M) where
+
+open import Data.Product using (_,_)
+
+import Categories.Enriched.Category as Enriched
+open Enriched using () renaming (Category to EnrichedCat)
+open import Categories.Enriched.Category M using (_[_,_])
+open import Categories.Enriched.Functor as EnrichedFunctor renaming (Functor to EnrichedFunctor)
+
+open Setoid-Category V
+open Commutation V
+open Monoidal M
+open HasInterchange I using (module swapInner) renaming (natural to interchange-natural)
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Category.Monoidal.Utilities M
+open import Categories.Enriched.Category.TensorProduct I using (_⊠_)
+open import Categories.Morphism.Reasoning V
+open Shorthands
+
+private
+  i⇒ = swapInner.from
+
+module _ {a b c d}
+        {𝒜 : EnrichedCat M a} {ℬ : EnrichedCat M b}
+        {𝒞 : EnrichedCat M c} {𝒟 : EnrichedCat M d}
+        where
+
+  infixr 7 _⊠F_
+
+  private
+    module 𝒜 = EnrichedCat 𝒜
+    module ℬ = EnrichedCat ℬ
+    module 𝒞 = EnrichedCat 𝒞
+    module 𝒟 = EnrichedCat 𝒟
+
+  _⊠F_ : (F : EnrichedFunctor M 𝒜 𝒞) (G : EnrichedFunctor M ℬ 𝒟) →
+         EnrichedFunctor M (𝒜 ⊠ ℬ) (𝒞 ⊠ 𝒟)
+  F ⊠F G = record
+    { map₀ = λ (A , B) → F.₀ A , G.₀ B
+    ; map₁ = F.₁ ⊗₁ G.₁
+    ; identity = identity
+    ; homomorphism = homomorphism
+    }
+    where
+    module F = EnrichedFunctor.Functor F
+    module G = EnrichedFunctor.Functor G
+    module 𝒜⊠ℬ = EnrichedCat (𝒜 ⊠ ℬ)
+    module 𝒞⊠𝒟 = EnrichedCat (𝒞 ⊠ 𝒟)
+
+    variable
+      A B C : 𝒜.Obj
+      X Y Z : ℬ.Obj
+
+    abstract
+      identity : (F.₁ ⊗₁ G.₁) ∘ 𝒜⊠ℬ.id {A , X} ≈ 𝒞⊠𝒟.id
+      identity = begin
+        (F.₁ ⊗₁ G.₁) ∘ (𝒜.id ⊗₁ ℬ.id) ∘ λ⇐    ≈⟨ pullˡ (⟺ ⊗.homomorphism) ⟩
+        ((F.₁ ∘ 𝒜.id) ⊗₁ (G.₁ ∘ ℬ.id)) ∘ λ⇐   ≈⟨ F.identity ⟩⊗⟨ G.identity ⟩∘⟨refl ⟩
+        (𝒞.id ⊗₁ 𝒟.id) ∘ λ⇐                   ∎
+
+      homomorphism :
+        [ (𝒜 [ B , C ] ⊗₀ ℬ [ Y , Z ]) ⊗₀ (𝒜 [ A , B ] ⊗₀ ℬ [ X , Y ]) ⇒
+          𝒞 [ F.₀ A , F.₀ C ] ⊗₀ 𝒟 [ G.₀ X , G.₀ Z ] ]⟨
+            𝒜⊠ℬ.⊚         ⇒⟨ 𝒜 [ A , C ] ⊗₀ ℬ [ X , Z ] ⟩
+            F.₁ ⊗₁ G.₁
+          ≈ (F.₁ ⊗₁ G.₁) ⊗₁ (F.₁ ⊗₁ G.₁)
+                            ⇒⟨ (𝒞 [ F.₀ B , F.₀ C ] ⊗₀ 𝒟 [ G.₀ Y , G.₀ Z ]) ⊗₀
+                                (𝒞 [ F.₀ A , F.₀ B ] ⊗₀ 𝒟 [ G.₀ X , G.₀ Y ]) ⟩
+            𝒞⊠𝒟.⊚
+          ⟩
+      homomorphism = let F⊗G-homo = F.homomorphism ⟩⊗⟨ G.homomorphism in begin
+        (F.₁ ⊗₁ G.₁) ∘ (𝒜.⊚ ⊗₁ ℬ.⊚) ∘ i⇒                      ≈⟨ pullˡ (⟺ ⊗.homomorphism) ⟩
+        ((F.₁ ∘ 𝒜.⊚) ⊗₁ (G.₁ ∘ ℬ.⊚)) ∘ i⇒                     ≈⟨ F⊗G-homo ⟩∘⟨refl ⟩
+        ((𝒞.⊚ ∘ (F.₁ ⊗₁ F.₁)) ⊗₁ (𝒟.⊚ ∘ (G.₁ ⊗₁ G.₁))) ∘ i⇒   ≈⟨ pushˡ ⊗.homomorphism ⟩
+        (𝒞.⊚ ⊗₁ 𝒟.⊚) ∘ (((F.₁ ⊗₁ F.₁) ⊗₁ (G.₁ ⊗₁ G.₁)) ∘ i⇒)  ≈⟨ pushʳ (⟺ interchange-natural) ⟩
+        𝒞⊠𝒟.⊚ ∘ ((F.₁ ⊗₁ G.₁) ⊗₁ (F.₁ ⊗₁ G.₁)) ∎

--- a/src/Categories/Enriched/Functor/TensorProduct/Symmetric.agda
+++ b/src/Categories/Enriched/Functor/TensorProduct/Symmetric.agda
@@ -1,0 +1,164 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Category.Monoidal.Symmetric using (Symmetric)
+
+-- Symmetry of the tensor product of enriched categories.
+
+module Categories.Enriched.Functor.TensorProduct.Symmetric
+  {o ℓ e} {V : Category o ℓ e} {M : Monoidal V} (S : Symmetric M) where
+
+open import Data.Product using (_,_; swap)
+
+import Categories.Enriched.Category as Enriched
+import Categories.Enriched.Category.Opposite as Opposite
+import Categories.Category.Monoidal.Interchange.Braided as BraidedInterchange
+import Categories.Category.Monoidal.Utilities as MonoidalUtilities
+
+open Category V
+open Monoidal M
+open Symmetric S using (braided)
+open BraidedInterchange braided using (module swapInner)
+  renaming (hasInterchange to interchange)
+open import Categories.Category.Monoidal.Interchange using (HasInterchange)
+open HasInterchange interchange using ()
+  renaming (natural to interchange-natural)
+open import Categories.Category.Monoidal.Braided.Properties braided
+  using (braiding-coherence-σ)
+  renaming (module Shorthands to BraidShorthands)
+open import Categories.Category.Monoidal.Properties M using (coherence-inv₃)
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Enriched.Category M using (_[_,_])
+open import Categories.Enriched.Category.TensorProduct interchange using (_⊠_)
+open import Categories.Enriched.Functor M using (Functor; _∘F_)
+open import Categories.Morphism.Reasoning V
+open import Categories.Category.Monoidal.Interchange.Symmetric S
+  using (swapInner-braiding′; swapInner-braidingʳ; swapInner-unitˡ⁻¹)
+open BraidShorthands
+open MonoidalUtilities.Shorthands M
+
+private
+  i⇒ = swapInner.from
+
+op-⊠F : ∀ {a b} {𝒜 : Enriched.Category M a} {ℬ : Enriched.Category M b} →
+  Functor (Opposite.op S 𝒜 ⊠ Opposite.op S ℬ) (Opposite.op S (𝒜 ⊠ ℬ))
+op-⊠F {𝒜 = 𝒜} {ℬ} = record
+  { map₀ = λ X → X
+  ; map₁ = id
+  ; identity = identityˡ
+  ; homomorphism = op-⊠-homomorphism
+  }
+  where
+  module 𝒜 = Enriched.Category 𝒜
+  module ℬ = Enriched.Category ℬ
+
+  variable
+    A B C : 𝒜.Obj
+    X Y Z : ℬ.Obj
+
+  abstract
+    op-⊠-homomorphism : id ∘
+        (((𝒜.⊚ {A = C} {B} {A} ∘ σ⇒) ⊗₁ (ℬ.⊚ {A = Z} {Y} {X} ∘ σ⇒)) ∘ i⇒)
+      ≈ (((𝒜.⊚ ⊗₁ ℬ.⊚) ∘ i⇒) ∘ σ⇒) ∘ (id ⊗₁ id)
+    op-⊠-homomorphism = begin
+      id ∘ (((𝒜.⊚ ∘ σ⇒) ⊗₁ (ℬ.⊚ ∘ σ⇒)) ∘ i⇒)  ≈⟨ identityˡ ⟩
+      ((𝒜.⊚ ∘ σ⇒) ⊗₁ (ℬ.⊚ ∘ σ⇒)) ∘ i⇒         ≈⟨ ⊗.homomorphism ⟩∘⟨refl ⟩
+      ((𝒜.⊚ ⊗₁ ℬ.⊚) ∘ (σ⇒ ⊗₁ σ⇒)) ∘ i⇒        ≈⟨ extendˡ swapInner-braiding′ ⟩
+      ((𝒜.⊚ ⊗₁ ℬ.⊚) ∘ i⇒) ∘ σ⇒                ≈⟨ introʳ ⊗.identity ⟩
+      (((𝒜.⊚ ⊗₁ ℬ.⊚) ∘ i⇒) ∘ σ⇒) ∘ (id ⊗₁ id) ∎
+
+swapF : ∀ {a b} {𝒜 : Enriched.Category M a} {ℬ : Enriched.Category M b} →
+  Functor (𝒜 ⊠ ℬ) (ℬ ⊠ 𝒜)
+swapF {𝒜 = 𝒜} {ℬ} = record
+  { map₀ = swap
+  ; map₁ = σ⇒
+  ; identity = swap-identity
+  ; homomorphism = pullˡ σ⇒-comm ○ extendˡ swapInner-braidingʳ
+  }
+  where
+  module 𝒜 = Enriched.Category 𝒜
+  module ℬ = Enriched.Category ℬ
+
+  abstract
+    swap-identity : {A : 𝒜.Obj} {X : ℬ.Obj} →
+                    σ⇒ {𝒜 [ A , A ]} {ℬ [ X , X ]} ∘ (𝒜.id ⊗₁ ℬ.id) ∘ λ⇐
+                    ≈ (ℬ.id ⊗₁ 𝒜.id) ∘ λ⇐
+    swap-identity = begin
+      σ⇒ ∘ (𝒜.id ⊗₁ ℬ.id) ∘ λ⇐            ≈⟨ pullˡ σ⇒-comm ⟩
+      ((ℬ.id ⊗₁ 𝒜.id) ∘ σ⇒) ∘ λ⇐          ≈⟨ pushʳ braiding-coherence-σ ⟩∘⟨refl ⟩
+      (((ℬ.id ⊗₁ 𝒜.id) ∘ λ⇐) ∘ ρ⇒) ∘ λ⇐   ≈⟨ pullʳ (refl⟩∘⟨ coherence-inv₃) ⟩
+      ((ℬ.id ⊗₁ 𝒜.id) ∘ λ⇐) ∘ ρ⇒ ∘ ρ⇐     ≈⟨ elimʳ unitorʳ.isoʳ ⟩
+      (ℬ.id ⊗₁ 𝒜.id) ∘ λ⇐                 ∎
+
+module LeftApplication {a b}
+  (𝒜 : Enriched.Category M a) (ℬ : Enriched.Category M b) where
+
+  private
+    module 𝒜 = Enriched.Category 𝒜
+    module ℬ = Enriched.Category ℬ
+    module 𝒜⊠ℬ = Enriched.Category (𝒜 ⊠ ℬ)
+
+    variable
+      A : 𝒜.Obj
+      X Y Z : ℬ.Obj
+      W : Obj
+
+    pairˡ : (A : 𝒜.Obj) → ℬ [ X , Y ] ⇒ (𝒜 ⊠ ℬ) [ (A , X) , (A , Y) ]
+    pairˡ A = (𝒜.id ⊗₁ id) ∘ λ⇐
+
+    abstract
+      pairˡ-natural : (f : W ⇒ ℬ [ X , Y ]) → pairˡ A ∘ f ≈ (𝒜.id ⊗₁ f) ∘ λ⇐
+      pairˡ-natural f = begin
+        ((𝒜.id ⊗₁ id) ∘ λ⇐) ∘ f         ≈⟨ pullʳ unitorˡ-commute-to ⟩
+        (𝒜.id ⊗₁ id) ∘ (id ⊗₁ f) ∘ λ⇐   ≈⟨ pullˡ merge₁ˡ ⟩
+        ((𝒜.id ∘ id) ⊗₁ f) ∘ λ⇐         ≈⟨ identityʳ ⟩⊗⟨refl ⟩∘⟨refl ⟩
+        (𝒜.id ⊗₁ f) ∘ λ⇐                ∎
+
+      pairˡ-slide : i⇒ ∘ ((𝒜.id {A} ⊗₁ id {ℬ [ Y , Z ]}) ⊗₁ (𝒜.id {A} ⊗₁ id {ℬ [ X , Y ]}))
+                    ≈ (((𝒜.id ⊗₁ 𝒜.id) ⊗₁ id) ∘ i⇒)
+      pairˡ-slide = begin
+        i⇒ ∘ ((𝒜.id ⊗₁ id) ⊗₁ (𝒜.id ⊗₁ id))   ≈⟨ interchange-natural ⟩
+        ((𝒜.id ⊗₁ 𝒜.id) ⊗₁ (id ⊗₁ id)) ∘ i⇒   ≈⟨ refl⟩⊗⟨ ⊗.identity ⟩∘⟨refl ⟩
+        ((𝒜.id ⊗₁ 𝒜.id) ⊗₁ id) ∘ i⇒           ∎
+
+      pairˡ-actions : (𝒜.⊚ {A = A} ⊗₁ ℬ.⊚ {A = X} {Y} {Z}) ∘ ((𝒜.id ⊗₁ 𝒜.id) ⊗₁ id)
+                      ≈ (𝒜.id ⊗₁ ℬ.⊚) ∘ (λ⇒ ⊗₁ id)
+      pairˡ-actions = begin
+        (𝒜.⊚ ⊗₁ ℬ.⊚) ∘ ((𝒜.id ⊗₁ 𝒜.id) ⊗₁ id)       ≈˘⟨ ⊗-distrib-over-∘ ⟩
+        (𝒜.⊚ ∘ (𝒜.id ⊗₁ 𝒜.id)) ⊗₁ (ℬ.⊚ ∘ id)        ≈⟨ (refl⟩∘⟨ serialize₁₂) ⟩⊗⟨ identityʳ ⟩
+        (𝒜.⊚ ∘ (𝒜.id ⊗₁ id) ∘ (id ⊗₁ 𝒜.id)) ⊗₁ ℬ.⊚  ≈⟨ pullˡ 𝒜.unitˡ ⟩⊗⟨refl ⟩
+        (λ⇒ ∘ (id ⊗₁ 𝒜.id)) ⊗₁ ℬ.⊚                  ≈⟨ unitorˡ-commute-from ⟩⊗⟨refl ⟩
+        (𝒜.id ∘ λ⇒) ⊗₁ ℬ.⊚                          ≈⟨ split₁ʳ ⟩
+        (𝒜.id ⊗₁ ℬ.⊚) ∘ (λ⇒ ⊗₁ id)                  ∎
+
+      pairˡ-⊚ : 𝒜⊠ℬ.⊚ {A = A , X} {A , Y} {A , Z} ∘ (pairˡ A ⊗₁ pairˡ A)
+                ≈ (𝒜.id ⊗₁ ℬ.⊚) ∘ λ⇐
+      pairˡ-⊚ {A = A} = let 𝒜⊗ℬ⊚ = 𝒜.⊚ ⊗₁ ℬ.⊚ in begin
+        ((𝒜.⊚ ⊗₁ ℬ.⊚) ∘ i⇒) ∘ (pairˡ A ⊗₁ pairˡ A)                  ≈⟨ pushʳ ⊗.homomorphism ⟩
+        ((𝒜⊗ℬ⊚ ∘ i⇒) ∘ ((𝒜.id ⊗₁ id) ⊗₁ (𝒜.id ⊗₁ id))) ∘ (λ⇐ ⊗₁ λ⇐) ≈⟨ extendˡ pairˡ-slide ⟩∘⟨refl ⟩
+        ((𝒜⊗ℬ⊚ ∘ ((𝒜.id ⊗₁ 𝒜.id) ⊗₁ id)) ∘ i⇒) ∘ (λ⇐ ⊗₁ λ⇐)         ≈⟨ assoc²αε ⟩
+        𝒜⊗ℬ⊚ ∘ ((𝒜.id ⊗₁ 𝒜.id) ⊗₁ id) ∘ i⇒ ∘ (λ⇐ ⊗₁ λ⇐)
+          ≈⟨ glue◽◃ pairˡ-actions swapInner-unitˡ⁻¹ ⟩
+        (𝒜.id ⊗₁ ℬ.⊚) ∘ λ⇐ ∎
+
+      pairˡ-homomorphism : pairˡ A ∘ ℬ.⊚ {A = X} {Y} {Z}
+                          ≈ 𝒜⊠ℬ.⊚ ∘ (pairˡ A ⊗₁ pairˡ A)
+      pairˡ-homomorphism {A = A} = begin
+        pairˡ A ∘ ℬ.⊚                 ≈⟨ pairˡ-natural ℬ.⊚ ⟩
+        (𝒜.id ⊗₁ ℬ.⊚) ∘ λ⇐            ≈˘⟨ pairˡ-⊚ ⟩
+        𝒜⊠ℬ.⊚ ∘ (pairˡ A ⊗₁ pairˡ A)  ∎
+
+  includeˡ : 𝒜.Obj → Functor ℬ (𝒜 ⊠ ℬ)
+  includeˡ A = record
+    { map₀ = A ,_
+    ; map₁ = pairˡ A
+    ; identity = pairˡ-natural ℬ.id
+    ; homomorphism = pairˡ-homomorphism
+    }
+
+open LeftApplication public
+
+includeʳ : ∀ {a b} (𝒜 : Enriched.Category M a) (ℬ : Enriched.Category M b) →
+  Enriched.Category.Obj ℬ → Functor 𝒜 (𝒜 ⊠ ℬ)
+includeʳ 𝒜 ℬ B = swapF ∘F includeˡ ℬ 𝒜 B


### PR DESCRIPTION
## Summary

Construct tensor products of enriched categories and enriched functors over a
monoidal category equipped with interchange.

This adds:

- the enriched category tensor product `𝒜 ⊠ ℬ`
- tensor products of enriched functors `F ⊠F G`
- compatibility between tensor products and enriched opposites
- the symmetry functor `swapF`
- canonical factor inclusions `includeˡ` and `includeʳ`
- symmetric interchange identities needed by these constructions
- naturality, cancellation, and unit laws for cyclic rotation of three tensor
  factors

## Motivation

For categories enriched over a monoidal category `V`, the tensor-product
category has pairs as objects and tensor products of hom objects:

    (𝒜 ⊠ ℬ) [ (A , X) , (B , Y) ] = 𝒜 [ A , B ] ⊗ ℬ [ X , Y ].

Composition must exchange the two middle hom objects before composing in each
factor. The existing `HasInterchange` interface provides exactly the
naturality, associativity, and unit coherence required to construct this
category without assuming that `V` is braided.

The notation `⊠` was chosen because it is visibly related to the underlying
tensor product `⊗`, while remaining distinct from it, and was previously unused
in this library. It is not essential to the construction; other notation would
be equally viable if maintainers prefer a different convention.

The same interchange calculus makes the construction functorial. When `V` is
symmetric, it additionally supplies the enriched swap functor, compatibility
with enriched opposites, and the canonical inclusions of either tensor factor.

These constructions provide generic enriched-category infrastructure needed
for hom bifunctors, enriched profunctors, and extraordinary naturality. In
particular, they will support the later formalization of the enriched argument
in Hajgató–Hasegawa’s construction of the compact-closed structure on
traced star-autonomous categories, without coupling that application to this foundational PR.

Independent of PRs #538 and #540, but similarly motivated.
