### PR TITLE
Prove tensor and double-dual coherence for rigid categories

### DIFF
--- a/src/Categories/Category/Monoidal/Reassociation.agda
+++ b/src/Categories/Category/Monoidal/Reassociation.agda
@@ -37,6 +37,9 @@ private
   α⇒ ∘ (α⇐ ∘ λ⇐)    ≈⟨ cancelˡ associator.isoʳ ⟩
   λ⇐                ∎
 
+λ⇒-α⇐ : id {X} ⊗₁ λ⇒ {Y} ≈ (ρ⇒ ⊗₁ id) ∘ α⇐
+λ⇒-α⇐ = switch-fromtoʳ associator triangle
+
 ρ⇒-assoc : ρ⇒ ∘ α⇐ {X} {Y} {unit} ≈ id ⊗₁ ρ⇒
 ρ⇒-assoc = ⟺ (switch-fromtoʳ associator coherence₂)
 

--- a/src/Categories/Category/Monoidal/Rigid/Properties.agda
+++ b/src/Categories/Category/Monoidal/Rigid/Properties.agda
@@ -1,0 +1,443 @@
+{-# OPTIONS --without-K --safe #-}
+
+-- Consequences of rigidity: rigidity transfers to the opposite monoidal category
+-- (`rigidˡ-Op` / `rigidʳ-Op`), and duals are closed under tensor — `[ X ⊗ Y ]⁻¹`
+-- with its cup/cap and the flip iso `[ X ⊗ Y ]⁻¹ ≅ Y ⁻¹ ⊗₀ X ⁻¹` (modules `Left`/`Right`).
+
+open import Categories.Category.Core using (Category)
+open import Categories.Category.Monoidal.Core using (Monoidal)
+
+module Categories.Category.Monoidal.Rigid.Properties
+    {o ℓ e} {C : Category o ℓ e} (M : Monoidal C) where
+
+import Categories.Category.Monoidal.Rigid M as Rigid
+open Rigid using (LeftRigid; RightRigid)
+import Categories.Category.Monoidal.Rigid as RigidModule
+import Categories.Category.Monoidal.Rigid.Dual as RigidDual
+
+open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Morphism.Reasoning C
+open import Categories.Morphism C using (_≅_)
+open import Categories.Category.Monoidal.Properties M
+  using (coherence-inv₃; monoidal-Op)
+open import Categories.Category.Monoidal.Reassociation M
+  using ( α⇐-id⊗-commute; λ⇐-assoc; λ⇒-assoc; λ⇒-α⇐; ρ⇐-assoc
+        ; pentagon-collapse-inv; whisker-comm )
+open import Categories.Category.Monoidal.CupCap M
+import Categories.Category.Monoidal.Utilities M as MonUtil
+
+open Category C
+  using (Obj; _⇒_; _≈_; id; _∘_; assoc; sym-assoc; module Equiv)
+open Monoidal M
+open MonUtil.Shorthands
+
+private
+  variable
+    A B W X Y Z : Obj
+
+  merge₂³-tail : {f : Y ⇒ Z} {g : X ⇒ Y} {h : W ⇒ X} {k : B ⇒ A ⊗₀ W} →
+    (id ⊗₁ f) ∘ (id ⊗₁ g) ∘ (id ⊗₁ h) ∘ k ≈ (id ⊗₁ (f ∘ g ∘ h)) ∘ k
+  merge₂³-tail = assoc²εβ ○ (merge₂³ ⟩∘⟨refl)
+
+rigidʳ-Op : RightRigid → RigidModule.LeftRigid monoidal-Op
+rigidʳ-Op R = record
+  { _⁻¹ = Rigid.RightRigid._⁻¹ R
+  ; η = Rigid.RightRigid.ε R
+  ; ε = Rigid.RightRigid.η R
+  ; snake₁ = assoc²αε ○ assoc ○ Rigid.RightRigid.snake₁ R
+  ; snake₂ = assoc²αε ○ assoc ○ Rigid.RightRigid.snake₂ R
+  }
+
+rigidˡ-Op : LeftRigid → RigidModule.RightRigid monoidal-Op
+rigidˡ-Op L = record
+  { _⁻¹ = Rigid.LeftRigid._⁻¹ L
+  ; η = Rigid.LeftRigid.ε L
+  ; ε = Rigid.LeftRigid.η L
+  ; snake₁ = assoc²αε ○ assoc ○ Rigid.LeftRigid.snake₁ L
+  ; snake₂ = assoc²αε ○ assoc ○ Rigid.LeftRigid.snake₂ L
+  }
+
+module Left (L : LeftRigid) where
+  open LeftRigid L using (_⁻¹; η; ε; snake₁; dual₁)
+  open RigidDual M L
+    using ( capˡ; capᵀ; capᵀ-cup; capᵀ-ε; cupᵀ; cupᵀ-unbend; cupˡ
+          ; cupᵀ-η; cupᵀ-unique; dual-uniqueˡ; dual₁-cup; snakeˡ-wire
+          ; snakeˡ-dual )
+
+  infix 4 [_⊗_]⁻¹
+
+  [_⊗_]⁻¹ : Obj → Obj → Obj
+  [ X ⊗ Y ]⁻¹ = Y ⁻¹ ⊗₀ X ⁻¹
+
+  private
+    -- `ε`, with `k` run along its wire first.
+    capₖ : {k : Y ⇒ X} → X ⁻¹ ⊗₀ Y ⇒ unit
+    capₖ {k = k} = ε ∘ (id ⊗₁ k)
+
+    abstract
+      unit-cup : cup-bendˡ {A = X} λ⇐ ≈ λ⇐ ∘ λ⇐
+      unit-cup = pullˡ λ⇐-assoc
+
+      unit-snakeˡ : ρ⇒ ∘ (id {unit} ⊗₁ λ⇒) ∘ α⇒ ∘ (λ⇐ ⊗₁ id) ∘ λ⇐ ≈ id
+      unit-snakeˡ = begin
+        ρ⇒ ∘ (id ⊗₁ λ⇒) ∘ α⇒ ∘ (λ⇐ ⊗₁ id) ∘ λ⇐  ≈⟨ refl⟩∘⟨ refl⟩∘⟨ unit-cup ⟩
+        ρ⇒ ∘ (id ⊗₁ λ⇒) ∘ λ⇐ ∘ λ⇐              ≈⟨ refl⟩∘⟨ extendʳ (⟺ unitorˡ-commute-to) ⟩
+        ρ⇒ ∘ λ⇐ ∘ λ⇒ ∘ λ⇐                       ≈⟨ refl⟩∘⟨ elimʳ unitorˡ.isoʳ ⟩
+        ρ⇒ ∘ λ⇐                                   ≈⟨ refl⟩∘⟨ coherence-inv₃ ⟩
+        ρ⇒ ∘ ρ⇐                                   ≈⟨ unitorʳ.isoʳ ⟩
+        id                                        ∎
+
+      unit-snakeʳ : λ⇒ ∘ (λ⇒ ⊗₁ id {unit}) ∘ α⇐ ∘ (id ⊗₁ λ⇐) ∘ ρ⇐ ≈ id
+      unit-snakeʳ = begin
+        λ⇒ ∘ (λ⇒ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ λ⇐) ∘ ρ⇐    ≈⟨ refl⟩∘⟨ pullˡ λ⇒-assoc ⟩
+        λ⇒ ∘ λ⇒ ∘ (id ⊗₁ λ⇐) ∘ ρ⇐                 ≈⟨ refl⟩∘⟨ extendʳ unitorˡ-commute-from ⟩
+        λ⇒ ∘ λ⇐ ∘ λ⇒ ∘ ρ⇐                         ≈⟨ cancelˡ unitorˡ.isoʳ ⟩
+        λ⇒ ∘ ρ⇐                                   ≈⟨ refl⟩∘⟨ coherence-inv₃ ⟨
+        λ⇒ ∘ λ⇐                                   ≈⟨ unitorˡ.isoʳ ⟩
+        id                                        ∎
+
+  unit⁻¹-iso : unit ≅ unit ⁻¹
+  unit⁻¹-iso = dual-uniqueˡ λ⇐ λ⇒ unit-snakeˡ unit-snakeʳ
+  module unit≅unit⁻¹ = _≅_ unit⁻¹-iso
+  open unit≅unit⁻¹ using () renaming (to to unit⁻¹⇐; from to unit⁻¹⇒)
+
+  -- The tensor dual `[ X ⊗ Y ]⁻¹ = Y ⁻¹ ⊗₀ X ⁻¹` is dual to `X ⊗₀ Y` by nesting
+  -- one bend inside the other — and that nesting is exactly why the dual reverses
+  -- its factors: the `X`-bend has to reach around the `Y`-bend.
+  --
+  --                ⊗-cup                                ⊗-cap
+  --
+  --   X      Y     Y ⁻¹    X ⁻¹            ╭───────────────────────────╮
+  --   │      │      │       │              │       ╭───────────╮       │
+  --   │      ╰──────╯       │   ← η        │       │           │       │
+  --   │         ↑ inner     │              │       │           │       │
+  --   ╰─────────────────────╯   ← η      Y ⁻¹    X ⁻¹          X       Y
+  --             ↑ outer                              ↑ inner ε
+  --                                          ↑ outer ε
+
+  ⊗-cup : unit ⇒ (X ⊗₀ Y) ⊗₀ [ X ⊗ Y ]⁻¹
+  ⊗-cup = cup-nest η η
+
+  ⊗-cap : [ X ⊗ Y ]⁻¹ ⊗₀ (X ⊗₀ Y) ⇒ unit
+  ⊗-cap = ε ∘ (id ⊗₁ capˡ) ∘ α⇒
+
+  private
+    cup-core : (cup : unit ⇒ X ⊗₀ Y) → A ⊗₀ B ⇒ X ⊗₀ ((Y ⊗₀ A) ⊗₀ B)
+    cup-core cup = α⇒ ∘ (cup-bendˡ cup ⊗₁ id)
+
+    cupˡ-core : A ⊗₀ B ⇒ Y ⊗₀ ((Y ⁻¹ ⊗₀ A) ⊗₀ B)
+    cupˡ-core = cup-core η
+
+    open-nest : (cup₀ : unit ⇒ A ⊗₀ B) (cup₁ : unit ⇒ X ⊗₀ Y) →
+                cup-bendˡ {A = Z} (cup-nest cup₀ cup₁)
+                ≈ (α⇐ ∘ (id ⊗₁ cup-core cup₁)) ∘ cup-bendˡ cup₀
+    open-nest cup₀ cup₁ = begin
+      α⇒ ∘ (cup-nest cup₀ cup₁ ⊗₁ id) ∘ λ⇐  ≈⟨ refl⟩∘⟨ split₁³ ⟩∘⟨refl ⟩
+      unit-conjˡ nested                     ≈⟨ cup-slideˡ ⟩
+      (head ∘ (α⇒ ∘ (cup₀ ⊗₁ id))) ∘ λ⇐     ≈⟨ pullʳ assoc ⟩
+      head ∘ cup-bendˡ cup₀                 ∎
+      where
+        nested = (α⇐ ⊗₁ id) ∘ ((id ⊗₁ cup-bendˡ cup₁) ⊗₁ id) ∘ (cup₀ ⊗₁ id)
+        head = α⇐ ∘ (id ⊗₁ cup-core cup₁)
+
+    -- `cupˡ` is natural in `k`: walk `k` down the cup's three factors, past the
+    -- associator, through the cup itself, and out along the unitor.
+    cupˡ-natural : {k : A ⇒ B} →
+                   (id {X} ⊗₁ (id {X ⁻¹} ⊗₁ k)) ∘ cupˡ ≈ cupˡ ∘ k
+    cupˡ-natural = cup-bendˡ-commute η
+
+    cupˡ-map : {f : X ⇒ Y} {k : A ⇒ B} →
+               (id {Y} ⊗₁ (dual₁ f ⊗₁ k)) ∘ cupˡ ≈ (f ⊗₁ id) ∘ cupˡ ∘ k
+    cupˡ-map {f = f} {k} = begin
+      (id ⊗₁ (dual₁ f ⊗₁ k)) ∘ cupˡ                       ≈⟨ refl⟩⊗⟨ serialize₁₂ ⟩∘⟨refl ⟩
+      (id ⊗₁ ((dual₁ f ⊗₁ id) ∘ (id ⊗₁ k))) ∘ cupˡ        ≈⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ (dual₁ f ⊗₁ id)) ∘ (id ⊗₁ (id ⊗₁ k)) ∘ cupˡ  ≈⟨ refl⟩∘⟨ cupˡ-natural ⟩
+      (id ⊗₁ (dual₁ f ⊗₁ id)) ∘ cupˡ ∘ k                  ≈⟨ pullˡ (cup-bendˡ-⊗ η) ⟩
+      cup-bendˡ ((id ⊗₁ dual₁ f) ∘ η) ∘ k                 ≈⟨ cup-bendˡ-resp dual₁-cup ⟩∘⟨refl ⟩
+      cup-bendˡ ((f ⊗₁ id) ∘ η) ∘ k                       ≈⟨ pullˡ (cup-bendˡ-⊗ η) ⟨
+      (f ⊗₁ (id ⊗₁ id)) ∘ cupˡ ∘ k                        ≈⟨ refl⟩⊗⟨ ⊗.identity ⟩∘⟨refl ⟩
+      (f ⊗₁ id) ∘ cupˡ ∘ k  ∎
+
+    snakeˡ : {k : Z ⇒ Y} → (ρ⇒ ∘ (id ⊗₁ capₖ)) ∘ cupˡ ≈ k
+    snakeˡ {k = k} = begin
+      (ρ⇒ ∘ (id ⊗₁ capₖ)) ∘ cupˡ                    ≈⟨ pullʳ (pushˡ split₂ˡ) ⟩
+      ρ⇒ ∘ (id ⊗₁ ε) ∘ (id ⊗₁ (id ⊗₁ k)) ∘ cupˡ     ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cupˡ-natural ⟩
+      ρ⇒ ∘ (id ⊗₁ ε) ∘ cupˡ ∘ k                     ≈⟨ assoc²εβ ○ elimˡ snake₁ ⟩
+      k                                             ∎
+
+    -- The same fold, under a whisker and between the associators the caller has it in.
+    cupˡ-core-fold : (id {X ⊗₀ Y} ⊗₁ α⇒ {Y ⁻¹} {A} {B}) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)
+                     ≈ α⇐ ∘ (id ⊗₁ cupˡ)
+    cupˡ-core-fold = begin
+      (id ⊗₁ α⇒) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)           ≈⟨ glue◽◃ α⇐-id⊗-commute merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ α⇒) ∘ cupˡ-core))         ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ cup-bendˡ-assoc η ⟩
+      α⇐ ∘ (id ⊗₁ cupˡ)                             ∎
+
+    -- The cap `ε ∘ (id ⊗₁ k) ∘ α⇒`, whiskered by `X ⊗₀ Y` and fed the nested cup, is
+    -- just `k` under the same whisker: `cupˡ-core-fold` straightens the cup out and
+    -- `snakeˡ` runs the loop.  (`⊗-cap` is this cap with `k = capˡ`.)
+    inner-snake : {k : A ⊗₀ B ⇒ Y} →
+                  ρ⇒ ∘ (id {X ⊗₀ Y} ⊗₁ (ε ∘ (id ⊗₁ k) ∘ α⇒)) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)
+                  ≈ id ⊗₁ k
+    inner-snake {k = k} = begin
+      ρ⇒ ∘ (id ⊗₁ (ε ∘ (id ⊗₁ k) ∘ α⇒)) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)
+        ≈⟨ refl⟩∘⟨ split₂³ ⟩∘⟨refl ⟩
+      ρ⇒ ∘ ((id ⊗₁ ε) ∘ (id ⊗₁ (id ⊗₁ k)) ∘ (id ⊗₁ α⇒)) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)
+        ≈⟨ refl⟩∘⟨ assoc²βε ⟩
+      ρ⇒ ∘ (id ⊗₁ ε) ∘ (id ⊗₁ (id ⊗₁ k)) ∘ (id ⊗₁ α⇒) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ cupˡ-core-fold ⟩
+      ρ⇒ ∘ (id ⊗₁ ε) ∘ (id ⊗₁ (id ⊗₁ k)) ∘ α⇐ ∘ (id ⊗₁ cupˡ)
+        ≈⟨ pushʳ (pullˡ merge₂ˡ) ⟩
+      cap-closeʳ capₖ ∘ α⇐ ∘ (id ⊗₁ cupˡ)          ≈⟨ pullˡ cap-closeʳ-natural ○ merge₂ˡ ⟩
+      id ⊗₁ (cap-closeʳ capₖ ∘ cupˡ)               ≈⟨ refl⟩⊗⟨ snakeˡ ⟩
+      id ⊗₁ k                                      ∎
+
+    -- Bending `⊗-cup` into place plants the outer cup `cupˡ` and leaves the inner
+    -- one, `cupˡ-core`, waiting under an associator for the cap to come and meet it.
+    ⊗-cup-open : α⇒ ∘ (⊗-cup {X} {Y} ⊗₁ id {X ⊗₀ Y}) ∘ λ⇐
+      ≈ α⇐ ∘ (id ⊗₁ cupˡ-core) ∘ cupˡ
+    ⊗-cup-open = open-nest η η ○ assoc
+
+    -- The `X ⊗₀ Y` snake: `⊗-cup-open` plants both cups, `inner-snake` runs the
+    -- inner loop, and what is left is the outer one — the nested snake, straightened
+    -- by `snakeˡ-wire`.
+    ⊗-snakeˡ : ρ⇒ ∘ (id ⊗₁ ⊗-cap {X} {Y}) ∘ α⇒ ∘ (⊗-cup ⊗₁ id) ∘ λ⇐ ≈ id
+    ⊗-snakeˡ = begin
+      ρ⇒ ∘ (id ⊗₁ ⊗-cap) ∘ α⇒ ∘ (⊗-cup ⊗₁ id) ∘ λ⇐          ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⊗-cup-open ⟩
+      ρ⇒ ∘ (id ⊗₁ ⊗-cap) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core) ∘ cupˡ    ≈⟨ reassoc-tail₅ ⟩
+      (ρ⇒ ∘ (id ⊗₁ ⊗-cap) ∘ α⇐ ∘ (id ⊗₁ cupˡ-core)) ∘ cupˡ  ≈⟨ inner-snake ⟩∘⟨refl ⟩
+      (id ⊗₁ capˡ) ∘ cupˡ                                   ≈⟨ snakeˡ-wire ⟩
+      id                                                    ∎
+
+  abstract
+    ⊗-cup-natural : {f : X ⇒ Y} {g : A ⇒ B} →
+      (id ⊗₁ (dual₁ g ⊗₁ dual₁ f)) ∘ ⊗-cup
+      ≈ ((f ⊗₁ g) ⊗₁ id) ∘ ⊗-cup
+    ⊗-cup-natural {f = f} {g} = begin
+      (id ⊗₁ (dual₁ g ⊗₁ dual₁ f)) ∘ α⇐ ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈⟨ extendʳ α⇐-id⊗-commute ○ (refl⟩∘⟨ pullˡ merge₂ˡ) ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ (dual₁ g ⊗₁ dual₁ f)) ∘ cupˡ)) ∘ η
+        ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ cupˡ-map ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ ((g ⊗₁ id) ∘ cupˡ ∘ dual₁ f)) ∘ η
+        ≈⟨ refl⟩∘⟨ (pushˡ split₂ˡ ○ (refl⟩∘⟨ pushˡ split₂ˡ)) ⟩
+      α⇐ ∘ (id ⊗₁ (g ⊗₁ id)) ∘ (id ⊗₁ cupˡ) ∘ (id ⊗₁ dual₁ f) ∘ η
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ dual₁-cup ⟩
+      α⇐ ∘ (id ⊗₁ (g ⊗₁ id)) ∘ (id ⊗₁ cupˡ) ∘ (f ⊗₁ id) ∘ η
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ extendʳ whisker-comm ⟨
+      α⇐ ∘ (id ⊗₁ (g ⊗₁ id)) ∘ (f ⊗₁ id) ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈⟨ refl⟩∘⟨ pullˡ (⟺ serialize₂₁) ⟩
+      α⇐ ∘ (f ⊗₁ (g ⊗₁ id)) ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈⟨ extendʳ assoc-commute-to ⟩
+      ((f ⊗₁ g) ⊗₁ id) ∘ ⊗-cup                            ∎
+
+  -- `⊗-cup`/`⊗-cap` exhibit `[ X ⊗ Y ]⁻¹` as *a* dual of `X ⊗₀ Y`, and `η`/`ε`
+  -- exhibit `(X ⊗₀ Y) ⁻¹` as *the* chosen one.  Duals are unique up to canonical
+  -- iso, so the two are isomorphic — transpose one pair's cap along the other's.
+
+  ⁻¹-flip-⊗ : [ X ⊗ Y ]⁻¹ ⇒ (X ⊗₀ Y) ⁻¹
+  ⁻¹-flip-⊗ {X} {Y} = capᵀ ⊗-cap
+
+  ⁻¹-flip-⊗⁻¹ : (X ⊗₀ Y) ⁻¹ ⇒ [ X ⊗ Y ]⁻¹
+  ⁻¹-flip-⊗⁻¹ {X} {Y} = cupᵀ ⊗-cup
+
+  private abstract
+    cupˡ-cupᵀ : (cup : unit ⇒ X ⊗₀ Z) →
+      (id {X} ⊗₁ (cupᵀ cup ⊗₁ id {A})) ∘ cupˡ
+      ≈ α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐
+    cupˡ-cupᵀ cup = begin
+      (id ⊗₁ (cupᵀ cup ⊗₁ id)) ∘ cupˡ                   ≈⟨ extendʳ (⟺ assoc-commute-from) ⟩
+      α⇒ ∘ (((id ⊗₁ cupᵀ cup) ⊗₁ id) ∘ (η ⊗₁ id) ∘ λ⇐)  ≈⟨ refl⟩∘⟨ pullˡ merge₁ˡ ⟩
+      α⇒ ∘ ((((id ⊗₁ cupᵀ cup) ∘ η) ⊗₁ id) ∘ λ⇐)        ≈⟨ refl⟩∘⟨ cupᵀ-η cup ⟩⊗⟨refl ⟩∘⟨refl ⟩
+      α⇒ ∘ (cup ⊗₁ id) ∘ λ⇐                             ∎
+
+  abstract
+    cupˡ-⊗ : (id {X ⊗₀ Y} ⊗₁ (⁻¹-flip-⊗⁻¹ ⊗₁ id {Z})) ∘ cupˡ
+              ≈ α⇒ ∘ (⊗-cup ⊗₁ id) ∘ λ⇐
+    cupˡ-⊗ = cupˡ-cupᵀ ⊗-cup
+
+    ⁻¹-flip-⊗⁻¹-natural : {f : X ⇒ Y} {g : A ⇒ B} →
+                          (dual₁ g ⊗₁ dual₁ f) ∘ ⁻¹-flip-⊗⁻¹
+                          ≈ ⁻¹-flip-⊗⁻¹ ∘ dual₁ (f ⊗₁ g)
+    ⁻¹-flip-⊗⁻¹-natural {f = f} {g} = cupᵀ-unique (begin
+      (id ⊗₁ ((dual₁ g ⊗₁ dual₁ f) ∘ ⁻¹-flip-⊗⁻¹)) ∘ η        ≈⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ (dual₁ g ⊗₁ dual₁ f)) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η  ≈⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟩
+      (id ⊗₁ (dual₁ g ⊗₁ dual₁ f)) ∘ ⊗-cup                    ≈⟨ ⊗-cup-natural ⟩
+      ((f ⊗₁ g) ⊗₁ id) ∘ ⊗-cup                                ≈⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟨
+      ((f ⊗₁ g) ⊗₁ id) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η              ≈⟨ extendʳ whisker-comm ⟩
+      (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ ((f ⊗₁ g) ⊗₁ id) ∘ η              ≈⟨ refl⟩∘⟨ dual₁-cup ⟨
+      (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ (id ⊗₁ dual₁ (f ⊗₁ g)) ∘ η        ≈⟨ pullˡ merge₂ˡ ⟩
+      (id ⊗₁ (⁻¹-flip-⊗⁻¹ ∘ dual₁ (f ⊗₁ g))) ∘ η              ∎)
+
+  private abstract
+    ⊗-cup-dual : {f : X ⊗₀ Y ⇒ Z} {k : [ X ⊗ Y ]⁻¹ ⇒ A} →
+                 (id ⊗₁ (k ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ f)) ∘ η
+                 ≈ (f ⊗₁ id) ∘ (id ⊗₁ k) ∘ ⊗-cup
+    ⊗-cup-dual {f = f} {k} = begin
+      (id ⊗₁ (k ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ f)) ∘ η           ≈⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ k) ∘ (id ⊗₁ (⁻¹-flip-⊗⁻¹ ∘ dual₁ f)) ∘ η   ≈⟨ refl⟩∘⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ k) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ (id ⊗₁ dual₁ f) ∘ η
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ dual₁-cup ⟩
+      (id ⊗₁ k) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ (f ⊗₁ id) ∘ η   ≈⟨ refl⟩∘⟨ extendʳ (⟺ whisker-comm) ⟩
+      (id ⊗₁ k) ∘ (f ⊗₁ id) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η   ≈⟨ extendʳ (⟺ whisker-comm) ⟩
+      (f ⊗₁ id) ∘ (id ⊗₁ k) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η   ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟩
+      (f ⊗₁ id) ∘ (id ⊗₁ k) ∘ ⊗-cup                     ∎
+
+    ⊗-cup-nest₁ : (cup : unit ⇒ X ⊗₀ A) →
+                  (id {X ⊗₀ Y} ⊗₁ (id ⊗₁ cupᵀ cup)) ∘ ⊗-cup
+                  ≈ cup-nest cup η
+    ⊗-cup-nest₁ cup = let id⊗cup = id ⊗₁ cupᵀ cup in begin
+      (id ⊗₁ id⊗cup) ∘ ⊗-cup                    ≈⟨ extendʳ α⇐-id⊗-commute ○ refl⟩∘⟨ pullˡ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ id⊗cup) ∘ cupˡ)) ∘ η  ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ cupˡ-natural ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ (cupˡ ∘ cupᵀ cup)) ∘ η        ≈⟨ refl⟩∘⟨ (pushˡ split₂ˡ ○ refl⟩∘⟨ cupᵀ-η cup) ⟩
+      α⇐ ∘ (id ⊗₁ cupˡ) ∘ cup                   ∎
+
+    ⊗-cup-nest₂ : (cup : unit ⇒ Y ⊗₀ A) →
+      (id {X ⊗₀ Y} ⊗₁ (cupᵀ cup ⊗₁ id {X ⁻¹})) ∘ ⊗-cup
+      ≈ cup-nest η cup
+    ⊗-cup-nest₂ cup = let cup⊗id = cupᵀ cup ⊗₁ id in begin
+      (id ⊗₁ cup⊗id) ∘ ⊗-cup                    ≈⟨ extendʳ α⇐-id⊗-commute ○ refl⟩∘⟨ pullˡ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ cup⊗id) ∘ cupˡ)) ∘ η  ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ cupˡ-cupᵀ cup ⟩∘⟨refl ⟩
+      cup-nest η cup                            ∎
+
+    cup-bendˡ-nest :
+      (cup₀ : unit ⇒ A ⊗₀ B) (cup₁ : unit ⇒ X ⊗₀ Y) →
+      (id ⊗₁ α⇒) ∘ cup-bendˡ {A = Z} (cup-nest cup₀ cup₁)
+      ≈ α⇐ ∘ (id ⊗₁ cup-bendˡ cup₁) ∘ cup-bendˡ cup₀
+    cup-bendˡ-nest cup₀ cup₁ = begin
+      (id ⊗₁ α⇒) ∘ cup-bendˡ (cup-nest cup₀ cup₁)
+        ≈⟨ refl⟩∘⟨ (open-nest cup₀ cup₁ ○ assoc) ⟩
+      (id ⊗₁ α⇒) ∘ α⇐ ∘ (id ⊗₁ cup-core cup₁) ∘ cup-bendˡ cup₀
+        ≈⟨ extendʳ α⇐-id⊗-commute ○ (refl⟩∘⟨ pullˡ merge₂ˡ) ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ α⇒) ∘ cup-core cup₁)) ∘ cup-bendˡ cup₀
+        ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ cup-bendˡ-assoc cup₁ ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ cup-bendˡ cup₁) ∘ cup-bendˡ cup₀  ∎
+
+    cup-nest-assoc :
+      (cup₀ : unit ⇒ A ⊗₀ B) (cup₁ : unit ⇒ W ⊗₀ X) (cup₂ : unit ⇒ Y ⊗₀ Z) →
+      (α⇒ ⊗₁ id) ∘ cup-nest (cup-nest cup₀ cup₁) cup₂
+      ≈ (id ⊗₁ α⇒) ∘ cup-nest cup₀ (cup-nest cup₁ cup₂)
+    cup-nest-assoc cup₀ cup₁ cup₂ = let
+        b₁ = cup-bendˡ cup₁
+        b₂ = cup-bendˡ cup₂
+        b₁₂ = cup-bendˡ (cup-nest cup₁ cup₂)
+        tail = (id ⊗₁ (id ⊗₁ b₂)) ∘ (id ⊗₁ b₁) ∘ cup₀
+        bend-nest = refl⟩⊗⟨ cup-bendˡ-nest cup₁ cup₂
+      in begin
+        α⇒ ⊗₁ id ∘ α⇐ ∘ id ⊗₁ b₂ ∘ α⇐ ∘ id ⊗₁ b₁ ∘ cup₀
+          ≈⟨ refl⟩∘⟨ (refl⟩∘⟨ extendʳ α⇐-id⊗-commute ○ sym-assoc) ⟩
+        α⇒ ⊗₁ id ∘ ((α⇐ ∘ α⇐) ∘ tail)                   ≈⟨ pullˡ pentagon-collapse-inv ⟩
+        (α⇐ ∘ id ⊗₁ α⇐) ∘ tail                          ≈⟨ pullʳ merge₂³-tail ⟩
+        α⇐ ∘ id ⊗₁ (α⇐ ∘ id ⊗₁ b₂ ∘ b₁) ∘ cup₀          ≈⟨ refl⟩∘⟨ bend-nest ⟩∘⟨refl ⟨
+        α⇐ ∘ id ⊗₁ (id ⊗₁ α⇒ ∘ b₁₂) ∘ cup₀              ≈⟨ refl⟩∘⟨ pushˡ split₂ˡ ⟩
+        α⇐ ∘ id ⊗₁ (id ⊗₁ α⇒) ∘ id ⊗₁ b₁₂ ∘ cup₀        ≈⟨ extendʳ (⟺ α⇐-id⊗-commute) ⟩
+        (id ⊗₁ α⇒) ∘ cup-nest cup₀ (cup-nest cup₁ cup₂) ∎
+
+  abstract
+    ⊗-cup-assoc :
+      (α⇒ {X} {Y} {Z} ⊗₁ id)
+        ∘ (id ⊗₁ (id ⊗₁ ⁻¹-flip-⊗⁻¹)) ∘ ⊗-cup
+      ≈ (id ⊗₁ α⇒) ∘ (id ⊗₁ (⁻¹-flip-⊗⁻¹ ⊗₁ id)) ∘ ⊗-cup
+    ⊗-cup-assoc = begin
+      (α⇒ ⊗₁ id) ∘ (id ⊗₁ (id ⊗₁ ⁻¹-flip-⊗⁻¹)) ∘ ⊗-cup    ≈⟨ refl⟩∘⟨ ⊗-cup-nest₁ ⊗-cup ⟩
+      (α⇒ ⊗₁ id) ∘ cup-nest ⊗-cup η                       ≈⟨ cup-nest-assoc η η η ⟩
+      (id ⊗₁ α⇒) ∘ cup-nest η ⊗-cup                       ≈⟨ refl⟩∘⟨ ⊗-cup-nest₂ ⊗-cup ⟨
+      (id ⊗₁ α⇒) ∘ (id ⊗₁ (⁻¹-flip-⊗⁻¹ ⊗₁ id)) ∘ ⊗-cup    ∎
+
+    ⁻¹-flip-⊗⁻¹-assoc :
+      (id {Z ⁻¹} ⊗₁ ⁻¹-flip-⊗⁻¹ {X} {Y}) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ α⇒
+      ≈ α⇒ ∘ (⁻¹-flip-⊗⁻¹ ⊗₁ id) ∘ ⁻¹-flip-⊗⁻¹
+    ⁻¹-flip-⊗⁻¹-assoc = cupᵀ-unique (begin
+      (id ⊗₁ ((id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ α⇒)) ∘ η
+        ≈⟨ ⊗-cup-dual ⟩
+      (α⇒ ⊗₁ id) ∘ (id ⊗₁ (id ⊗₁ ⁻¹-flip-⊗⁻¹)) ∘ ⊗-cup  ≈⟨ ⊗-cup-assoc ⟩
+      (id ⊗₁ α⇒) ∘ (id ⊗₁ (⁻¹-flip-⊗⁻¹ ⊗₁ id)) ∘ ⊗-cup
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟨
+      (id ⊗₁ α⇒) ∘ (id ⊗₁ (⁻¹-flip-⊗⁻¹ ⊗₁ id)) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η
+        ≈⟨ (refl⟩∘⟨ pullˡ merge₂ˡ) ○ pullˡ merge₂ˡ ⟩
+      (id ⊗₁ (α⇒ ∘ (⁻¹-flip-⊗⁻¹ ⊗₁ id) ∘ ⁻¹-flip-⊗⁻¹)) ∘ η  ∎)
+
+    ⁻¹-flip-⊗⁻¹-unitaryˡ : (id {X ⁻¹} ⊗₁ unit⁻¹⇐) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ λ⇒ ≈ ρ⇐
+    ⁻¹-flip-⊗⁻¹-unitaryˡ = cupᵀ-unique (begin
+      (id ⊗₁ ((id ⊗₁ unit⁻¹⇐) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ λ⇒)) ∘ η
+        ≈⟨ ⊗-cup-dual ⟩
+      (λ⇒ ⊗₁ id) ∘ (id ⊗₁ (id ⊗₁ unit⁻¹⇐)) ∘ ⊗-cup  ≈⟨ refl⟩∘⟨ ⊗-cup-nest₁ λ⇐ ⟩
+      (λ⇒ ⊗₁ id) ∘ cup-nest λ⇐ η                    ≈⟨ pullˡ λ⇒-assoc ⟩
+      λ⇒ ∘ (id ⊗₁ cupˡ) ∘ λ⇐                        ≈⟨ extendʳ unitorˡ-commute-from ⟩
+      cupˡ ∘ λ⇒ ∘ λ⇐                                ≈⟨ elimʳ unitorˡ.isoʳ ⟩
+      cupˡ                                            ≈⟨ refl⟩∘⟨ refl⟩∘⟨ coherence-inv₃ ⟩
+      α⇒ ∘ (η ⊗₁ id) ∘ ρ⇐                            ≈⟨ refl⟩∘⟨ ⟺ unitorʳ-commute-to ⟩
+      α⇒ ∘ ρ⇐ ∘ η                                   ≈⟨ pullˡ (⟺ ρ⇐-assoc) ⟩
+      (id ⊗₁ ρ⇐) ∘ η                                ∎)
+
+    ⁻¹-flip-⊗⁻¹-unitaryʳ : (unit⁻¹⇐ ⊗₁ id {X ⁻¹}) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ ρ⇒ ≈ λ⇐
+    ⁻¹-flip-⊗⁻¹-unitaryʳ = cupᵀ-unique (begin
+      (id ⊗₁ ((unit⁻¹⇐ ⊗₁ id) ∘ ⁻¹-flip-⊗⁻¹ ∘ dual₁ ρ⇒)) ∘ η   ≈⟨ ⊗-cup-dual ⟩
+      (ρ⇒ ⊗₁ id) ∘ (id ⊗₁ (unit⁻¹⇐ ⊗₁ id)) ∘ ⊗-cup             ≈⟨ refl⟩∘⟨ ⊗-cup-nest₂ λ⇐ ⟩
+      (ρ⇒ ⊗₁ id) ∘ cup-nest η λ⇐                ≈⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩⊗⟨ unit-cup ⟩∘⟨refl ⟩
+      (ρ⇒ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ (λ⇐ ∘ λ⇐)) ∘ η   ≈⟨ pullˡ (⟺ λ⇒-α⇐) ⟩
+      (id ⊗₁ λ⇒) ∘ (id ⊗₁ (λ⇐ ∘ λ⇐)) ∘ η
+        ≈⟨ pullˡ (merge₂ˡ ○ (refl⟩⊗⟨ cancelˡ unitorˡ.isoʳ)) ⟩
+      (id ⊗₁ λ⇐) ∘ η                            ∎)
+
+    ⁻¹-flip-⊗-cup : (id {X ⊗₀ Y} ⊗₁ ⁻¹-flip-⊗) ∘ ⊗-cup ≈ η
+    ⁻¹-flip-⊗-cup = capᵀ-cup ⊗-snakeˡ
+
+    ⁻¹-flip-⊗-cap : ε {X ⊗₀ Y} ∘ (⁻¹-flip-⊗ ⊗₁ id) ≈ ⊗-cap
+    ⁻¹-flip-⊗-cap = capᵀ-ε ⊗-cap
+
+  private
+    snakeʳ-cap : ([ X ⊗ Y ]⁻¹ ⊗₀ (X ⊗₀ Y)) ⊗₀ [ X ⊗ Y ]⁻¹ ⇒ unit ⊗₀ [ X ⊗ Y ]⁻¹
+    snakeʳ-cap = (ε ⊗₁ id) ∘ ((id ⊗₁ capˡ) ⊗₁ id) ∘ (α⇒ ⊗₁ id)
+
+    nested-cup : unit ⇒ X ⊗₀ (Y ⊗₀ [ X ⊗ Y ]⁻¹)
+    nested-cup {X} = (id ⊗₁ cupˡ {X = X ⁻¹}) ∘ η
+
+    -- `id ⊗₁ ⊗-cup` with only its leading associator split off — the shape
+    -- `⊗-snakeʳ` produces (via `split₂ˡ`) and `snakeʳ-core-fold` consumes.
+    snakeʳ-cup : [ X ⊗ Y ]⁻¹ ⊗₀ unit ⇒ [ X ⊗ Y ]⁻¹ ⊗₀ ((X ⊗₀ Y) ⊗₀ [ X ⊗ Y ]⁻¹)
+    snakeʳ-cup = (id ⊗₁ α⇐) ∘ (id ⊗₁ nested-cup)
+
+    nested-cap : ([ X ⊗ Y ]⁻¹ ⊗₀ (X ⊗₀ Y)) ⊗₀ [ X ⊗ Y ]⁻¹ ⇒ (Y ⁻¹ ⊗₀ Y) ⊗₀ [ X ⊗ Y ]⁻¹
+    nested-cap = ((id ⊗₁ capˡ) ∘ α⇒) ⊗₁ id
+
+    snakeʳ-core : [ X ⊗ Y ]⁻¹ ⇒ (Y ⁻¹ ⊗₀ Y) ⊗₀ [ X ⊗ Y ]⁻¹
+    snakeʳ-core = nested-cap ∘ α⇐ ∘ snakeʳ-cup ∘ ρ⇐
+
+  private abstract
+    nested-cap-slide : nested-cap {X} {Y} ∘ α⇐ ∘ (id {[ X ⊗ Y ]⁻¹} ⊗₁ α⇐)
+                       ≈ α⇐ ∘ (id ⊗₁ capˡ) ∘ α⇒
+    nested-cap-slide = let bend-ε = refl⟩⊗⟨ cap-bendˡ-assoc ε in begin
+      nested-cap ∘ α⇐ ∘ (id ⊗₁ α⇐)                        ≈⟨ cap-slideʳ ⟩
+      α⇐ ∘ (id ⊗₁ ((capˡ ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ α⇐))) ∘ α⇒  ≈⟨ refl⟩∘⟨ bend-ε ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ capˡ) ∘ α⇒                              ∎
+
+    snakeʳ-core-fold : snakeʳ-core {X} {Y} ≈ α⇐ ∘ (id ⊗₁ cupˡ)
+    snakeʳ-core-fold = begin
+      snakeʳ-core                                                   ≈⟨ refl⟩∘⟨ assoc²δα ⟩
+      nested-cap ∘ (((α⇐ ∘ (id ⊗₁ α⇐)) ∘ (id ⊗₁ nested-cup)) ∘ ρ⇐)  ≈⟨ pull-first nested-cap-slide ⟩
+      (α⇐ ∘ (id ⊗₁ capˡ) ∘ α⇒) ∘ ((id ⊗₁ nested-cup) ∘ ρ⇐)          ≈⟨ assoc²βε ⟩
+      α⇐ ∘ (id ⊗₁ capˡ) ∘ (α⇒ ∘ cup-openʳ nested-cup)
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ cup-openʳ-natural ⟩
+      α⇐ ∘ (id ⊗₁ capˡ) ∘ (id ⊗₁ cup-openʳ nested-cup)              ≈⟨ refl⟩∘⟨ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ (capˡ ∘ (id ⊗₁ nested-cup) ∘ ρ⇐))                 ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ cupᵀ-unbend ⟩
+      α⇐ ∘ (id ⊗₁ cupˡ)                                             ∎
+
+    ⊗-snakeʳ : λ⇒ ∘ (⊗-cap {X} {Y} ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ ⊗-cup) ∘ ρ⇐ ≈ id
+    ⊗-snakeʳ = begin
+      λ⇒ ∘ (⊗-cap ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ ⊗-cup) ∘ ρ⇐
+        ≈⟨ refl⟩∘⟨ split₁³ ⟩∘⟨ refl⟩∘⟨ split₂ˡ ⟩∘⟨refl ⟩
+      λ⇒ ∘ snakeʳ-cap ∘ α⇐ ∘ snakeʳ-cup ∘ ρ⇐                ≈⟨ refl⟩∘⟨ (refl⟩∘⟨ merge₁ˡ) ⟩∘⟨refl ⟩
+      λ⇒ ∘ ((ε ⊗₁ id) ∘ nested-cap) ∘ α⇐ ∘ snakeʳ-cup ∘ ρ⇐  ≈⟨ refl⟩∘⟨ pullʳ (snakeʳ-core-fold) ⟩
+      λ⇒ ∘ (ε ⊗₁ id) ∘ α⇐ ∘ (id ⊗₁ cupˡ)                    ≈⟨ assoc²εα ⟩
+      capˡ ∘ (id ⊗₁ cupˡ)                                   ≈⟨ snakeˡ-dual ⟩
+      id                                                    ∎
+
+  -- `Y ⁻¹ ⊗₀ X ⁻¹` and the chosen dual `(X ⊗₀ Y) ⁻¹` are both left duals of
+  -- `X ⊗₀ Y` — the former via `⊗-cup`/`⊗-cap` (with snakes `⊗-snakeˡ`/`⊗-snakeʳ`),
+  -- the latter canonically — so the flip isomorphism is just an instance of the
+  -- uniqueness of left duals.  Its `from`/`to` are `⁻¹-flip-⊗`/`⁻¹-flip-⊗⁻¹`.
+  ⁻¹-flip-⊗-iso : [ X ⊗ Y ]⁻¹ ≅ (X ⊗₀ Y) ⁻¹
+  ⁻¹-flip-⊗-iso = dual-uniqueˡ ⊗-cup ⊗-cap ⊗-snakeˡ ⊗-snakeʳ
+
+module Right (R : RightRigid) where
+  open RigidDual monoidal-Op (rigidʳ-Op R) public

--- a/src/Categories/Category/Monoidal/Rigid/Symmetry.agda
+++ b/src/Categories/Category/Monoidal/Rigid/Symmetry.agda
@@ -3,7 +3,8 @@
 -- Consequences of a symmetric monoidal structure for rigid monoidal categories:
 -- * A left rigid structure induces a right rigid structure, and vice versa.
 --   (This makes any symmetric rigid monoidal category a compact closed category.)
--- * The induced left and right dual morphisms agree.
+-- * The left and right duals of an object are isomorphic, and the isomorphism is natural.
+-- * The dual of the dual of an object is canonically isomorphic to the original object
 
 open import Categories.Category.Core using (Category)
 open import Categories.Category.Monoidal.Core using (Monoidal)
@@ -22,18 +23,32 @@ open import Categories.Category.Monoidal.Braided.Properties braided
   renaming (module Shorthands to BraidShorthands)
 import Categories.Category.Monoidal.Braided.Properties as BraidedProperties
 import Categories.Category.Monoidal.Construction.Reverse as Reverse
+import Categories.Category.Monoidal.Interchange.Symmetric as SymmetricInterchange
+import Categories.Category.Monoidal.Rigid.Dual as RigidDual
+import Categories.Category.Monoidal.Rigid.Properties as RigidPropertiesModule
 open import Categories.Category.Monoidal.Reasoning M
+open import Categories.Category.Monoidal.Properties M using (coherence-inv₃)
+open import Categories.Category.Monoidal.Reassociation M
+  using (α⇐-id⊗-commute; whisker-comm)
 open import Categories.Category.Monoidal.CupCap M
-  using (cup-bendˡ; cup-bendˡ-resp; cup-bendˡ-⊗; cup-openˡ; cup-openʳ)
+  using (cup-bendˡ; cup-bendˡ-resp; cup-bendˡ-⊗; cup-openˡ; cup-openʳ
+        ; parallel-cups-commute )
 open import Categories.Category.Monoidal.Symmetric.Properties S
-  using (braiding-selfInverse; cup-swap; mirrorˡ)
+  using (braiding-selfInverse; cup-swap; middle-braid; mirrorˡ)
 open import Categories.Morphism.Reasoning C
+open import Categories.Morphism C using (_≅_; module ≅)
 
 open MonUtil.Shorthands
 open BraidShorthands
 
 private
+  module Interchange = SymmetricInterchange S
   module RevProps = BraidedProperties (Reverse.Reverse-Braided braided)
+  open Interchange using (swapInner-braiding′)
+
+  module swapInner {A B X Y} =
+    _≅_ (Interchange.swapInner-iso {A} {B} {X} {Y})
+  open swapInner using () renaming (from to i⇒)
 
   variable
     A B X Y Z : Obj
@@ -202,3 +217,134 @@ abstract
     RightRigid.dual₁ R f                            ≈⟨ dual₁-roundtripʳ R f ⟨
     RightRigid.dual₁ (left⇒right (right⇒left R)) f  ≈⟨ dual₁ˡ≈dual₁ʳ (right⇒left R) f ⟨
     LeftRigid.dual₁ (right⇒left R) f                ∎
+
+-- The Drinfeld double-dual isomorphism `(X ⁻¹) ⁻¹ ≅ X`.  It holds in any braided
+-- rigid category, but the strict-left-dual route below picks up the ribbon twist
+-- `σ⇒ ∘ σ⇒`, which vanishes only under symmetry — so we prove just that case.
+--
+-- `η`/`ε` make `X ⁻¹` a left dual of `X`; braiding them makes `X` a *left* dual of
+-- `X ⁻¹` (the bends are the same, read with the two wires crossed), and uniqueness
+-- of left duals then identifies `X` with `(X ⁻¹) ⁻¹`.
+--
+--   X ⁻¹        X                X          X ⁻¹
+--     │         │                 ╲        ╱
+--     │         │                  ╲      ╱          σ⇒ ∘ η : the same bend,
+--     ╰─────────╯   ← η             ╲────╱           with the wires crossed
+--
+-- The twist is where a merely braided category would differ: undoing the crossing
+-- on the other side costs a second `σ⇒`, and `σ⇒ ∘ σ⇒ ≈ id` is exactly symmetry.
+
+module DoubleDualˡ (L : LeftRigid M) where
+  open LeftRigid L using (_⁻¹; η; ε; snake₁; snake₂; dual₁)
+  open import Categories.Category.Monoidal.Rigid.Dual M L
+    using (cupˡ; cupᵀ-η; cupᵀ-unique; dual-uniqueˡ; dual₁-cup)
+  module RigidProperties = RigidPropertiesModule M
+  open RigidProperties.Left L using (⊗-cup; ⁻¹-flip-⊗⁻¹)
+
+  private abstract
+    ⊗-cup-interchange :
+      i⇒ {X} {X ⁻¹} {Y} {Y ⁻¹} ∘ (η ⊗₁ η) ∘ λ⇐ ≈ (id ⊗₁ σ⇒) ∘ ⊗-cup
+    ⊗-cup-interchange = begin
+      i⇒ ∘ (η ⊗₁ η) ∘ λ⇐
+        ≈⟨ refl⟩∘⟨ pushˡ serialize₁₂ ⟩
+      i⇒ ∘ (η ⊗₁ id) ∘ (id ⊗₁ η) ∘ λ⇐
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ ⟺ unitorˡ-commute-to ⟩
+      i⇒ ∘ (η ⊗₁ id) ∘ λ⇐ ∘ η                   ≈⟨ assoc²βε ⟩
+      α⇐ ∘ (id ⊗₁ (α⇒ ∘ (σ⇒ ⊗₁ id) ∘ α⇐)) ∘ α⇒
+        ∘ (η ⊗₁ id) ∘ λ⇐ ∘ η
+        ≈⟨ refl⟩∘⟨ refl⟩∘⟨ parallel-cups-commute ⟨
+      α⇐ ∘ (id ⊗₁ (α⇒ ∘ (σ⇒ ⊗₁ id) ∘ α⇐))
+        ∘ (id ⊗₁ cup-openʳ η) ∘ η
+        ≈⟨ refl⟩∘⟨ pullˡ merge₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ ((α⇒ ∘ (σ⇒ ⊗₁ id) ∘ α⇐) ∘ cup-openʳ η)) ∘ η
+        ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ (refl⟩∘⟨ cup-swap) ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ ((α⇒ ∘ (σ⇒ ⊗₁ id) ∘ α⇐) ∘ σ⇐
+        ∘ (η ⊗₁ id) ∘ λ⇐)) ∘ η
+        ≈⟨ refl⟩∘⟨ refl⟩⊗⟨ extendʳ middle-braid ⟩∘⟨refl ⟩
+      α⇐ ∘ (id ⊗₁ ((id ⊗₁ σ⇒) ∘ cupˡ)) ∘ η
+        ≈⟨ refl⟩∘⟨ pushˡ split₂ˡ ⟩
+      α⇐ ∘ (id ⊗₁ (id ⊗₁ σ⇒)) ∘ (id ⊗₁ cupˡ) ∘ η
+        ≈⟨ extendʳ α⇐-id⊗-commute ⟨
+      (id ⊗₁ σ⇒) ∘ α⇐ ∘ (id ⊗₁ cupˡ) ∘ η  ∎
+
+    tensor-cup-braiding : (σ⇒ {X} {Y} ⊗₁ id) ∘ ⊗-cup
+                          ≈ (id ⊗₁ σ⇒) ∘ ⊗-cup
+    tensor-cup-braiding = begin
+      (σ⇒ ⊗₁ id) ∘ ⊗-cup                    ≈⟨ intro-center (⊗-cancel identity² commutative) ⟩
+      (σ⇒ ⊗₁ id) ∘ ((id ⊗₁ σ⇒ ∘ id ⊗₁ σ⇒) ∘ ⊗-cup)
+        ≈⟨ pull-first (⟺ serialize₁₂) ⟩
+      (σ⇒ ⊗₁ σ⇒) ∘ (id ⊗₁ σ⇒) ∘ ⊗-cup       ≈⟨ refl⟩∘⟨ ⊗-cup-interchange ⟨
+      (σ⇒ ⊗₁ σ⇒) ∘ i⇒ ∘ (η ⊗₁ η) ∘ λ⇐       ≈⟨ extendʳ swapInner-braiding′ ⟩
+      i⇒ ∘ σ⇒ ∘ (η ⊗₁ η) ∘ λ⇐               ≈⟨ refl⟩∘⟨ extendʳ σ⇒-comm ⟩
+      i⇒ ∘ (η ⊗₁ η) ∘ σ⇒ ∘ λ⇐               ≈⟨ refl⟩∘⟨ refl⟩∘⟨ braiding-selfInverse ⟩∘⟨refl ⟨
+      i⇒ ∘ (η ⊗₁ η) ∘ σ⇐ ∘ λ⇐               ≈⟨ refl⟩∘⟨ refl⟩∘⟨ braiding-coherence-inv ⟩
+      i⇒ ∘ (η ⊗₁ η) ∘ ρ⇐                    ≈⟨ refl⟩∘⟨ refl⟩∘⟨ coherence-inv₃ ⟨
+      i⇒ ∘ (η ⊗₁ η) ∘ λ⇐                    ≈⟨ ⊗-cup-interchange ⟩
+      (id ⊗₁ σ⇒) ∘ ⊗-cup                    ∎
+
+  abstract
+    dual-braiding-compat : ⁻¹-flip-⊗⁻¹ ∘ dual₁ (σ⇒ {X} {Y}) ≈ σ⇒ ∘ ⁻¹-flip-⊗⁻¹
+    dual-braiding-compat = cupᵀ-unique (begin
+      (id ⊗₁ (⁻¹-flip-⊗⁻¹ ∘ dual₁ σ⇒)) ∘ η        ≈⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ (id ⊗₁ dual₁ σ⇒) ∘ η  ≈⟨ refl⟩∘⟨ dual₁-cup ⟩
+      (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ (σ⇒ ⊗₁ id) ∘ η        ≈⟨ extendʳ (⟺ whisker-comm) ⟩
+      (σ⇒ ⊗₁ id) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η        ≈⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟩
+      (σ⇒ ⊗₁ id) ∘ ⊗-cup                          ≈⟨ tensor-cup-braiding ⟩
+      (id ⊗₁ σ⇒) ∘ ⊗-cup                          ≈⟨ refl⟩∘⟨ cupᵀ-η ⊗-cup ⟨
+      (id ⊗₁ σ⇒) ∘ (id ⊗₁ ⁻¹-flip-⊗⁻¹) ∘ η        ≈⟨ pullˡ merge₂ˡ ⟩
+      (id ⊗₁ (σ⇒ ∘ ⁻¹-flip-⊗⁻¹)) ∘ η              ∎)
+
+  ⁻¹⁻¹≅ : (X ⁻¹) ⁻¹ ≅ X
+  ⁻¹⁻¹≅ = ≅.sym (dual-uniqueˡ (σ⇒ ∘ η) (ε ∘ σ⇒)
+                              (braid-snakeʳ snake₂) (braid-snakeˡ snake₁))
+
+  j⇒ : (X ⁻¹) ⁻¹ ⇒ X
+  j⇒ = _≅_.from ⁻¹⁻¹≅
+
+  j⇐ : X ⇒ (X ⁻¹) ⁻¹
+  j⇐ = _≅_.to ⁻¹⁻¹≅
+
+  private abstract
+    j-cup : (id ⊗₁ j⇒) ∘ η {X ⁻¹} ≈ σ⇒ ∘ η
+    j-cup = cupᵀ-η (σ⇒ ∘ η)
+
+    double-dual-cup : (f : X ⇒ Y) →
+      (id ⊗₁ (j⇒ ∘ dual₁ (dual₁ f))) ∘ η
+      ≈ (id ⊗₁ (f ∘ j⇒)) ∘ η
+    double-dual-cup f = begin
+      (id ⊗₁ (j⇒ ∘ dual₁ (dual₁ f))) ∘ η            ≈⟨ pushˡ split₂ˡ ⟩
+      (id ⊗₁ j⇒) ∘ (id ⊗₁ dual₁ (dual₁ f)) ∘ η      ≈⟨ refl⟩∘⟨ dual₁-cup ⟩
+      (id ⊗₁ j⇒) ∘ (dual₁ f ⊗₁ id) ∘ η              ≈⟨ extendʳ (⟺ whisker-comm) ⟩
+      (dual₁ f ⊗₁ id) ∘ (id ⊗₁ j⇒) ∘ η              ≈⟨ refl⟩∘⟨ j-cup ⟩
+      (dual₁ f ⊗₁ id) ∘ σ⇒ ∘ η                      ≈⟨ extendʳ (⟺ σ⇒-comm) ⟩
+      σ⇒ ∘ (id ⊗₁ dual₁ f) ∘ η                      ≈⟨ refl⟩∘⟨ dual₁-cup ⟩
+      σ⇒ ∘ (f ⊗₁ id) ∘ η                            ≈⟨ extendʳ σ⇒-comm ⟩
+      (id ⊗₁ f) ∘ σ⇒ ∘ η                            ≈⟨ refl⟩∘⟨ j-cup ⟨
+      (id ⊗₁ f) ∘ (id ⊗₁ j⇒) ∘ η                    ≈⟨ pullˡ merge₂ˡ ⟩
+      (id ⊗₁ (f ∘ j⇒)) ∘ η                          ∎
+
+  abstract
+    double-dual-natural : (f : X ⇒ Y) →
+      j⇒ ∘ dual₁ (dual₁ f) ≈ f ∘ j⇒
+    double-dual-natural f = cupᵀ-unique (double-dual-cup f)
+
+    double-dual-on-morphisms : (f : X ⇒ Y) →
+      dual₁ (dual₁ f) ≈ j⇐ ∘ f ∘ j⇒
+    double-dual-on-morphisms f = switch-fromtoˡ ⁻¹⁻¹≅ (double-dual-natural f)
+
+module DoubleDualʳ (R : RightRigid M) where
+  open RightRigid R using (_⁻¹; dual₁)
+  open DoubleDualˡ (right⇒left R) public using (⁻¹⁻¹≅; j⇒; j⇐)
+
+  private
+    module L = LeftRigid (right⇒left R)
+    module D = RigidDual M (right⇒left R)
+
+  abstract
+    double-dual-on-morphisms : (f : X ⇒ Y) →
+      dual₁ (dual₁ f) ≈ j⇐ ∘ f ∘ j⇒
+    double-dual-on-morphisms f = begin
+      dual₁ (dual₁ f)        ≈⟨ dual₁ʳ≈dual₁ˡ R (dual₁ f) ⟩
+      L.dual₁ (dual₁ f)      ≈⟨ D.dual₁-resp-≈ (dual₁ʳ≈dual₁ˡ R f) ⟩
+      L.dual₁ (L.dual₁ f)    ≈⟨ DoubleDualˡ.double-dual-on-morphisms (right⇒left R) f ⟩
+      j⇐ ∘ f ∘ j⇒                ∎


### PR DESCRIPTION
## Summary

Extend the rigid dual calculus introduced in #538 with coherent duals of the
monoidal unit and tensor products, together with the symmetric double-dual
comparison.

This adds:

- transfer of left and right rigidity to the opposite monoidal category
- the canonical isomorphism between the unit and its chosen dual
- nested cups and caps exhibiting `Y ⁻¹ ⊗ X ⁻¹` as a dual of `X ⊗ Y`
- the canonical comparison `(Y ⁻¹ ⊗ X ⁻¹) ≅ (X ⊗ Y) ⁻¹`
- naturality, associativity, and unit coherence for this tensor-dual comparison
- compatibility of dualization with the symmetry
- agreement between the left- and right-induced dual morphisms
- the canonical double-dual isomorphism `(X ⁻¹) ⁻¹ ≅ X`
- naturality and morphism-level coherence for double dualization
- a supporting reassociation identity for the tensor-unit calculation

## Motivation

PR #538 developed the calculus of cups, caps, transposes, dual morphisms, and
uniqueness of duals. To package dualization monoidally, one additionally needs
to show coherently that dualization sends the unit to its dual and reverses
tensor products:

    (X ⊗ Y) ⁻¹ ≅ Y ⁻¹ ⊗ X ⁻¹.

The tensor comparison is constructed by nesting the cups and caps for `X` and
`Y`. The resulting object is another dual of `X ⊗ Y`, so uniqueness of duals
provides the canonical comparison with the chosen dual. This PR proves its
naturality, associativity, and unit laws.

In the symmetric case, left and right rigidity induce the same dual morphisms,
the tensor comparison respects the braiding, and double dualization is
canonically isomorphic to the identity. These results provide the coherence
needed by the following compact-closed dualization branch.
