### PR TITLE
Add scalar and tensor coherence for enriched categories

### DIFF
--- a/src/Categories/Category/Monoidal/Construction/CommutativeMonoid.agda
+++ b/src/Categories/Category/Monoidal/Construction/CommutativeMonoid.agda
@@ -1,0 +1,72 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Algebra.Bundles using (CommutativeMonoid)
+
+-- A commutative monoid is a one-object monoidal category whose tensor is
+-- multiplication.
+
+module Categories.Category.Monoidal.Construction.CommutativeMonoid
+  o {c ℓ} (M : CommutativeMonoid c ℓ) where
+
+open import Data.Product using (_,_; uncurry)
+import Relation.Binary.Reasoning.Setoid as SetoidR
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Construction.MonoidAsCategory
+open import Categories.Category.Monoidal.Core using (Monoidal; monoidalHelper)
+open import Categories.Category.Monoidal.Symmetric using (Symmetric; symmetricHelper)
+open import Categories.NaturalTransformation.NaturalIsomorphism using (niHelper)
+import Categories.Morphism as Morphism
+
+open CommutativeMonoid M
+open import Algebra.Properties.CommutativeSemigroup commutativeSemigroup using (medial)
+
+baseCat : Category o _ _
+baseCat = MonoidAsCategory o monoid
+
+CMonoidAsMonoidalCat : Monoidal (baseCat)
+CMonoidAsMonoidalCat = monoidalHelper _ record
+  { ⊗ = record
+    { F₀ = λ _ → _
+    ; F₁ = uncurry _∙_
+    ; identity = identityˡ _
+    ; homomorphism = medial _ _ _ _
+    ; F-resp-≈ = uncurry ∙-cong
+    }
+  ; unit = _
+  ; unitorˡ = Morphism.≅.refl _
+  ; unitorʳ = Morphism.≅.refl _
+  ; associator = Morphism.≅.refl _
+  ; unitorˡ-commute = λ { {f = f} →
+      trans (identityˡ _) (trans (identityˡ f) (sym (identityʳ f))) }
+  ; unitorʳ-commute = λ { {f = f} → identityˡ (f ∙ ε) }
+  ; assoc-commute = assoc-natural
+  ; triangle = identityʳ _
+  ; pentagon = trans (∙-cong (identityˡ _) (identityˡ _)) (identityˡ _)
+  }
+  where
+  abstract
+    -- The outer units are the components of the identity associator.
+    assoc-natural : {f g h : Carrier} → ε ∙ ((f ∙ g) ∙ h) ≈ (f ∙ (g ∙ h)) ∙ ε
+    assoc-natural {f = f} {g} {h} = begin
+      ε ∙ ((f ∙ g) ∙ h)  ≈⟨ identityˡ _ ⟩
+      (f ∙ g) ∙ h        ≈⟨ assoc f g h ⟩
+      f ∙ (g ∙ h)        ≈⟨ identityʳ _ ⟨
+      (f ∙ (g ∙ h)) ∙ ε  ∎
+      where open SetoidR setoid
+
+CMonoidAsSymmetricMonoidal : Symmetric CMonoidAsMonoidalCat
+CMonoidAsSymmetricMonoidal = symmetricHelper _ record
+  { braiding = niHelper record
+    { η = λ _ → ε
+    ; η⁻¹ = λ _ → ε
+    ; commute = λ { (f , g) →
+        trans (identityˡ _) (trans (comm f g) (sym (identityʳ _))) }
+    ; iso = λ _ → record
+      { isoˡ = identityˡ _
+      ; isoʳ = identityˡ _
+      }
+    }
+  ; commutative = identityˡ _
+  ; hexagon = ∙-cong (identityˡ _) (identityˡ _)
+  }

--- a/src/Categories/Category/Monoidal/Scalars.agda
+++ b/src/Categories/Category/Monoidal/Scalars.agda
@@ -2,8 +2,8 @@
 
 -- The scalars of a monoidal category are the endomorphisms of the unit object.
 -- They form a monoid under composition, with natural left and right actions on
--- the morphisms of the category. These are in fact natural transformations of
--- the identity functor, but we do not prove that here.
+-- the morphisms of the category. These actions define natural transformations
+-- of the identity functor.
 -- See https://ncatlab.org/nlab/show/scalar for this terminology
 -- in dagger-, compact-, and closed monoidal categories, where scalars are
 -- discussed as the endomorphism ring of the tensor unit. The same page cites
@@ -21,6 +21,10 @@ module Categories.Category.Monoidal.Scalars
 open import Algebra.Bundles using (Monoid; CommutativeMonoid)
 
 open import Categories.Object.Endomorphism 𝒞 using (Endo; Endo-∘-Monoid)
+open import Categories.Functor using () renaming (id to idF)
+open import Categories.NaturalTransformation
+  using (NaturalTransformation; ntHelper; _∘ᵥ_) renaming (id to idNT)
+open import Categories.NaturalTransformation.Equivalence using (_≃_)
 open import Categories.Category.Monoidal.Reasoning M
 open import Categories.Category.Monoidal.Utilities M using (module Shorthands)
 import Categories.Category.Monoidal.Properties M as MonoidalProps
@@ -93,7 +97,7 @@ module Action where
     f ∘ ρ⇒ ∘ (id ⊗₁ g)              ≈⟨ pullˡ (⟺ unitorʳ-commute-from) ⟩
     (ρ⇒ ∘ (f ⊗₁ id)) ∘ (id ⊗₁ g)    ≈⟨ pullʳ merge₂ʳ ⟩
     ρ⇒ ∘ (f ⊗₁ (id ∘ g))            ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ identityˡ ⟩
-    ρ⇒ ∘ (f ⊗₁ g)                   ≈˘⟨ coherence₃ ⟩∘⟨refl ⟩
+    ρ⇒ ∘ (f ⊗₁ g)                   ≈⟨ coherence₃ ⟩∘⟨refl ⟨
     λ⇒ ∘ (f ⊗₁ g)                   ∎
 
 open Action public
@@ -106,43 +110,39 @@ open Action public
 -- Concretely the two actions agree on scalars (the unitors coincide on the unit),
 -- while `s ·ʳ t` is `s ∘ t` and `s ·ˡ t` is `t ∘ s`.
 module Eckmann-Hilton where
+  -- The two actions agree on a scalar: the unitors coincide on the unit.
+  ·ʳ≈·ˡ : s ·ʳ t ≈ s ·ˡ t
+  ·ʳ≈·ˡ = ⟺ coherence₃ ⟩∘⟨ refl⟩∘⟨ ⟺ coherence-inv₃
+
   private
     -- A scalar sandwiched between the unitors in either slot is itself: swap the
     -- unitors by coherence₃ and apply id-·ˡ / id-·ʳ.
     absorbᵣ : ρ⇒ ∘ (id ⊗₁ s) ∘ ρ⇐ ≈ s
     absorbᵣ {s} = begin
-      ρ⇒ ∘ (id ⊗₁ s) ∘ ρ⇐  ≈⟨ ⟺ coherence₃ ⟩∘⟨ refl⟩∘⟨ ⟺ coherence-inv₃ ⟩
+      ρ⇒ ∘ (id ⊗₁ s) ∘ ρ⇐  ≈⟨ ·ʳ≈·ˡ ⟩
       λ⇒ ∘ (id ⊗₁ s) ∘ λ⇐  ≈⟨ id-·ˡ ⟩
       s                    ∎
 
     absorbₗ : λ⇒ ∘ (s ⊗₁ id) ∘ λ⇐ ≈ s
     absorbₗ {s} = begin
-      λ⇒ ∘ (s ⊗₁ id) ∘ λ⇐  ≈⟨ coherence₃ ⟩∘⟨ refl⟩∘⟨ coherence-inv₃ ⟩
+      λ⇒ ∘ (s ⊗₁ id) ∘ λ⇐  ≈⟨ ·ʳ≈·ˡ ⟨
       ρ⇒ ∘ (s ⊗₁ id) ∘ ρ⇐  ≈⟨ id-·ʳ ⟩
       s                    ∎
-
-  -- The two actions agree on a scalar: the unitors coincide on the unit.
-  ·ʳ≈·ˡ : s ·ʳ t ≈ s ·ˡ t
-  ·ʳ≈·ˡ = ⟺ coherence₃ ⟩∘⟨ refl⟩∘⟨ ⟺ coherence-inv₃
 
   -- Acting by a scalar on a scalar is composition: slide the acting scalar out
   -- past its unitor; the other unitor absorbs the scalar acted on.
   ·ʳ-scalar : s ·ʳ t ≈ s ∘ t
   ·ʳ-scalar {s} {t} = begin
-    ρ⇒ ∘ (s ⊗₁ t) ∘ ρ⇐                 ≈⟨ refl⟩∘⟨ serialize₁₂ ⟩∘⟨refl ⟩
-    ρ⇒ ∘ ((s ⊗₁ id) ∘ (id ⊗₁ t)) ∘ ρ⇐  ≈⟨ refl⟩∘⟨ assoc ⟩
+    ρ⇒ ∘ (s ⊗₁ t) ∘ ρ⇐                 ≈⟨ refl⟩∘⟨ pushˡ serialize₁₂ ⟩
     ρ⇒ ∘ (s ⊗₁ id) ∘ (id ⊗₁ t) ∘ ρ⇐    ≈⟨ pullˡ unitorʳ-commute-from ⟩
-    (s ∘ ρ⇒) ∘ (id ⊗₁ t) ∘ ρ⇐          ≈⟨ assoc ⟩
-    s ∘ ρ⇒ ∘ (id ⊗₁ t) ∘ ρ⇐            ≈⟨ refl⟩∘⟨ absorbᵣ ⟩
+    (s ∘ ρ⇒) ∘ (id ⊗₁ t) ∘ ρ⇐          ≈⟨ pullʳ absorbᵣ ⟩
     s ∘ t                              ∎
 
   ·ˡ-scalar : s ·ˡ t ≈ t ∘ s
   ·ˡ-scalar {s} {t} = begin
-    λ⇒ ∘ (s ⊗₁ t) ∘ λ⇐                 ≈⟨ refl⟩∘⟨ serialize₂₁ ⟩∘⟨refl ⟩
-    λ⇒ ∘ ((id ⊗₁ t) ∘ (s ⊗₁ id)) ∘ λ⇐  ≈⟨ refl⟩∘⟨ assoc ⟩
+    λ⇒ ∘ (s ⊗₁ t) ∘ λ⇐                 ≈⟨ refl⟩∘⟨ pushˡ serialize₂₁ ⟩
     λ⇒ ∘ (id ⊗₁ t) ∘ (s ⊗₁ id) ∘ λ⇐    ≈⟨ pullˡ unitorˡ-commute-from ⟩
-    (t ∘ λ⇒) ∘ (s ⊗₁ id) ∘ λ⇐          ≈⟨ assoc ⟩
-    t ∘ λ⇒ ∘ (s ⊗₁ id) ∘ λ⇐            ≈⟨ refl⟩∘⟨ absorbₗ ⟩
+    (t ∘ λ⇒) ∘ (s ⊗₁ id) ∘ λ⇐          ≈⟨ pullʳ absorbₗ ⟩
     t ∘ s                              ∎
 
   -- Eckmann–Hilton: s ∘ t = s ·ʳ t = s ·ˡ t = t ∘ s.
@@ -167,3 +167,37 @@ module Eckmann-Hilton where
     }
 
 open Eckmann-Hilton public
+
+-- Scalars act naturally on every object through the identity functor.
+module NaturalAction where
+  private abstract
+    commute : (f : A ⇒ B) → (s ·ˡ id) ∘ f ≈ f ∘ (s ·ˡ id)
+    commute {s = s} f = begin
+      (s ·ˡ id) ∘ f           ≈⟨ refl⟩∘⟨ id-·ˡ ⟨
+      (s ·ˡ id) ∘ (idₛ ·ˡ f)  ≈⟨ ·ˡ-∘ ⟨
+      (s ·ₛ idₛ) ·ˡ (id ∘ f)  ≈⟨ ·ˡ-resp-≈ (scalar-comm s idₛ) (⟺ id-comm) ⟩
+      (idₛ ·ₛ s) ·ˡ (f ∘ id)  ≈⟨ ·ˡ-∘ ⟩
+      (idₛ ·ˡ f) ∘ (s ·ˡ id)  ≈⟨ id-·ˡ ⟩∘⟨refl ⟩
+      f ∘ (s ·ˡ id)           ∎
+
+  Scale⟦_⟧ : Scalar → NaturalTransformation (idF {C = 𝒞}) idF
+  Scale⟦ s ⟧ = ntHelper record
+    { η = λ _ → s ·ˡ id
+    ; commute = commute
+    }
+
+  -- Scale⟦_⟧ is a monoid homomorphism to the natural transformations of the identity functor
+  Scale-id : Scale⟦ idₛ ⟧ ≃ idNT
+  Scale-id = id-·ˡ
+
+  Scale-·ₛ : Scale⟦ s ·ₛ t ⟧ ≃ Scale⟦ s ⟧ ∘ᵥ Scale⟦ t ⟧
+  Scale-·ₛ = ·ˡ-resp-≈ Equiv.refl (⟺ identityˡ) ○ ·ˡ-∘
+
+  Scale-unit : NaturalTransformation.η Scale⟦ s ⟧ unit ≈ s
+  Scale-unit = ·ˡ-scalar ○ identityˡ
+
+  -- Scale⟦_⟧ is an injective/faithful monoid homomorphism
+  Scale-injective : Scale⟦ s ⟧ ≃ Scale⟦ t ⟧ → s ≈ t
+  Scale-injective Scale-s≈t = ⟺ Scale-unit ○ Scale-s≈t ○ Scale-unit
+
+open NaturalAction public

--- a/src/Categories/Enriched/Category/Equivalence.agda
+++ b/src/Categories/Enriched/Category/Equivalence.agda
@@ -1,0 +1,34 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core using () renaming (Category to Setoid-Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+
+-- Strong equivalences of enriched categories.
+
+module Categories.Enriched.Category.Equivalence
+  {o ℓ e} {V : Setoid-Category o ℓ e} (M : Monoidal V) where
+
+open import Level using (_⊔_)
+
+open import Categories.Enriched.Category M using (Category)
+open import Categories.Enriched.Functor M using (Functor; _∘F_)
+  renaming (id to idF)
+open import Categories.Enriched.NaturalTransformation.NaturalIsomorphism M
+  using (NaturalIsomorphism)
+
+record WeakInverse {a b} {C : Category a} {D : Category b}
+  (F : Functor C D) (G : Functor D C) : Set (ℓ ⊔ e ⊔ a ⊔ b) where
+  field
+    F∘G≈id : NaturalIsomorphism (F ∘F G) idF
+    G∘F≈id : NaturalIsomorphism (G ∘F F) idF
+
+  module F∘G≈id = NaturalIsomorphism F∘G≈id
+  module G∘F≈id = NaturalIsomorphism G∘F≈id
+
+record StrongEquivalence {a b} (C : Category a) (D : Category b) : Set (ℓ ⊔ e ⊔ a ⊔ b) where
+  field
+    F            : Functor C D
+    G            : Functor D C
+    weak-inverse : WeakInverse F G
+
+  open WeakInverse weak-inverse public

--- a/src/Categories/Enriched/Category/Properties.agda
+++ b/src/Categories/Enriched/Category/Properties.agda
@@ -1,0 +1,52 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core using () renaming (Category to Setoid-Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Enriched.Category using (Category)
+
+-- Derived unit laws for generalized elements of enriched hom-objects.
+
+module Categories.Enriched.Category.Properties
+  {o ℓ e v} {V : Setoid-Category o ℓ e} (M : Monoidal V) (C : Category M v) where
+
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Category.Monoidal.Utilities M using (module Shorthands)
+open import Categories.Morphism.Reasoning V
+
+open Setoid-Category V renaming (id to idV)
+  using (_⇒_; _≈_; _∘_; assoc; sym-assoc; identityˡ; identityʳ)
+open Monoidal M using (_⊗₀_; _⊗₁_; unit; module unitorˡ; module unitorʳ;
+  unitorˡ-commute-from; unitorʳ-commute-from)
+open Category C
+open Shorthands
+
+private
+  variable
+    A B : Obj
+    X : Setoid-Category.Obj V
+    f g : X ⇒ hom A B
+
+abstract
+  unitˡ-var : ⊚ ∘ (id ⊗₁ f) ∘ λ⇐ ≈ f
+  unitˡ-var {f = f} = begin
+    ⊚ ∘ (id ⊗₁ f) ∘ λ⇐                        ≈⟨ pushʳ (⟺ (identityʳ ⟩⊗⟨ identityˡ) ⟩∘⟨refl) ⟩
+    (⊚ ∘ ((id ∘ idV) ⊗₁ (idV ∘ f))) ∘ λ⇐      ≈⟨ pushʳ ⊗-distrib-over-∘ ⟩∘⟨refl ⟩
+    ((⊚ ∘ (id ⊗₁ idV)) ∘ (idV ⊗₁ f)) ∘ λ⇐     ≈⟨ unitˡ ⟩∘⟨refl ⟩∘⟨refl ⟩
+    (λ⇒ ∘ (idV ⊗₁ f)) ∘ λ⇐                    ≈⟨ unitorˡ-commute-from ⟩∘⟨refl ⟩
+    (f ∘ λ⇒) ∘ λ⇐                             ≈⟨ cancelʳ unitorˡ.isoʳ ⟩
+    f                                         ∎
+
+  unitʳ-var : ⊚ ∘ (f ⊗₁ id) ∘ ρ⇐ ≈ f
+  unitʳ-var {f = f} = begin
+    ⊚ ∘ (f ⊗₁ id) ∘ ρ⇐                        ≈⟨ pushʳ (⟺ (identityˡ ⟩⊗⟨ identityʳ) ⟩∘⟨refl) ⟩
+    (⊚ ∘ ((idV ∘ f) ⊗₁ (id ∘ idV))) ∘ ρ⇐      ≈⟨ pushʳ ⊗-distrib-over-∘ ⟩∘⟨refl ⟩
+    ((⊚ ∘ (idV ⊗₁ id)) ∘ (f ⊗₁ idV)) ∘ ρ⇐     ≈⟨ unitʳ ⟩∘⟨refl ⟩∘⟨refl ⟩
+    (ρ⇒ ∘ (f ⊗₁ idV)) ∘ ρ⇐                    ≈⟨ unitorʳ-commute-from ⟩∘⟨refl ⟩
+    (f ∘ ρ⇒) ∘ ρ⇐                             ≈⟨ cancelʳ unitorʳ.isoʳ ⟩
+    f                                         ∎
+
+  id-commuteˡ : f ≈ g → ⊚ ∘ (id ⊗₁ f) ∘ λ⇐ ≈ ⊚ ∘ (g ⊗₁ id) ∘ ρ⇐
+  id-commuteˡ f≈g = unitˡ-var ○ f≈g ○ ⟺ unitʳ-var
+
+  id-commuteʳ : f ≈ g → ⊚ ∘ (id ⊗₁ g) ∘ λ⇐ ≈ ⊚ ∘ (f ⊗₁ id) ∘ ρ⇐
+  id-commuteʳ f≈g = unitˡ-var ○ ⟺ f≈g ○ ⟺ unitʳ-var

--- a/src/Categories/Enriched/Category/Scalar.agda
+++ b/src/Categories/Enriched/Category/Scalar.agda
@@ -1,0 +1,42 @@
+{-# OPTIONS --without-K --safe #-}
+
+import Categories.Category.Core as Base
+open import Categories.Category.Monoidal.Core using (Monoidal)
+
+-- The scalar enriched category is the unit for tensor products of enriched
+-- categories.
+
+module Categories.Enriched.Category.Scalar
+  {o ℓ e} {V : Base.Category o ℓ e} (M : Monoidal V) where
+
+open import Data.Unit.Polymorphic using (⊤)
+open import Level using (Level)
+
+open import Categories.Category.Monoidal.Properties M using (coherence₁; coherence₃)
+open import Categories.Category.Monoidal.Utilities M
+  using (unitor-coherenceˡ; module Shorthands)
+import Categories.Enriched.Category M as Enriched
+open import Categories.Morphism.Reasoning V
+
+open Base.Category V
+open HomReasoning
+open Monoidal M using (unit; _⊗₁_; module ⊗)
+open Shorthands
+
+private
+  variable
+    v : Level
+
+V-Scalar : Enriched.Category v
+V-Scalar = record
+  { Obj = ⊤
+  ; hom = λ _ _ → unit
+  ; id = id
+  ; ⊚ = λ⇒
+  ; ⊚-assoc = begin
+      λ⇒ ∘ (λ⇒ ⊗₁ id)                  ≈˘⟨ refl⟩∘⟨ coherence₁ ⟩
+      λ⇒ ∘ λ⇒ ∘ α⇒                    ≈˘⟨ refl⟩∘⟨ unitor-coherenceˡ ⟩∘⟨refl ⟩
+      λ⇒ ∘ (id ⊗₁ λ⇒) ∘ α⇒            ∎
+  ; unitˡ = elimʳ ⊗.identity
+  ; unitʳ = elimʳ ⊗.identity ○ coherence₃
+  }

--- a/src/Categories/Enriched/Category/TensorProduct/Properties.agda
+++ b/src/Categories/Enriched/Category/TensorProduct/Properties.agda
@@ -1,0 +1,310 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Category.Monoidal.Symmetric using (Symmetric)
+
+-- Coherence for tensor products of enriched categories.
+
+module Categories.Enriched.Category.TensorProduct.Properties
+  {o ℓ e} {V : Category o ℓ e} {M : Monoidal V} (S : Symmetric M) where
+
+open import Data.Product using (_,_)
+open import Data.Product.Algebra using (×-assoc)
+open import Function.Bundles using (Inverse)
+
+import Categories.Category.Construction.Core V as Core
+import Categories.Category.Monoidal.Braided.Properties as BraidedProperties
+import Categories.Category.Monoidal.Interchange.Braided as BraidedInterchange
+import Categories.Category.Monoidal.Interchange.Symmetric as SymmetricInterchange
+open import Categories.Category.Monoidal.Interchange using (HasInterchange)
+open import Categories.Category.Monoidal.Properties M using (coherence-inv₁)
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Category.Monoidal.Utilities M using (_⊗ᵢ_; module Shorthands)
+import Categories.Enriched.Category M as Enriched
+import Categories.Enriched.Category.Properties as EnrichedProperties
+open import Categories.Enriched.Category.Equivalence M using (StrongEquivalence; WeakInverse)
+import Categories.Enriched.Category.TensorProduct
+open import Categories.Enriched.Category.Underlying M using (Underlying)
+open import Categories.Enriched.Functor M using (Functor; _∘F_)
+  renaming (id to idF)
+import Categories.Enriched.Functor.TensorProduct as TensorFunctor
+import Categories.Enriched.Functor.TensorProduct.Symmetric as TensorSymmetric
+open import Categories.Enriched.NaturalTransformation M
+  using (module NaturalTransformation) renaming (id to idNT)
+open import Categories.Enriched.NaturalTransformation.NaturalIsomorphism M
+  using (NaturalIsomorphism)
+open import Categories.Morphism.Reasoning V
+
+open Category V
+open Monoidal M
+open Core.Shorthands
+open Shorthands
+
+open Symmetric S using (braided; commutative)
+open BraidedInterchange braided using () renaming (hasInterchange to interchange)
+open BraidedProperties.Shorthands braided
+open Categories.Enriched.Category.TensorProduct interchange using (_⊠_)
+open TensorFunctor interchange using (_⊠F_)
+open TensorSymmetric S using (swapF)
+
+module Reassociation {v} (𝒜 ℬ 𝒞 : Enriched.Category v) where
+
+  private
+    open HasInterchange interchange using (module swapInner)
+      renaming (swapInner to ι; assoc to interchange-assoc)
+    open swapInner using () renaming (from to i⇒; to to i⇐)
+    open SymmetricInterchange S using () renaming (swapInner-selfInverse to ι⁻¹≈ι)
+
+    module 𝒜 = Enriched.Category 𝒜
+    module ℬ = Enriched.Category ℬ
+    module 𝒞 = Enriched.Category 𝒞
+    module ×α = Inverse (×-assoc v 𝒜.Obj ℬ.Obj 𝒞.Obj)
+
+    variable
+      A₀ A₁ A₂ : 𝒜.Obj -- source, intermediate, and target in each factor
+      B₀ B₁ B₂ : ℬ.Obj
+      C₀ C₁ C₂ : 𝒞.Obj
+      U₀ U₁ V₀ V₁ W₀ W₁ : Obj -- two composition layers in each tensor factor
+
+    abstract
+      unit-insertion : α⇒ {unit} {unit} {unit} ∘ (λ⇐ ⊗₁ id) ≈ λ⇐
+      unit-insertion = begin
+        α⇒ ∘ (λ⇐ ⊗₁ id)  ≈˘⟨ refl⟩∘⟨ coherence-inv₁ ⟩
+        α⇒ ∘ α⇐ ∘ λ⇐     ≈⟨ cancelˡ associator.isoʳ ⟩
+        λ⇐               ∎
+
+    abstract
+      α-id : α⇒ ∘ ((((𝒜.id {A₀} ⊗₁ ℬ.id {B₀}) ∘ λ⇐) ⊗₁ 𝒞.id {C₀}) ∘ λ⇐)
+        ≈ (𝒜.id ⊗₁ ((ℬ.id ⊗₁ 𝒞.id) ∘ λ⇐)) ∘ λ⇐
+      α-id = let
+        identities : unit ⊗₀ (unit ⊗₀ unit) ⇒
+          𝒜.hom A₀ A₀ ⊗₀ (ℬ.hom B₀ B₀ ⊗₀ 𝒞.hom C₀ C₀)
+        identities = 𝒜.id ⊗₁ (ℬ.id ⊗₁ 𝒞.id)
+        glue-unit = glue◽◃ assoc-commute-from unit-insertion
+        in begin
+        α⇒ ∘ ((((𝒜.id ⊗₁ ℬ.id) ∘ λ⇐) ⊗₁ 𝒞.id) ∘ λ⇐)         ≈⟨ refl⟩∘⟨ split₁ʳ ⟩∘⟨refl ⟩
+        α⇒ ∘ (((𝒜.id ⊗₁ ℬ.id) ⊗₁ 𝒞.id) ∘ (λ⇐ ⊗₁ id)) ∘ λ⇐   ≈⟨ extendʳ glue-unit ⟩
+        identities ∘ λ⇐ ∘ λ⇐                                ≈⟨ refl⟩∘⟨ unitorˡ-commute-to ⟩
+        identities ∘ (id ⊗₁ λ⇐) ∘ λ⇐                        ≈⟨ pullˡ merge₂ʳ ⟩
+        (𝒜.id ⊗₁ ((ℬ.id ⊗₁ 𝒞.id) ∘ λ⇐)) ∘ λ⇐                ∎
+
+    abstract
+      interchange-assocᵢ :
+        (associator {U₀} {V₀} {W₀} ⊗ᵢ associator {U₁} {V₁} {W₁})
+          ∘ᵢ ι ∘ᵢ (ι ⊗ᵢ idᵢ)
+        ≈ᵢ ι ∘ᵢ (idᵢ ⊗ᵢ ι) ∘ᵢ associator
+      interchange-assocᵢ = ⌞ interchange-assoc ⌟
+
+    abstract
+      interchange-assoc⁻¹ :
+        α⇐ {U₀ ⊗₀ U₁} {V₀ ⊗₀ V₁} {W₀ ⊗₀ W₁} ∘ ((id ⊗₁ i⇒) ∘ i⇒)
+        ≈ ((i⇒ ⊗₁ id) ∘ i⇒) ∘ (α⇐ ⊗₁ α⇐)
+      interchange-assoc⁻¹ = begin
+        α⇐ ∘ ((id ⊗₁ i⇒) ∘ i⇒)          ≈⟨ sym-assoc ⟩
+        (α⇐ ∘ (id ⊗₁ i⇒)) ∘ i⇒          ≈⟨ (refl⟩∘⟨ refl⟩⊗⟨ ι⁻¹≈ι) ⟩∘⟨ ι⁻¹≈ι ⟩
+        (α⇐ ∘ (id ⊗₁ i⇐)) ∘ i⇐          ≈˘⟨ to-≈ interchange-assocᵢ ⟩
+        ((i⇐ ⊗₁ id) ∘ i⇐) ∘ (α⇐ ⊗₁ α⇐)  ≈˘⟨ (ι⁻¹≈ι ⟩⊗⟨refl ⟩∘⟨ ι⁻¹≈ι) ⟩∘⟨refl ⟩
+        ((i⇒ ⊗₁ id) ∘ i⇒) ∘ (α⇐ ⊗₁ α⇐)  ∎
+
+    abstract
+      α⇐-⊚ : α⇐ ∘
+          ((𝒜.⊚ {A₀} {A₁} {A₂} ⊗₁
+            ((ℬ.⊚ {B₀} {B₁} {B₂} ⊗₁ 𝒞.⊚ {C₀} {C₁} {C₂}) ∘ i⇒)) ∘ i⇒)
+        ≈ ((((𝒜.⊚ ⊗₁ ℬ.⊚) ∘ i⇒) ⊗₁ 𝒞.⊚) ∘ i⇒) ∘ (α⇐ ⊗₁ α⇐)
+      α⇐-⊚ = let
+        ⊚³ : (((𝒜.hom A₁ A₂ ⊗₀ 𝒜.hom A₀ A₁) ⊗₀ (ℬ.hom B₁ B₂ ⊗₀ ℬ.hom B₀ B₁))
+               ⊗₀ (𝒞.hom C₁ C₂ ⊗₀ 𝒞.hom C₀ C₁))
+             ⇒ (𝒜.hom A₀ A₂ ⊗₀ ℬ.hom B₀ B₂) ⊗₀ 𝒞.hom C₀ C₂
+        ⊚³ = (𝒜.⊚ ⊗₁ ℬ.⊚) ⊗₁ 𝒞.⊚
+        glue-interchange = glue◽◃ assoc-commute-to interchange-assoc⁻¹
+        in begin
+        α⇐ ∘ ((𝒜.⊚ ⊗₁ ((ℬ.⊚ ⊗₁ 𝒞.⊚) ∘ i⇒)) ∘ i⇒)          ≈⟨ refl⟩∘⟨ pushˡ split₂ʳ ⟩
+        α⇐ ∘ ((𝒜.⊚ ⊗₁ (ℬ.⊚ ⊗₁ 𝒞.⊚)) ∘ ((id ⊗₁ i⇒) ∘ i⇒))  ≈⟨ glue-interchange ⟩
+        ⊚³ ∘ (((i⇒ ⊗₁ id) ∘ i⇒) ∘ (α⇐ ⊗₁ α⇐))             ≈⟨ assoc²δα ⟩
+        ((⊚³ ∘ (i⇒ ⊗₁ id)) ∘ i⇒) ∘ (α⇐ ⊗₁ α⇐)             ≈⟨ merge₁ʳ ⟩∘⟨refl ⟩∘⟨refl ⟩
+        ((((𝒜.⊚ ⊗₁ ℬ.⊚) ∘ i⇒) ⊗₁ 𝒞.⊚) ∘ i⇒) ∘ (α⇐ ⊗₁ α⇐)  ∎
+
+    abstract
+      α-⊚ : α⇒ ∘
+          (((𝒜.⊚ {A₀} {A₁} {A₂} ⊗₁ ℬ.⊚ {B₀} {B₁} {B₂}) ∘ i⇒)
+            ⊗₁ 𝒞.⊚ {C₀} {C₁} {C₂}) ∘ i⇒
+        ≈ ((𝒜.⊚ ⊗₁ ((ℬ.⊚ ⊗₁ 𝒞.⊚) ∘ i⇒)) ∘ i⇒) ∘ (α⇒ ⊗₁ α⇒)
+      α-⊚ = ⟺ (conjugate-to (associator ⊗ᵢ associator) associator α⇐-⊚)
+
+    abstract
+      α⇐-id : α⇐ ∘
+          ((𝒜.id {A₀} ⊗₁ ((ℬ.id {B₀} ⊗₁ 𝒞.id {C₀}) ∘ λ⇐)) ∘ λ⇐)
+        ≈ (((𝒜.id ⊗₁ ℬ.id) ∘ λ⇐) ⊗₁ 𝒞.id) ∘ λ⇐
+      α⇐-id = ⟺ (switch-fromtoˡ associator α-id)
+
+  α⇒F : Functor ((𝒜 ⊠ ℬ) ⊠ 𝒞) (𝒜 ⊠ (ℬ ⊠ 𝒞))
+  α⇒F = record
+    { map₀ = ×α.to
+    ; map₁ = α⇒
+    ; identity = α-id
+    ; homomorphism = α-⊚
+    }
+
+  α⇐F : Functor (𝒜 ⊠ (ℬ ⊠ 𝒞)) ((𝒜 ⊠ ℬ) ⊠ 𝒞)
+  α⇐F = record
+    { map₀ = ×α.from
+    ; map₁ = α⇐
+    ; identity = α⇐-id
+    ; homomorphism = α⇐-⊚
+    }
+
+  private
+    module L = Enriched.Category ((𝒜 ⊠ ℬ) ⊠ 𝒞)
+    module R = Enriched.Category (𝒜 ⊠ (ℬ ⊠ 𝒞))
+    module UL = Underlying ((𝒜 ⊠ ℬ) ⊠ 𝒞)
+    module UR = Underlying (𝒜 ⊠ (ℬ ⊠ 𝒞))
+    module Lₚ = EnrichedProperties M ((𝒜 ⊠ ℬ) ⊠ 𝒞)
+    module Rₚ = EnrichedProperties M (𝒜 ⊠ (ℬ ⊠ 𝒞))
+
+    α⇒∘α⇐ : NaturalIsomorphism (α⇒F ∘F α⇐F) idF
+    α⇒∘α⇐ = record
+      { from = record
+        { comp = λ _ → R.id
+        ; commute = Rₚ.id-commuteˡ associator.isoʳ
+        }
+      ; to = record
+        { comp = λ _ → R.id
+        ; commute = Rₚ.id-commuteʳ associator.isoʳ
+        }
+      ; iso = record { isoˡ = UR.identity² ; isoʳ = UR.identity² }
+      }
+
+    α⇐∘α⇒ : NaturalIsomorphism (α⇐F ∘F α⇒F) idF
+    α⇐∘α⇒ = record
+      { from = record
+        { comp = λ _ → L.id
+        ; commute = Lₚ.id-commuteˡ associator.isoˡ
+        }
+      ; to = record
+        { comp = λ _ → L.id
+        ; commute = Lₚ.id-commuteʳ associator.isoˡ
+        }
+      ; iso = record { isoˡ = UL.identity² ; isoʳ = UL.identity² }
+      }
+
+  ⊠-associator : StrongEquivalence ((𝒜 ⊠ ℬ) ⊠ 𝒞) (𝒜 ⊠ (ℬ ⊠ 𝒞))
+  ⊠-associator = record
+    { F = α⇒F
+    ; G = α⇐F
+    ; weak-inverse = record
+      { F∘G≈id = α⇒∘α⇐
+      ; G∘F≈id = α⇐∘α⇒
+      }
+    }
+
+open Reassociation public
+
+module ReassociationNaturality {v}
+  {𝒜₀ 𝒜₁ ℬ₀ ℬ₁ 𝒞₀ 𝒞₁ : Enriched.Category v}
+  (F : Functor 𝒜₀ 𝒜₁) (G : Functor ℬ₀ ℬ₁) (H : Functor 𝒞₀ 𝒞₁) where
+
+  private
+    module F = Functor F
+    module G = Functor G
+    module H = Functor H
+    module 𝒜₀ = Enriched.Category 𝒜₀
+    module ℬ₀ = Enriched.Category ℬ₀
+    module 𝒞₀ = Enriched.Category 𝒞₀
+    module 𝒟 = Enriched.Category (𝒜₁ ⊠ (ℬ₁ ⊠ 𝒞₁))
+    module 𝒟ₚ = EnrichedProperties M (𝒜₁ ⊠ (ℬ₁ ⊠ 𝒞₁))
+    module U𝒟 = Underlying (𝒜₁ ⊠ (ℬ₁ ⊠ 𝒞₁))
+
+    variable
+      A B : 𝒜₀.Obj -- source and target in each factor
+      X Y : ℬ₀.Obj
+      W Z : 𝒞₀.Obj
+
+    α-natural : α⇒ ∘ ((F.₁ {A} {B} ⊗₁ G.₁ {X} {Y}) ⊗₁ H.₁ {W} {Z})
+      ≈ (F.₁ ⊗₁ (G.₁ ⊗₁ H.₁)) ∘ α⇒
+    α-natural = assoc-commute-from
+
+  ⊠-associator-commute : NaturalIsomorphism
+    (α⇒F 𝒜₁ ℬ₁ 𝒞₁ ∘F ((F ⊠F G) ⊠F H))
+    ((F ⊠F (G ⊠F H)) ∘F α⇒F 𝒜₀ ℬ₀ 𝒞₀)
+  ⊠-associator-commute = record
+    { from = record
+      { comp = λ _ → 𝒟.id
+      ; commute = 𝒟ₚ.id-commuteˡ α-natural
+      }
+    ; to = record
+      { comp = λ _ → 𝒟.id
+      ; commute = 𝒟ₚ.id-commuteʳ α-natural
+      }
+    ; iso = record { isoˡ = U𝒟.identity² ; isoʳ = U𝒟.identity² }
+    }
+
+open ReassociationNaturality public
+
+swap² : ∀ {v} (𝒜 ℬ : Enriched.Category v) →
+  NaturalIsomorphism (swapF ∘F swapF) (idF {C = 𝒜 ⊠ ℬ})
+swap² 𝒜 ℬ = record
+  { from = record
+    { comp = λ _ → 𝒜⊠ℬ.id
+    ; commute = 𝒜⊠ℬₚ.id-commuteˡ commutative
+    }
+  ; to = record
+    { comp = λ _ → 𝒜⊠ℬ.id
+    ; commute = 𝒜⊠ℬₚ.id-commuteʳ commutative
+    }
+  ; iso = record { isoˡ = U𝒜⊠ℬ.identity² ; isoʳ = U𝒜⊠ℬ.identity² }
+  }
+  where
+    module 𝒜⊠ℬ = Enriched.Category (𝒜 ⊠ ℬ)
+    module U𝒜⊠ℬ = Underlying (𝒜 ⊠ ℬ)
+    module 𝒜⊠ℬₚ = EnrichedProperties M (𝒜 ⊠ ℬ)
+
+private
+  swap-inverse : ∀ {v} (𝒜 ℬ : Enriched.Category v) →
+    WeakInverse
+      (swapF {𝒜 = 𝒜} {ℬ = ℬ})
+      (swapF {𝒜 = ℬ} {ℬ = 𝒜})
+  swap-inverse 𝒜 ℬ = record
+    { F∘G≈id = swap² ℬ 𝒜
+    ; G∘F≈id = swap² 𝒜 ℬ
+    }
+
+⊠-swap : ∀ {v} (𝒜 ℬ : Enriched.Category v) → StrongEquivalence (𝒜 ⊠ ℬ) (ℬ ⊠ 𝒜)
+⊠-swap 𝒜 ℬ = record
+  { F = swapF
+  ; G = swapF
+  ; weak-inverse = swap-inverse 𝒜 ℬ
+  }
+
+module SwapNaturality {v}
+  {𝒜₀ 𝒜₁ ℬ₀ ℬ₁ : Enriched.Category v}
+  (F : Functor 𝒜₀ 𝒜₁) (G : Functor ℬ₀ ℬ₁) where
+
+  private
+    module F = Functor F
+    module G = Functor G
+    module 𝒟 = Enriched.Category (ℬ₁ ⊠ 𝒜₁)
+    module 𝒟ₚ = EnrichedProperties M (ℬ₁ ⊠ 𝒜₁)
+    module U𝒟 = Underlying (ℬ₁ ⊠ 𝒜₁)
+
+    module 𝒜₀ = Enriched.Category 𝒜₀
+    module ℬ₀ = Enriched.Category ℬ₀
+
+    variable
+      A B : 𝒜₀.Obj -- source and target in each factor
+      X Y : ℬ₀.Obj
+
+  ⊠-swap-commute : NaturalIsomorphism (swapF ∘F (F ⊠F G)) ((G ⊠F F) ∘F swapF)
+  ⊠-swap-commute = record
+    { from = record
+      { comp = λ _ → 𝒟.id
+      ; commute = 𝒟ₚ.id-commuteˡ σ⇒-comm
+      }
+    ; to = record
+      { comp = λ _ → 𝒟.id
+      ; commute = 𝒟ₚ.id-commuteʳ σ⇒-comm
+      }
+    ; iso = record { isoˡ = U𝒟.identity² ; isoʳ = U𝒟.identity² }
+    }
+
+open SwapNaturality public

--- a/src/Categories/Enriched/Category/TensorProduct/Properties.agda
+++ b/src/Categories/Enriched/Category/TensorProduct/Properties.agda
@@ -81,6 +81,7 @@ module Reassociation {v} (𝒜 ℬ 𝒞 : Enriched.Category v) where
         identities : unit ⊗₀ (unit ⊗₀ unit) ⇒
           𝒜.hom A₀ A₀ ⊗₀ (ℬ.hom B₀ B₀ ⊗₀ 𝒞.hom C₀ C₀)
         identities = 𝒜.id ⊗₁ (ℬ.id ⊗₁ 𝒞.id)
+        glue-unit : α⇒ ∘ (((𝒜.id ⊗₁ ℬ.id) ⊗₁ 𝒞.id) ∘ (λ⇐ ⊗₁ id)) ≈ identities ∘ λ⇐
         glue-unit = glue◽◃ assoc-commute-from unit-insertion
         in begin
         α⇒ ∘ ((((𝒜.id ⊗₁ ℬ.id) ∘ λ⇐) ⊗₁ 𝒞.id) ∘ λ⇐)         ≈⟨ refl⟩∘⟨ split₁ʳ ⟩∘⟨refl ⟩
@@ -117,6 +118,9 @@ module Reassociation {v} (𝒜 ℬ 𝒞 : Enriched.Category v) where
                ⊗₀ (𝒞.hom C₁ C₂ ⊗₀ 𝒞.hom C₀ C₁))
              ⇒ (𝒜.hom A₀ A₂ ⊗₀ ℬ.hom B₀ B₂) ⊗₀ 𝒞.hom C₀ C₂
         ⊚³ = (𝒜.⊚ ⊗₁ ℬ.⊚) ⊗₁ 𝒞.⊚
+        glue-interchange : α⇐ ∘
+            ((𝒜.⊚ ⊗₁ (ℬ.⊚ ⊗₁ 𝒞.⊚)) ∘ ((id ⊗₁ i⇒) ∘ i⇒))
+          ≈ ⊚³ ∘ (((i⇒ ⊗₁ id) ∘ i⇒) ∘ (α⇐ ⊗₁ α⇐))
         glue-interchange = glue◽◃ assoc-commute-to interchange-assoc⁻¹
         in begin
         α⇐ ∘ ((𝒜.⊚ ⊗₁ ((ℬ.⊚ ⊗₁ 𝒞.⊚) ∘ i⇒)) ∘ i⇒)          ≈⟨ refl⟩∘⟨ pushˡ split₂ʳ ⟩

--- a/src/Categories/Enriched/NaturalTransformation/NaturalIsomorphism.agda
+++ b/src/Categories/Enriched/NaturalTransformation/NaturalIsomorphism.agda
@@ -35,6 +35,25 @@ module _ {c d} {C : Category c} {D : Category d} where
   NaturalIsomorphism F G = F ≅ G
     where open Morphism (EnrichedFunctors C D) using (_≅_)
 
+  -- Lift pointwise inverse laws for enriched natural transformations to an
+  -- isomorphism in the enriched functor category.
+
+  record NIHelper (F G : Functor C D) : Set (ℓ ⊔ e ⊔ c) where
+    field
+      F⇒G : NaturalTransformation F G
+      F⇐G : NaturalTransformation G F
+      iso  : ∀ X → Morphism.Iso (Underlying D) (F⇒G [ X ]) (F⇐G [ X ])
+
+  niHelper : {F G : Functor C D} → NIHelper F G → NaturalIsomorphism F G
+  niHelper α = record
+    { from = NIHelper.F⇒G α
+    ; to = NIHelper.F⇐G α
+    ; iso = record
+      { isoˡ = λ {X} → Morphism.Iso.isoˡ (NIHelper.iso α X)
+      ; isoʳ = λ {X} → Morphism.Iso.isoʳ (NIHelper.iso α X)
+      }
+    }
+
   -- A commonly used shorthand for NaturalIsomorphism
 
   infix 4 _≃_

--- a/src/Categories/Enriched/NaturalTransformation/TensorProduct.agda
+++ b/src/Categories/Enriched/NaturalTransformation/TensorProduct.agda
@@ -1,0 +1,181 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+open import Categories.Category.Monoidal.Interchange using (HasInterchange)
+
+-- Tensor products of enriched natural transformations.
+
+module Categories.Enriched.NaturalTransformation.TensorProduct
+  {o ℓ e} {V : Category o ℓ e} {M : Monoidal V} (I : HasInterchange M) where
+
+open import Data.Product using (_,_)
+
+import Categories.Enriched.Category as Enriched
+open import Categories.Enriched.Category M using (_[_,_])
+
+open Category V
+open Monoidal M
+open HasInterchange I using (module swapInner)
+  renaming (natural to interchange-natural; unitˡ to interchange-unitˡ;
+            unitʳ to interchange-unitʳ)
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Category.Monoidal.Utilities M
+open import Categories.Enriched.Category.TensorProduct I using (_⊠_)
+open import Categories.Enriched.Functor M using (Functor)
+open import Categories.Enriched.Functor.TensorProduct I using (_⊠F_)
+open import Categories.Enriched.NaturalTransformation M using (NaturalTransformation)
+open import Categories.Enriched.NaturalTransformation.NaturalIsomorphism M
+  using (NaturalIsomorphism; _ᵢ[_])
+open import Categories.Morphism.Reasoning V
+open Shorthands
+open NaturalIsomorphism
+
+private
+  variable
+    P Q R S : Obj
+
+  open swapInner using () renaming (from to i⇒)
+
+  i⇒λ : i⇒ ∘ (λ⇐ ⊗₁ id) ≈ (λ⇐ {P} ⊗₁ λ⇐ {Q}) ∘ λ⇒
+  i⇒λ = switch-fromtoˡ (unitorˡ ⊗ᵢ unitorˡ) interchange-unitˡ
+
+  i⇒ρ : i⇒ ∘ (id ⊗₁ λ⇐) ≈ (ρ⇐ {P} ⊗₁ ρ⇐ {Q}) ∘ ρ⇒
+  i⇒ρ = switch-fromtoˡ (unitorʳ ⊗ᵢ unitorʳ) interchange-unitʳ
+
+  iλ² : i⇒ ∘ (λ⇐ ⊗₁ id) ∘ λ⇐ ≈ λ⇐ {P} ⊗₁ λ⇐ {Q}
+  iλ² = begin
+    i⇒ ∘ (λ⇐ ⊗₁ id) ∘ λ⇐        ≈⟨ pullˡ i⇒λ ⟩
+    ((λ⇐ ⊗₁ λ⇐) ∘ λ⇒) ∘ λ⇐      ≈⟨ cancelʳ unitorˡ.isoʳ ⟩
+    λ⇐ ⊗₁ λ⇐                    ∎
+
+  iρ² : i⇒ ∘ (id ⊗₁ λ⇐) ∘ ρ⇐ ≈ ρ⇐ {P} ⊗₁ ρ⇐ {Q}
+  iρ² = begin
+    i⇒ ∘ (id ⊗₁ λ⇐) ∘ ρ⇐        ≈⟨ pullˡ i⇒ρ ⟩
+    ((ρ⇐ ⊗₁ ρ⇐) ∘ ρ⇒) ∘ ρ⇐      ≈⟨ cancelʳ unitorʳ.isoʳ ⟩
+    ρ⇐ ⊗₁ ρ⇐                    ∎
+
+module _ {a b c d}
+  {𝒜 : Enriched.Category M a} {ℬ : Enriched.Category M b}
+  {𝒞 : Enriched.Category M c} {𝒟 : Enriched.Category M d} where
+
+  private
+    module 𝒜 = Enriched.Category 𝒜
+    module ℬ = Enriched.Category ℬ
+    module 𝒞 = Enriched.Category 𝒞
+    module 𝒟 = Enriched.Category 𝒟
+    module 𝒞⊠𝒟 = Enriched.Category (𝒞 ⊠ 𝒟)
+
+    variable
+      A B C : 𝒞.Obj
+      X Y Z : 𝒟.Obj
+
+  private abstract
+    ⊚⊠ˡ : {p : unit ⇒ 𝒞 [ B , C ]} {q : unit ⇒ 𝒟 [ Y , Z ]}
+      {f : R ⇒ 𝒞 [ A , B ]} {g : S ⇒ 𝒟 [ X , Y ]} →
+      𝒞⊠𝒟.⊚ ∘ (((p ⊗₁ q) ∘ λ⇐) ⊗₁ (f ⊗₁ g)) ∘ λ⇐
+      ≈ (𝒞.⊚ ∘ (p ⊗₁ f) ∘ λ⇐) ⊗₁ (𝒟.⊚ ∘ (q ⊗₁ g) ∘ λ⇐)
+    ⊚⊠ˡ {p = p} {q} {f} {g} = begin
+      𝒞⊠𝒟.⊚ ∘ (((p ⊗₁ q) ∘ λ⇐) ⊗₁ (f ⊗₁ g)) ∘ λ⇐
+        ≈⟨ pullʳ (refl⟩∘⟨ pushˡ split₁ʳ) ⟩
+      (𝒞.⊚ ⊗₁ 𝒟.⊚) ∘ i⇒ ∘ ((p ⊗₁ q) ⊗₁ (f ⊗₁ g)) ∘
+        (λ⇐ ⊗₁ id) ∘ λ⇐
+        ≈⟨ refl⟩∘⟨ extendʳ interchange-natural ⟩
+      (𝒞.⊚ ⊗₁ 𝒟.⊚) ∘ ((p ⊗₁ f) ⊗₁ (q ⊗₁ g)) ∘ i⇒ ∘
+        (λ⇐ ⊗₁ id) ∘ λ⇐
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ iλ² ⟩
+      (𝒞.⊚ ⊗₁ 𝒟.⊚) ∘ ((p ⊗₁ f) ⊗₁ (q ⊗₁ g)) ∘ (λ⇐ ⊗₁ λ⇐)
+        ≈⟨ refl⟩∘⟨ ⊗.homomorphism ⟨
+      (𝒞.⊚ ⊗₁ 𝒟.⊚) ∘ ((p ⊗₁ f ∘ λ⇐) ⊗₁ (q ⊗₁ g ∘ λ⇐))
+        ≈⟨ ⊗.homomorphism ⟨
+      (𝒞.⊚ ∘ (p ⊗₁ f) ∘ λ⇐) ⊗₁ (𝒟.⊚ ∘ (q ⊗₁ g) ∘ λ⇐) ∎
+
+    ⊚⊠ʳ : {p : P ⇒ 𝒞 [ B , C ]} {q : Q ⇒ 𝒟 [ Y , Z ]}
+      {f : unit ⇒ 𝒞 [ A , B ]} {g : unit ⇒ 𝒟 [ X , Y ]} →
+      𝒞⊠𝒟.⊚ ∘ ((p ⊗₁ q) ⊗₁ ((f ⊗₁ g) ∘ λ⇐)) ∘ ρ⇐
+      ≈ (𝒞.⊚ ∘ (p ⊗₁ f) ∘ ρ⇐) ⊗₁ (𝒟.⊚ ∘ (q ⊗₁ g) ∘ ρ⇐)
+    ⊚⊠ʳ {p = p} {q} {f} {g} = begin
+      𝒞⊠𝒟.⊚ ∘ ((p ⊗₁ q) ⊗₁ ((f ⊗₁ g) ∘ λ⇐)) ∘ ρ⇐
+        ≈⟨ pullʳ (refl⟩∘⟨ pushˡ split₂ʳ) ⟩
+      (𝒞.⊚ ⊗₁ 𝒟.⊚) ∘ i⇒ ∘ ((p ⊗₁ q) ⊗₁ (f ⊗₁ g)) ∘
+        (id ⊗₁ λ⇐) ∘ ρ⇐
+        ≈⟨ refl⟩∘⟨ extendʳ interchange-natural ⟩
+      (𝒞.⊚ ⊗₁ 𝒟.⊚) ∘ ((p ⊗₁ f) ⊗₁ (q ⊗₁ g)) ∘ i⇒ ∘
+        (id ⊗₁ λ⇐) ∘ ρ⇐
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ iρ² ⟩
+      (𝒞.⊚ ⊗₁ 𝒟.⊚) ∘ ((p ⊗₁ f) ⊗₁ (q ⊗₁ g)) ∘ (ρ⇐ ⊗₁ ρ⇐)
+        ≈⟨ refl⟩∘⟨ ⊗.homomorphism ⟨
+      (𝒞.⊚ ⊗₁ 𝒟.⊚) ∘ ((p ⊗₁ f ∘ ρ⇐) ⊗₁ (q ⊗₁ g ∘ ρ⇐))
+        ≈⟨ ⊗.homomorphism ⟨
+      (𝒞.⊚ ∘ (p ⊗₁ f) ∘ ρ⇐) ⊗₁ (𝒟.⊚ ∘ (q ⊗₁ g) ∘ ρ⇐) ∎
+
+    ⊚⊠ : {p : unit ⇒ 𝒞 [ B , C ]} {q : unit ⇒ 𝒟 [ Y , Z ]}
+      {f : unit ⇒ 𝒞 [ A , B ]} {g : unit ⇒ 𝒟 [ X , Y ]} →
+      𝒞⊠𝒟.⊚ ∘ (((p ⊗₁ q) ∘ λ⇐) ⊗₁ ((f ⊗₁ g) ∘ λ⇐)) ∘ λ⇐
+      ≈ ((𝒞.⊚ ∘ (p ⊗₁ f) ∘ λ⇐) ⊗₁ (𝒟.⊚ ∘ (q ⊗₁ g) ∘ λ⇐)) ∘ λ⇐
+    ⊚⊠ {p = p} {q} {f} {g} = begin
+      𝒞⊠𝒟.⊚ ∘ ((p ⊗₁ q) ∘ λ⇐) ⊗₁ ((f ⊗₁ g) ∘ λ⇐) ∘ λ⇐       ≈⟨ refl⟩∘⟨ pushˡ split₂ʳ ⟩
+      𝒞⊠𝒟.⊚ ∘ ((p ⊗₁ q) ∘ λ⇐) ⊗₁ (f ⊗₁ g) ∘ (id ⊗₁ λ⇐) ∘ λ⇐ ≈⟨ refl⟩∘⟨ refl⟩∘⟨ unitorˡ-commute-to ⟨
+      𝒞⊠𝒟.⊚ ∘ (((p ⊗₁ q) ∘ λ⇐) ⊗₁ (f ⊗₁ g)) ∘ λ⇐ ∘ λ⇐       ≈⟨ assoc²εβ ⟩
+      (𝒞⊠𝒟.⊚ ∘ (((p ⊗₁ q) ∘ λ⇐) ⊗₁ (f ⊗₁ g)) ∘ λ⇐) ∘ λ⇐     ≈⟨ ⊚⊠ˡ ⟩∘⟨refl ⟩
+      ((𝒞.⊚ ∘ (p ⊗₁ f) ∘ λ⇐) ⊗₁ (𝒟.⊚ ∘ (q ⊗₁ g) ∘ λ⇐)) ∘ λ⇐ ∎
+
+  infixr 7 _⊠NT_ _⊠NI_
+  open NaturalTransformation
+
+  private abstract
+    ⊠-commute : {F G : Functor 𝒜 𝒞} {H K : Functor ℬ 𝒟}
+      (α : NaturalTransformation F G) (β : NaturalTransformation H K) →
+      {A₁ A₂ : 𝒜.Obj} {B₁ B₂ : ℬ.Obj} →
+        𝒞⊠𝒟.⊚ ∘ (((α [ A₂ ] ⊗₁ β [ B₂ ]) ∘ λ⇐) ⊗₁ (Functor.₁ F ⊗₁ Functor.₁ H))  ∘ λ⇐
+      ≈ 𝒞⊠𝒟.⊚ ∘ ((Functor.₁ G ⊗₁ Functor.₁ K)  ⊗₁ ((α [ A₁ ] ⊗₁ β [ B₁ ]) ∘ λ⇐)) ∘ ρ⇐
+    ⊠-commute {F = F} {G} {H} {K} α β {A₁} {A₂} {B₁} {B₂} = begin
+      𝒞⊠𝒟.⊚ ∘
+        (((α [ A₂ ] ⊗₁ β [ B₂ ]) ∘ λ⇐) ⊗₁ (F.₁ ⊗₁ H.₁)) ∘ λ⇐            ≈⟨ ⊚⊠ˡ ⟩
+      (𝒞.⊚ ∘ (α [ A₂ ] ⊗₁ F.₁) ∘ λ⇐) ⊗₁ (𝒟.⊚ ∘ (β [ B₂ ] ⊗₁ H.₁) ∘ λ⇐)  ≈⟨ α.commute ⟩⊗⟨ β.commute ⟩
+      (𝒞.⊚ ∘ (G.₁ ⊗₁ α [ A₁ ]) ∘ ρ⇐) ⊗₁ (𝒟.⊚ ∘ (K.₁ ⊗₁ β [ B₁ ]) ∘ ρ⇐)  ≈⟨ ⊚⊠ʳ ⟨
+      𝒞⊠𝒟.⊚ ∘ ((G.₁ ⊗₁ K.₁) ⊗₁ ((α [ A₁ ] ⊗₁ β [ B₁ ]) ∘ λ⇐)) ∘ ρ⇐      ∎
+      where
+        module F = Functor F
+        module G = Functor G
+        module H = Functor H
+        module K = Functor K
+        module α = NaturalTransformation α
+        module β = NaturalTransformation β
+
+  _⊠NT_ : {F G : Functor 𝒜 𝒞} {H K : Functor ℬ 𝒟} →
+    NaturalTransformation F G → NaturalTransformation H K →
+    NaturalTransformation (F ⊠F H) (G ⊠F K)
+  α ⊠NT β = record
+    { comp = λ (A , X) → (α [ A ] ⊗₁ β [ X ]) ∘ λ⇐
+    ; commute = ⊠-commute α β
+    }
+
+  private abstract
+    ⊠-isoˡ : {F G : Functor 𝒜 𝒞} {H K : Functor ℬ 𝒟}
+      (α : NaturalIsomorphism F G) (β : NaturalIsomorphism H K) →
+      {A₁ : 𝒜.Obj} {B₁ : ℬ.Obj} →
+      𝒞⊠𝒟.⊚ ∘ (((to α [ A₁ ] ⊗₁ to β [ B₁ ]) ∘ λ⇐) ⊗₁
+        ((from α [ A₁ ] ⊗₁ from β [ B₁ ]) ∘ λ⇐)) ∘ λ⇐
+      ≈ (𝒞.id ⊗₁ 𝒟.id) ∘ λ⇐
+    ⊠-isoˡ α β = ⊚⊠ ○ (isoˡ α ⟩⊗⟨ isoˡ β ⟩∘⟨refl)
+
+    ⊠-isoʳ : {F G : Functor 𝒜 𝒞} {H K : Functor ℬ 𝒟}
+      (α : NaturalIsomorphism F G) (β : NaturalIsomorphism H K) →
+      {A₁ : 𝒜.Obj} {B₁ : ℬ.Obj} →
+      𝒞⊠𝒟.⊚ ∘ (((from α [ A₁ ] ⊗₁ from β [ B₁ ]) ∘ λ⇐) ⊗₁
+        ((to α [ A₁ ] ⊗₁ to β [ B₁ ]) ∘ λ⇐)) ∘ λ⇐
+      ≈ (𝒞.id ⊗₁ 𝒟.id) ∘ λ⇐
+    ⊠-isoʳ α β = ⊚⊠ ○ (isoʳ α ⟩⊗⟨ isoʳ β ⟩∘⟨refl)
+
+  _⊠NI_ : {F G : Functor 𝒜 𝒞} {H K : Functor ℬ 𝒟} →
+    NaturalIsomorphism F G → NaturalIsomorphism H K →
+    NaturalIsomorphism (F ⊠F H) (G ⊠F K)
+  α ⊠NI β = record
+    { from = from α ⊠NT from β
+    ; to = to α ⊠NT to β
+    ; iso = record
+      { isoˡ = ⊠-isoˡ α β
+      ; isoʳ = ⊠-isoʳ α β
+      }
+    }


### PR DESCRIPTION
## Summary

Develop the scalar, transformation, and coherence infrastructure needed to
treat tensor products of enriched categories monoidally.

This adds:

- the symmetric monoidal category associated to a commutative monoid
- the action `Scale⟦_⟧` of monoidal scalars as natural transformations of the
  identity functor
- the one-object enriched category `V-Scalar`
- `NIHelper`, lifting pointwise inverse laws to enriched natural isomorphisms
- tensor products of enriched natural transformations and natural
  isomorphisms
- strong associator and swap equivalences for `⊠`, including their naturality
- generic unit and equivalence lemmas used by these constructions

## Motivation

PR #544 constructs tensor products of enriched categories and enriched
functors. The next layer requires tensor products of their transformations and
the associator and swap equivalences that compare differently bracketed or
ordered tensor products.

The eventual tensor unit is the one-object `V`-enriched category

    V-Scalar [ _ , _ ] = unit.

The accompanying ordinary scalar calculus records the Eckmann–Hilton
phenomenon: endomorphisms of the tensor unit form a commutative monoid and act
naturally on every morphism. Packaging a commutative monoid as a one-object
symmetric monoidal category makes the relationship with `V-Scalar` explicit.

This PR provides the reusable scalar and tensor-coherence ingredients without
yet assembling the category of enriched categories into a monoidal category.
It extends PR #544 and is independent of PRs #538 and #540.
